### PR TITLE
Workflow refactoring and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ![stars](https://img.shields.io/github/stars/kousuke-nakano/jQMC?style=social)
 ![short-pytest](https://github.com/kousuke-nakano/jQMC/actions/workflows/jqmc-run-short-pytest.yml/badge.svg)
 ![full-pytest](https://github.com/kousuke-nakano/jQMC/actions/workflows/jqmc-run-full-pytest.yml/badge.svg)
-![codecov](https://codecov.io/github/kousuke-nakano/jQMC/graph/badge.svg?token=H0Z7M86C1E)
+![codecov](https://codecov.io/github/kousuke-nakano/jQMC/graph/badge.svg)
 ![DL](https://img.shields.io/pypi/dm/jqmc)
 ![python_version](https://img.shields.io/pypi/pyversions/jqmc)
 ![pypi_version](https://badge.fury.io/py/jqmc.svg)

--- a/doc/api_reference_cli.md
+++ b/doc/api_reference_cli.md
@@ -71,8 +71,8 @@ The input file is a JSON/YAML document whose keys match the parameters listed be
 | `opt_JNN_param`            |      `false` | Optimize neural-network Jastrow parameters.                                                                          |
 | `opt_lambda_param`         |      `false` | Optimize geminal (λ) parameters.                                                                                     |
 | `opt_with_projected_MOs`   |      `false` | If `true`, optimize lambda parameters (for AOs) or molecular orbital coefficients (for MOs) in a restricted MO space. |
-| `opt_J3_basis_exp`         |      `false` | Optimize J3 AO Gaussian exponents. Cannot be combined with `opt_with_projected_MOs`. |
-| `opt_J3_basis_coeff`       |      `false` | Optimize J3 AO contraction coefficients. Cannot be combined with `opt_with_projected_MOs`. |
+| `opt_J3_basis_exp`         |      `false` | Optimize J3 AO Gaussian exponents. Can be combined with `opt_with_projected_MOs`. |
+| `opt_J3_basis_coeff`       |      `false` | Optimize J3 AO contraction coefficients. Can be combined with `opt_with_projected_MOs`. |
 | `opt_lambda_basis_exp`     |      `false` | Optimize Geminal AO Gaussian exponents (up and down spins, concatenated). Cannot be combined with `opt_with_projected_MOs`. |
 | `opt_lambda_basis_coeff`   |      `false` | Optimize Geminal AO contraction coefficients (up and down spins, concatenated). Cannot be combined with `opt_with_projected_MOs`. |
 | `num_param_opt`            |          `0` | Number of parameters to optimize, chosen in descending order of \|f\| / std(f). If `0`, optimize **all** parameters. |

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -377,7 +377,6 @@ opt_JNN_param = false
 opt_lambda_param = false
 opt_with_projected_MOs = false
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 Please lunch the job.
@@ -699,12 +698,7 @@ opt_J3_param = false
 opt_JNN_param = true
 opt_lambda_param = false
 opt_with_projected_MOs = false
-opt_J3_basis_exp = false # Optimize J3 AO Gaussian exponents.
-opt_J3_basis_coeff = false # Optimize J3 AO contraction coefficients.
-opt_lambda_basis_exp = false # Optimize Geminal AO Gaussian exponents (up+dn).
-opt_lambda_basis_coeff = false # Optimize Geminal AO contraction coefficients (up+dn).
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 optimizer_kwargs = { method = "adam" }
 ```
 
@@ -919,12 +913,7 @@ opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = true
 opt_with_projected_MOs = true
-opt_J3_basis_exp = false # Optimize J3 AO Gaussian exponents. Cannot be combined with opt_with_projected_MOs.
-opt_J3_basis_coeff = false # Optimize J3 AO contraction coefficients. Cannot be combined with opt_with_projected_MOs.
-opt_lambda_basis_exp = false # Optimize Geminal AO Gaussian exponents (up+dn). Cannot be combined with opt_with_projected_MOs.
-opt_lambda_basis_coeff = false # Optimize Geminal AO contraction coefficients (up+dn). Cannot be combined with opt_with_projected_MOs.
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 The key differences from `example01` are:
@@ -1245,7 +1234,6 @@ opt_JNN_param = false
 opt_lambda_param = false
 opt_with_projected_MOs = false
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 Please lunch the job.
@@ -1466,12 +1454,7 @@ opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = true
 opt_with_projected_MOs = false
-opt_J3_basis_exp = false # Optimize J3 AO Gaussian exponents.
-opt_J3_basis_coeff = false # Optimize J3 AO contraction coefficients.
-opt_lambda_basis_exp = false # Optimize Geminal AO Gaussian exponents (up+dn).
-opt_lambda_basis_coeff = false # Optimize Geminal AO contraction coefficients (up+dn).
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 > [!IMPORTANT]
@@ -1773,12 +1756,7 @@ opt_J1_param = true
 opt_J2_param = true
 opt_J3_param = true
 opt_lambda_param = false
-opt_J3_basis_exp = false
-opt_J3_basis_coeff = false
-opt_lambda_basis_exp = false
-opt_lambda_basis_coeff = false
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If None, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 Please launch the job.
@@ -1992,12 +1970,7 @@ opt_J1_param = true
 opt_J2_param = true
 opt_J3_param = true
 opt_lambda_param = true
-opt_J3_basis_exp = false
-opt_J3_basis_coeff = false
-opt_lambda_basis_exp = false
-opt_lambda_basis_coeff = false
 num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If None, all parameters are optimized.
-opt_filter_min_SN_ratio = 4.0 # minimum |f|/|std f| to update a parameter. Parameters with SN <= this are frozen. Applied before num_param_opt. Set 0 to disable.
 ```
 
 Please launch the job.
@@ -2448,8 +2421,6 @@ VMC_Workflow(
     opt_J3_param=True,
     opt_with_projected_MOs=True,
     target_error=0.001,
-    target_snr=4.5,
-    energy_slope_sigma_threshold=2.0,
 )
 ```
 
@@ -2663,8 +2634,6 @@ VMC_Workflow(
     opt_J3_param=True,
     opt_with_projected_MOs=False,
     target_error=1.0e-3,
-    target_snr=4.5,
-    energy_slope_sigma_threshold=2.0,
     optimizer_kwargs={
         "method": "sr",
         "delta": 0.350,
@@ -2692,7 +2661,7 @@ LRDMC_Workflow(
     queue_label="cores-4-mpi-4-gpu-4-omp-1-30m",
     alat=0.30,
     number_of_walkers=nw,
-    num_projection_per_measurement=40,
+    num_mcmc_per_measurement=40,
     pilot_steps=1000,  # explicit step count
 )
 ```
@@ -2872,8 +2841,6 @@ VMC_Workflow(
     opt_lambda_param=False,
     opt_with_projected_MOs=False,
     target_error=3.0e-3,
-    target_snr=4.5,
-    energy_slope_sigma_threshold=2.0,
     optimizer_kwargs={
         "method": "sr",
         "delta": 0.350,

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -97,6 +97,33 @@ Pass a **file** produced by an upstream workflow.  `filename` can be:
   (e.g. `"hamiltonian_data_opt_step_91.h5"`), which is then used to
   locate the file in the upstream directory.
 
+> **Important: file renaming.**  When a dynamic `FileFrom` resolves to
+> a name that differs from what the downstream workflow expects (e.g.
+> `hamiltonian_data_opt_step_91.h5` vs. `hamiltonian_data.h5`), use
+> `rename_input_files` to map it to the expected name.  Entries of
+> `None` keep the original name.  A pre-launch validation check will
+> raise `FileNotFoundError` **before any job is submitted** if required
+> files are missing.
+>
+> ```python
+> Container(
+>     label="mcmc",
+>     dirname="02_mcmc",
+>     input_files=[
+>         FileFrom("vmc", ValueFrom("vmc", "optimized_hamiltonian")),
+>     ],
+>     rename_input_files=["hamiltonian_data.h5"],
+>     workflow=MCMC_Workflow(...),
+> )
+> ```
+>
+> With multiple input files, use `None` to skip renaming for specific entries:
+>
+> ```python
+> input_files=[h5, FileFrom("vmc", ValueFrom("vmc", "optimized_hamiltonian"))],
+> rename_input_files=[None, "hamiltonian_data.h5"],
+> ```
+
 #### `ValueFrom(label, key)`
 
 Pass a **scalar value** from an upstream workflow's `output_values`
@@ -370,6 +397,35 @@ cached error from previous runs exceeds the new target and
 automatically re-estimates additional steps from the accumulated
 data.  Continuation runs are launched from where the previous
 execution left off, up to `max_continuation`.
+
+
+### Pre-launch validation
+
+Before any job is submitted, the engine verifies that all required
+files are present in the project directory.  Two checks are performed:
+
+1. Every resolved entry in `input_files` (after renaming) exists.
+2. The workflow's `hamiltonian_file` (e.g. `"hamiltonian_data.h5"`)
+   exists.
+
+If any file is missing, a `FileNotFoundError` is raised immediately
+with a message listing the missing files:
+
+```text
+FileNotFoundError: [mcmc-N2-0.80] Required file(s) missing in '05_mcmc/'
+before workflow launch: ['hamiltonian_data.h5'].
+Check that input_files and rename_input_files are configured correctly.
+```
+
+This catches misconfigured `rename_input_files` (e.g. a dynamic
+`FileFrom` + `ValueFrom` that produces `hamiltonian_data_opt_step_91.h5`
+but the workflow expects `hamiltonian_data.h5`) before wasting
+compute resources.
+
+Additionally, when the project directory already exists from a
+previous interrupted run, any input files that are missing (but
+available from the source) are automatically copied in.  Existing
+files are not overwritten.
 
 
 ### Restart behavior

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -69,6 +69,96 @@ run_pipeline.py
 | `WorkflowStatus` / `JobStatus` | Enums for workflow-level and per-job status values. See [Status enums](#status-enums). |
 
 
+### Inter-workflow data passing (`FileFrom` / `ValueFrom`)
+
+`FileFrom` and `ValueFrom` declare inter-workflow dependencies inside a
+`Container` definition.  At launch time, the `Launcher` resolves them
+to actual paths or values.
+
+#### `FileFrom(label, filename)`
+
+Pass a **file** produced by an upstream workflow.  `filename` can be:
+
+- A **static string** — when the exact name is known at definition time:
+
+  ```python
+  FileFrom("vmc", "hamiltonian_data_opt_step_9.h5")
+  ```
+
+- A **`ValueFrom` object** — when the name is determined at runtime
+  (e.g. VMC early convergence produces a step number that cannot be
+  predicted):
+
+  ```python
+  FileFrom("vmc", ValueFrom("vmc", "optimized_hamiltonian"))
+  ```
+
+  Here the `ValueFrom` is resolved first, yielding the actual basename
+  (e.g. `"hamiltonian_data_opt_step_91.h5"`), which is then used to
+  locate the file in the upstream directory.
+
+#### `ValueFrom(label, key)`
+
+Pass a **scalar value** from an upstream workflow's `output_values`
+dict.  The available keys depend on the workflow class — see the
+table below.
+
+#### Available `output_values` keys
+
+Each workflow populates `output_values` on completion.  These keys
+can be referenced by downstream workflows via
+`ValueFrom("label", "key")`.
+
+##### `VMC_Workflow`
+
+| Key | Type | Description |
+|---|---|---|
+| `optimized_hamiltonian` | `str` | Basename of the last optimised Hamiltonian file (e.g. `"hamiltonian_data_opt_step_91.h5"`). |
+| `checkpoint` | `str` | Basename of the restart checkpoint file. |
+| `num_mcmc_steps` | `int` | Estimated MCMC steps per optimisation step (automatic mode). |
+| `estimated_mcmc_steps` | `int` | Same as above, in fixed-step mode. |
+| `energy` | `float` | Energy from the last optimisation step (Ha). |
+| `energy_error` | `float` | Statistical error on `energy` (Ha). |
+| `signal_to_noise` | `float` | Average S/N over the trailing window (force convergence only). |
+| `signal_to_noise_last` | `float` | S/N of the last optimisation step. |
+| `energy_slope` | `float` | Slope of energy vs. step (energy-slope check only). |
+| `energy_slope_std` | `float` | Standard deviation of the energy slope. |
+
+##### `MCMC_Workflow`
+
+| Key | Type | Description |
+|---|---|---|
+| `energy` | `float` | VMC energy (Ha). |
+| `energy_error` | `float` | Statistical error on `energy` (Ha). |
+| `restart_chk` | `str` | Basename of the restart checkpoint file. |
+| `forces` | `object` | Atomic forces (only when `atomic_force=True`). |
+| `num_mcmc_steps` | `int` | Estimated total measurement steps (automatic mode). |
+| `estimated_steps` | `int` | Same as above, in fixed-step mode. |
+
+##### `LRDMC_Workflow`
+
+| Key | Type | Description |
+|---|---|---|
+| `energy` | `float` | DMC energy (Ha). |
+| `energy_error` | `float` | Statistical error on `energy` (Ha). |
+| `alat` | `float` | Lattice spacing used for this run. |
+| `restart_chk` | `str` | Basename of the restart checkpoint file. |
+| `forces` | `object` | Atomic forces (only when `atomic_force=True`). |
+| `estimated_steps` | `int` | Estimated total measurement steps. |
+| `num_projection_per_measurement` | `int` | GFMC projections per measurement (GFMC_n mode only). |
+| `time_projection_tau` | `float` | Imaginary-time projection step (GFMC_t mode only). |
+
+##### `LRDMC_Ext_Workflow`
+
+| Key | Type | Description |
+|---|---|---|
+| `extrapolated_energy` | `float` | Continuum-limit ($a^2 \to 0$) extrapolated energy (Ha). |
+| `extrapolated_energy_error` | `float` | Statistical error on `extrapolated_energy` (Ha). |
+| `per_alat_results` | `dict` | Per-alat energy/error results. |
+| `errors` | `list[str]` | Error messages for alat runs that failed. |
+| `error` | `str` | Top-level error message (only on failure). |
+
+
 ### Target error-bar estimation
 
 When `target_error` is set, each workflow (MCMC and LRDMC) operates in
@@ -785,8 +875,9 @@ mcmc = Container(
     dirname="mcmc_prod",
     input_files=[
         h5,
-        FileFrom("vmc", "hamiltonian_data_opt_step_*.h5"),
+        FileFrom("vmc", ValueFrom("vmc", "optimized_hamiltonian")),
     ],
+    rename_input_files=[None, "hamiltonian_data.h5"],
     workflow=MCMC_Workflow(
         server_machine_name=server,
         hamiltonian_file=h5,
@@ -802,7 +893,7 @@ lrdmc = Container(
     dirname="lrdmc_ext",
     input_files=[
         h5,
-        FileFrom("vmc", "hamiltonian_data_opt_step_*.h5"),
+        FileFrom("vmc", ValueFrom("vmc", "optimized_hamiltonian")),
     ],
     workflow=LRDMC_Ext_Workflow(
         server_machine_name=server,
@@ -822,8 +913,11 @@ pipeline.launch()
 ```
 
 In this example, `mcmc-prod` and `lrdmc-ext` depend on `vmc` (via
-`FileFrom`).  Additionally, `lrdmc-ext` depends on `mcmc-prod` (via
-`ValueFrom` for `E_scf`), so the DAG becomes
+`FileFrom`).  The optimised Hamiltonian filename is resolved
+dynamically through `ValueFrom("vmc", "optimized_hamiltonian")`,
+so the pipeline works correctly even when VMC converges early
+(e.g. step 91 instead of 150).  Additionally, `lrdmc-ext` depends on
+`mcmc-prod` (via `ValueFrom` for `E_scf`), so the DAG becomes
 VMC → MCMC → LRDMC-ext.  The `target_survived_walkers_ratio`
 triggers automatic calibration of `num_projection_per_measurement`
 independently at each lattice spacing.  All alat values run their

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -41,13 +41,13 @@ run_pipeline.py
      │  creates asyncio.Task per ready node
      │
      ├──► Container("vmc")
-     │         └─► VMC_Workflow.async_launch()
+     │         └─► VMC_Workflow.configure() → .run()
      │
      ├──► Container("mcmc-prod")   ← runs in parallel
-     │         └─► MCMC_Workflow.async_launch()
+     │         └─► MCMC_Workflow.configure() → .run()
      │
      └──► Container("lrdmc-ext")   ← runs in parallel
-               └─► LRDMC_Ext_Workflow.async_launch()
+               └─► LRDMC_Ext_Workflow.configure() → .run()
                        ├─► LRDMC_Workflow (alat=0.50)  ┐
                        ├─► LRDMC_Workflow (alat=0.40)  ├ parallel
                        └─► LRDMC_Workflow (alat=0.25)  ┘
@@ -55,9 +55,9 @@ run_pipeline.py
 
 ### Key components
 
-| Class | Role |
+| Class / Module | Role |
 |---|---|
-| `Launcher` | Executes a DAG of `Container` nodes in topological order, launching independent nodes in parallel. |
+| `Launcher` | Executes a DAG of `Container` nodes in topological order, launching independent nodes in parallel. Provides `get_session_state()`, `get_current_job()`, `get_job_history()` for session introspection. |
 | `Container` | Wraps any `Workflow` subclass in a dedicated project directory with state tracking (`workflow_state.toml`). |
 | `FileFrom` / `ValueFrom` | Declare inter-workflow dependencies (files or computed values). |
 | `WF_Workflow` | Converts a TREXIO file to `hamiltonian_data.h5`. |
@@ -65,6 +65,8 @@ run_pipeline.py
 | `MCMC_Workflow` | Production energy sampling (`job_type=mcmc`). |
 | `LRDMC_Workflow` | Lattice-regularized diffusion Monte Carlo for a single $a$ value. |
 | `LRDMC_Ext_Workflow` | Runs multiple `LRDMC_Workflow` instances at different lattice spacings and performs $a^2 \to 0$ extrapolation. |
+| `ScientificPhase` | Enum defining the scientific phases of a workflow session (INIT → SCF → WF_BUILD → VMC → MCMC → LRDMC → COMPLETED). See [Phase management](#phase-management). |
+| `WorkflowStatus` / `JobStatus` | Enums for workflow-level and per-job status values. See [Status enums](#status-enums). |
 
 
 ### Target error-bar estimation
@@ -239,6 +241,153 @@ This means a pipeline can be interrupted at any point (Ctrl-C, node
 failure, wall-time limit) and simply re-run; it will pick up exactly
 where it left off.
 
+When a job leaves the scheduler queue, the engine automatically collects
+**job accounting** data (if `jobacct` is configured in `machine_data.yaml`)
+before fetching output files.  The raw accounting output is saved to
+`job_accounting_{job_id}.txt` alongside `workflow_state.toml`.  See
+[Job accounting](#job-accounting).
+
+
+### Phase management
+
+A workflow session progresses through a sequence of **scientific phases**
+defined by the `ScientificPhase` enum (module `_phase`):
+
+```text
+INIT → SCF → WF_BUILD → VMC_PILOT → VMC → MCMC_PILOT → MCMC
+                                                         ↓
+                        COMPLETED ← LRDMC_FIT ← LRDMC ← LRDMC_PILOT
+```
+
+Not every pipeline uses every phase (e.g. a VMC-only pipeline skips
+LRDMC phases).  The allowed transitions are defined in
+`PHASE_TRANSITIONS` — for example, from `VMC` you may advance to
+`MCMC_PILOT`, `MCMC`, `LRDMC_PILOT`, `LRDMC`, or `COMPLETED`.
+
+Each phase has a list of **allowed actions** (`PHASE_ALLOWED_ACTIONS`)
+that further depends on the current `WorkflowStatus`:
+
+- When `status == RUNNING`, configuration actions (`configure_*`) are
+  filtered out.
+- When `status == FAILED`, only recovery actions (`recover_*`) and
+  `rollback_phase` are available.
+
+A set of **always-allowed actions** (`advance_phase`, `rollback_phase`,
+`close_session`, `register_artifact`, `mark_unhealthy`) is appended
+regardless of phase/status.
+
+The `require_action()` function enforces these rules at the boundary
+between an MCP tool call and a workflow method — if the action is not
+permitted, a `ValueError` is raised immediately.
+
+
+### Status enums
+
+Workflow status and job status are represented by `str`-based enums
+(`WorkflowStatus`, `JobStatus`) so they remain human-readable in
+`workflow_state.toml` and can be compared directly with strings.
+
+**WorkflowStatus** values:
+
+| Value | Meaning |
+|---|---|
+| `pending` | Not yet started |
+| `copying` | Input files being transferred |
+| `submitted` | Job submitted to scheduler |
+| `running` | Execution in progress |
+| `completed` | Finished successfully |
+| `failed` | Terminated with an error |
+| `cancelled` | Manually cancelled |
+
+**JobStatus** values (per-job, stored in `[[jobs]]` of
+`workflow_state.toml`):
+
+| Value | Meaning |
+|---|---|
+| `submitted` | Job submitted |
+| `completed` | Job finished (output not yet fetched) |
+| `fetched` | Output files retrieved |
+| `failed` | Job failed |
+
+
+### Artifact registry
+
+The engine records file lineage in the `[[artifacts]]` array of
+`workflow_state.toml`.  Each entry tracks:
+
+| Field | Description |
+|---|---|
+| `filename` | Basename of the artifact file |
+| `produced_by_job` | Input file that produced this artifact |
+| `produced_at` | ISO 8601 timestamp |
+| `artifact_type` | `"file"` (default) |
+| `upstream` | Optional list of `{label, file}` dicts tracing the dependency chain |
+
+Use `register_artifact()` to add an entry, `get_artifact_lineage()` to
+look up a single file, and `get_artifact_registry()` to list all
+artifacts.
+
+
+### Error recording
+
+When a workflow fails, the `[error]` section of `workflow_state.toml`
+is populated via `set_error()`:
+
+```toml
+[error]
+message = "Job killed after 86400s"
+exception_type = "RuntimeError"
+traceback = "..."
+```
+
+The engine records raw data only — failure classification and recovery
+strategy are responsibilities of external tooling (e.g. an MCP agent).
+
+
+### Job accounting
+
+For queuing systems (PBS, Slurm, Fujitsu TCS, etc.), the engine can
+collect scheduler accounting data after a job leaves the queue.  This
+is configured via the optional `jobacct` field in `machine_data.yaml`
+(see [machine_data.yaml parameters](#parameters)).
+
+The engine executes `{jobacct} {job_id}` and writes the raw output to
+a separate file `job_accounting_{job_id}.txt`.  The `[job_accounting]`
+section of `workflow_state.toml` stores only the command and a
+reference to that file:
+
+```toml
+[job_accounting]
+command = "sacct -j --format=State,ExitCode,MaxRSS,Elapsed,Timelimit -P --noheader 12345"
+file = "job_accounting_12345.txt"
+```
+
+No parsing or interpretation is performed — that responsibility belongs
+to external tooling.  If `jobacct` is not configured, this section is
+simply absent.
+
+
+### Session state queries
+
+The `Launcher` provides three methods for programmatic introspection
+(useful for MCP adapters and monitoring tools):
+
+| Method | Returns |
+|---|---|
+| `get_session_state()` | Dict with per-workflow summaries, dependency graph, and progress counters (completed / failed / running / pending / total). |
+| `get_current_job()` | The first workflow with status `running` or `submitted`, or `None`. |
+| `get_job_history()` | Flat, chronologically-sorted list of all jobs across all workflows. |
+
+
+### Machine catalog
+
+Two helper functions are available for machine discovery:
+
+| Function | Description |
+|---|---|
+| `list_machines()` | Returns a list of dicts summarising all machines defined in `machine_data.yaml` (name, machine_type, queuing, ssh_host, workspace_root). |
+| `probe_environment(machine_name)` | Tests connectivity to the named machine (SSH for remote, always reachable for local). Returns `{"reachable": True/False, ...}`. |
+
 
 ## Configuration
 
@@ -291,6 +440,29 @@ my-cluster:                          # nickname (freely chosen)
   jobcheck: /opt/pbs/bin/qstat
   jobdel: /opt/pbs/bin/qdel
   jobnum_index: 0
+  jobacct: /opt/pbs/bin/qstat -xf
+
+my-slurm:                            # Slurm example
+  ssh_host: slurm-cluster
+  machine_type: remote
+  queuing: true
+  workspace_root: /home/user/jqmc_work
+  jobsubmit: sbatch
+  jobcheck: squeue --noheader
+  jobdel: scancel
+  jobnum_index: 3
+  jobacct: sacct -j --format=State,ExitCode,MaxRSS,Elapsed,Timelimit -P --noheader
+
+my-fugaku:                           # Fujitsu TCS example
+  ssh_host: fugaku
+  machine_type: remote
+  queuing: true
+  workspace_root: /vol0004/user/jqmc_work
+  jobsubmit: /usr/local/bin/pjsub
+  jobcheck: /usr/local/bin/pjstat
+  jobdel: /usr/local/bin/pjdel
+  jobnum_index: 5
+  jobacct: pjstat -H -s --choose jid,st,ec,elp,pc --data
 ```
 
 #### Parameters
@@ -305,6 +477,7 @@ my-cluster:                          # nickname (freely chosen)
 | `jobcheck` | String (command) | When `queuing: true` | Command to check job status (e.g. `qstat`, `squeue --noheader`, `pjstat`). |
 | `jobdel` | String (command) | When `queuing: true` | Command to cancel a job (e.g. `qdel`, `scancel`, `pjdel`). |
 | `jobnum_index` | Integer | When `queuing: true` | 0-based column index of the job ID in the output of `jobsubmit`. For PBS (`42.server`), use `0`. For Slurm (`Submitted batch job 42`), use `3`. |
+| `jobacct` | String (command) | No | Scheduler accounting command **with flags**. The engine executes `{jobacct} {job_id}` after a job leaves the queue and saves the raw output to `job_accounting_{job_id}.txt`. No parsing is performed. Examples: `sacct -j --format=State,ExitCode,MaxRSS,Elapsed,Timelimit -P --noheader` (Slurm), `qstat -xf` (PBS), `pjstat -H -s --choose jid,st,ec,elp,pc --data` (Fujitsu TCS). If omitted, no accounting data is collected. |
 | `ip` | String | No | IP address or hostname of the remote machine. Usually the SSH alias in `~/.ssh/config` is used instead. |
 
 #### SSH connection
@@ -377,11 +550,20 @@ You can name the file anything you like (e.g. `submit_gpu.sh`).
 
 #### Predefined variables
 
-| Variable | Description |
-|---|---|
-| `_INPUT_` | Path to the input file |
-| `_OUTPUT_` | Path to the output file |
-| `_JOBNAME_` | Job name |
+| Variable | Description | Default |
+|---|---|---|
+| `_INPUT_` | Path to the jqmc input TOML file | (set by workflow) |
+| `_OUTPUT_` | Path to the jqmc stdout+stderr capture file | `"out.o"` |
+| `_JOBNAME_` | Job name | `"jqmc-wf"` |
+| `_JOB_STDOUT_` | Path for the **scheduler** stdout file (e.g. PBS `-o`, Slurm `--output`) | `"job_{jobname}.o"` |
+| `_JOB_STDERR_` | Path for the **scheduler** stderr file (e.g. PBS `-e`, Slurm `--error`) | `"job_{jobname}.e"` |
+
+`_JOB_STDOUT_` and `_JOB_STDERR_` allow the engine to track where the
+scheduler writes its output, which is useful for failure diagnosis.
+If these placeholders are not present in the template the scheduler's
+default naming convention is used (backward-compatible).
+The file paths are recorded in the `[job_files]` section of
+`workflow_state.toml`.
 
 #### Custom variables
 
@@ -397,12 +579,34 @@ surrounding underscores. For example, `num_cores = 48` becomes
 #PBS -q _QUEUE_
 #PBS -l nodes=_NODES_:ppn=_MPI_PER_NODE_
 #PBS -l walltime=_MAX_TIME_
+#PBS -o _JOB_STDOUT_
+#PBS -e _JOB_STDERR_
 
 export OMP_NUM_THREADS=_OMP_NUM_THREADS_
 INPUT=_INPUT_
 OUTPUT=_OUTPUT_
 
+cd ${PBS_O_WORKDIR}
 mpirun -np _NUM_CORES_ jqmc ${INPUT} > ${OUTPUT} 2>&1
+```
+
+#### Example (`submit_mpi.sh` for Slurm)
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=_JOBNAME_
+#SBATCH --partition=_QUEUE_
+#SBATCH --nodes=_NODES_
+#SBATCH --ntasks=_NUM_CORES_
+#SBATCH --time=_MAX_TIME_
+#SBATCH --output=_JOB_STDOUT_
+#SBATCH --error=_JOB_STDERR_
+
+export OMP_NUM_THREADS=_OMP_NUM_THREADS_
+INPUT=_INPUT_
+OUTPUT=_OUTPUT_
+
+srun jqmc ${INPUT} > ${OUTPUT} 2>&1
 ```
 
 #### Example (`submit_serial.sh`)
@@ -413,11 +617,14 @@ mpirun -np _NUM_CORES_ jqmc ${INPUT} > ${OUTPUT} 2>&1
 #PBS -q _QUEUE_
 #PBS -l nodes=_NODES_
 #PBS -l walltime=_MAX_TIME_
+#PBS -o _JOB_STDOUT_
+#PBS -e _JOB_STDERR_
 
 export OMP_NUM_THREADS=_OMP_NUM_THREADS_
 INPUT=_INPUT_
 OUTPUT=_OUTPUT_
 
+cd ${PBS_O_WORKDIR}
 jqmc ${INPUT} > ${OUTPUT} 2>&1
 ```
 

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -243,8 +243,8 @@ where it left off.
 
 When a job leaves the scheduler queue, the engine automatically collects
 **job accounting** data (if `jobacct` is configured in `machine_data.yaml`)
-before fetching output files.  The raw accounting output is saved to
-`job_accounting_{job_id}.txt` alongside `workflow_state.toml`.  See
+before fetching output files.  The accounting command and output file
+path are stored in the corresponding `[[jobs]]` record.  See
 [Job accounting](#job-accounting).
 
 
@@ -309,6 +309,25 @@ Workflow status and job status are represented by `str`-based enums
 | `fetched` | Output files retrieved |
 | `failed` | Job failed |
 
+Each `[[jobs]]` record contains:
+
+| Field | Description |
+|---|---|
+| `input_file` | Basename of the generated TOML input file |
+| `output_file` | Basename of the stdout capture file |
+| `job_id` | Scheduler job ID (or `"local"` for local runs) |
+| `server_machine` | Machine name |
+| `status` | One of the `JobStatus` values above |
+| `submitted_at` | ISO 8601 timestamp |
+| `step` | Step index (0 = pilot, 1, 2, … = production) |
+| `run_id` | Short hex identifier for the job |
+| `completed_at` | ISO 8601 timestamp (set on completion) |
+| `fetched_at` | ISO 8601 timestamp (set on fetch) |
+| `job_stdout` | Scheduler stdout path (queuing systems only) |
+| `job_stderr` | Scheduler stderr path (queuing systems only) |
+| `job_acct_command` | Accounting command executed (queuing systems only) |
+| `job_acct_file` | Path to raw accounting output file (queuing systems only) |
+
 
 ### Artifact registry
 
@@ -352,19 +371,27 @@ is configured via the optional `jobacct` field in `machine_data.yaml`
 (see [machine_data.yaml parameters](#parameters)).
 
 The engine executes `{jobacct} {job_id}` and writes the raw output to
-a separate file `job_accounting_{job_id}.txt`.  The `[job_accounting]`
-section of `workflow_state.toml` stores only the command and a
-reference to that file:
+a separate file `job_accounting_{job_id}.txt`.  The accounting command
+and file path are stored per-job in the `[[jobs]]` record:
 
 ```toml
-[job_accounting]
-command = "sacct -j --format=State,ExitCode,MaxRSS,Elapsed,Timelimit -P --noheader 12345"
-file = "job_accounting_12345.txt"
+[[jobs]]
+input_file = "vmc-H2-0.74_1_aebf13bd.toml"
+output_file = "vmc-H2-0.74_1_aebf13bd.out"
+job_id = "12345"
+server_machine = "my-cluster"
+status = "fetched"
+step = 1
+run_id = "aebf13bd"
+job_stdout = "job_vmc-H2-0.74.o"
+job_stderr = "job_vmc-H2-0.74.e"
+job_acct_command = "sacct -j 12345 --format=State,ExitCode,MaxRSS,Elapsed -P"
+job_acct_file = "job_accounting_12345.txt"
 ```
 
 No parsing or interpretation is performed — that responsibility belongs
-to external tooling.  If `jobacct` is not configured, this section is
-simply absent.
+to external tooling.  If `jobacct` is not configured, the
+`job_acct_command` and `job_acct_file` fields are simply absent.
 
 
 ### Session state queries
@@ -562,8 +589,8 @@ You can name the file anything you like (e.g. `submit_gpu.sh`).
 scheduler writes its output, which is useful for failure diagnosis.
 If these placeholders are not present in the template the scheduler's
 default naming convention is used (backward-compatible).
-The file paths are recorded in the `[job_files]` section of
-`workflow_state.toml`.
+The file paths are recorded per-job in the `[[jobs]]` records of
+`workflow_state.toml` (as `job_stdout` and `job_stderr`).
 
 #### Custom variables
 

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -120,7 +120,11 @@ optimization:
 | `opt_lambda_basis_exp` | `False` | Optimize Geminal AO Gaussian exponents |
 | `opt_lambda_basis_coeff` | `False` | Optimize Geminal AO contraction coefficients |
 
-These cannot be combined with `opt_with_projected_MOs`.
+`opt_lambda_basis_exp` and `opt_lambda_basis_coeff` cannot be combined
+with `opt_with_projected_MOs` (changing Geminal AO exponents/coefficients
+invalidates the overlap matrix used by the MO projection).
+`opt_J3_basis_exp` and `opt_J3_basis_coeff` **can** be used together
+with `opt_with_projected_MOs`.
 
 When set, the corresponding parameters are passed through to the
 jqmc input TOML via `resolve_with_defaults()`.  When left as `None`

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -186,6 +186,25 @@ in `output_values` for downstream inspection.
 In fixed-step mode (`num_mcmc_steps` is set), the convergence checks
 are not performed.
 
+##### Early exit on convergence
+
+When convergence criteria are set, the VMC production loop exits
+early as soon as all active checks pass, instead of always running
+the full `max_continuation` steps.  This avoids wasting compute
+time once the optimization has plateaued.
+
+On re-runs with changed criteria (e.g. lowering `target_snr`),
+convergence is re-evaluated from the fetched results before
+submitting new jobs.  If the existing results already satisfy the
+new criteria, the workflow completes immediately without launching
+additional runs.
+
+When no convergence criterion is set (`target_snr = None` and
+`energy_slope_sigma_threshold = None`), all `max_continuation`
+steps run unconditionally.  If convergence is **not** achieved
+after exhausting all production steps, the workflow returns
+`FAILED`.
+
 #### Step estimation formula
 
 The required number of production steps is estimated via
@@ -244,6 +263,23 @@ After each production run, the error bar is re-evaluated.
 If it exceeds the target, additional steps are estimated and a
 continuation run is launched automatically, up to `max_continuation`
 times.
+
+#### Target error not met
+
+If `max_continuation` runs complete but the statistical error still
+exceeds `target_error`, the workflow logs a **warning** and returns
+`COMPLETED` (not `FAILED`).  The calculation itself succeeded; only
+the error-bar criterion was not fully met.  This applies to both
+`MCMC_Workflow` and `LRDMC_Workflow`.
+
+#### Continuation with tighter target error
+
+When re-running a pipeline with a stricter `target_error` (e.g.
+lowering from `1e-3` to `5e-4`), the workflow detects that the
+cached error from previous runs exceeds the new target and
+automatically re-estimates additional steps from the accumulated
+data.  Continuation runs are launched from where the previous
+execution left off, up to `max_continuation`.
 
 
 ### Restart behavior
@@ -337,8 +373,8 @@ Each `[[jobs]]` record contains:
 
 | Field | Description |
 |---|---|
-| `input_file` | Basename of the generated TOML input file |
-| `output_file` | Basename of the stdout capture file |
+| `input_file` | Basename of the generated TOML input file (`input_{jobname}_{step}_{run_id}.toml`) |
+| `output_file` | Basename of the stdout capture file (`output_{jobname}_{step}_{run_id}.out`) |
 | `job_id` | Scheduler job ID (or `"local"` for local runs) |
 | `server_machine` | Machine name |
 | `status` | One of the `JobStatus` values above |
@@ -371,6 +407,32 @@ look up a single file, and `get_artifact_registry()` to list all
 artifacts.
 
 
+### Input staleness detection
+
+When a `Container` completes successfully, it records the **size** and
+**modification time** of each input file in the `[input_fingerprints]`
+section of `workflow_state.toml`.  On subsequent runs, if the container
+is already `completed`, the engine compares the current input files
+against the recorded fingerprints.
+
+If any input has changed (e.g. an upstream VMC produced a new optimised
+wavefunction), the engine logs a warning:
+
+```text
+WARNING: Inputs have changed but previous results are still present.
+Delete 'mcmc_prod/' to re-run with the updated inputs.
+```
+
+The container is **not** automatically re-run — the user must
+manually delete the stale directory.  This conservative approach
+avoids the risk of mixing old and new job data on the remote server.
+
+Note that staleness is tracked per-file by `os.stat()` metadata
+(size + mtime), not by file content hashing.  If an upstream
+workflow re-runs but produces an identical output file (same size
+and mtime), no warning is triggered.
+
+
 ### Error recording
 
 When a workflow fails, the `[error]` section of `workflow_state.toml`
@@ -400,8 +462,8 @@ and file path are stored per-job in the `[[jobs]]` record:
 
 ```toml
 [[jobs]]
-input_file = "vmc-H2-0.74_1_aebf13bd.toml"
-output_file = "vmc-H2-0.74_1_aebf13bd.out"
+input_file = "input_vmc-H2-0.74_1_aebf13bd.toml"
+output_file = "output_vmc-H2-0.74_1_aebf13bd.out"
 job_id = "12345"
 server_machine = "my-cluster"
 status = "fetched"

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -409,11 +409,11 @@ artifacts.
 
 ### Input staleness detection
 
-When a `Container` completes successfully, it records the **size** and
-**modification time** of each input file in the `[input_fingerprints]`
+When a `Container` completes successfully, it records the **SHA-256
+content hash** of each input file in the `[input_fingerprints]`
 section of `workflow_state.toml`.  On subsequent runs, if the container
-is already `completed`, the engine compares the current input files
-against the recorded fingerprints.
+is already `completed` or `running`, the engine compares the current
+input files against the recorded fingerprints.
 
 If any input has changed (e.g. an upstream VMC produced a new optimised
 wavefunction), the engine logs a warning:
@@ -427,10 +427,9 @@ The container is **not** automatically re-run — the user must
 manually delete the stale directory.  This conservative approach
 avoids the risk of mixing old and new job data on the remote server.
 
-Note that staleness is tracked per-file by `os.stat()` metadata
-(size + mtime), not by file content hashing.  If an upstream
-workflow re-runs but produces an identical output file (same size
-and mtime), no warning is triggered.
+Staleness is tracked per-file by SHA-256 content hashing.  If an
+upstream workflow re-runs but produces a byte-identical output file,
+no warning is triggered.
 
 
 ### Error recording

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -453,11 +453,11 @@ my-slurm:                            # Slurm example
   jobnum_index: 3
   jobacct: sacct -j --format=State,ExitCode,MaxRSS,Elapsed,Timelimit -P --noheader
 
-my-fugaku:                           # Fujitsu TCS example
-  ssh_host: fugaku
+my-fujitsu:                          # Fujitsu TCS example
+  ssh_host: fujitsu
   machine_type: remote
   queuing: true
-  workspace_root: /vol0004/user/jqmc_work
+  workspace_root: /home/user/jqmc_work
   jobsubmit: /usr/local/bin/pjsub
   jobcheck: /usr/local/bin/pjstat
   jobdel: /usr/local/bin/pjdel

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -402,11 +402,10 @@ execution left off, up to `max_continuation`.
 ### Pre-launch validation
 
 Before any job is submitted, the engine verifies that all required
-files are present in the project directory.  Two checks are performed:
-
-1. Every resolved entry in `input_files` (after renaming) exists.
-2. The workflow's `hamiltonian_file` (e.g. `"hamiltonian_data.h5"`)
-   exists.
+files are present in the project directory.  Every resolved entry in
+`input_files` (after renaming) must exist.  Workflow-internal files
+(e.g. `hamiltonian_file`) are **not** checked because some workflows
+(e.g. `WF_Workflow`) *produce* them rather than consume them.
 
 If any file is missing, a `FileNotFoundError` is raised immediately
 with a message listing the missing files:

--- a/doc/notes/workflows.md
+++ b/doc/notes/workflows.md
@@ -106,6 +106,26 @@ independently runs its own calibration, error-bar pilot, and production
 in parallel.  There is no inter-alat interaction until the final
 extrapolation step.
 
+#### AO basis optimization
+
+`VMC_Workflow` supports optimizing the atomic-orbital (AO) Gaussian
+basis parameters alongside Jastrow / orbital coefficients.  Four
+boolean flags control which basis parameters are included in the
+optimization:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `opt_J3_basis_exp` | `False` | Optimize J3 (three-body Jastrow) AO Gaussian exponents |
+| `opt_J3_basis_coeff` | `False` | Optimize J3 AO contraction coefficients |
+| `opt_lambda_basis_exp` | `False` | Optimize Geminal AO Gaussian exponents |
+| `opt_lambda_basis_coeff` | `False` | Optimize Geminal AO contraction coefficients |
+
+These cannot be combined with `opt_with_projected_MOs`.
+
+When set, the corresponding parameters are passed through to the
+jqmc input TOML via `resolve_with_defaults()`.  When left as `None`
+(the default), the jqmc binary applies its own defaults (`false`).
+
 #### VMC convergence checks
 
 After all production runs complete, the VMC workflow checks whether
@@ -591,6 +611,13 @@ If these placeholders are not present in the template the scheduler's
 default naming convention is used (backward-compatible).
 The file paths are recorded per-job in the `[[jobs]]` records of
 `workflow_state.toml` (as `job_stdout` and `job_stderr`).
+
+> **Note:** `job_stdout` and `job_stderr` are treated as **optional**
+> during fetch.  If the files do not exist on the remote server (e.g.
+> the job script template does not include `#SBATCH --output` /
+> `#SBATCH --error` directives), the engine logs a warning and
+> continues instead of raising an error.  All other output files
+> remain mandatory.
 
 #### Custom variables
 

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -7,7 +7,7 @@
 ![fork](https://img.shields.io/github/forks/kousuke-nakano/jQMC?style=social)
 ![stars](https://img.shields.io/github/stars/kousuke-nakano/jQMC?style=social)
 ![full-pytest](https://github.com/kousuke-nakano/jQMC/actions/workflows/jqmc-run-full-pytest.yml/badge.svg)
-![codecov](https://codecov.io/github/kousuke-nakano/jQMC/graph/badge.svg?token=H0Z7M86C1E)
+![codecov](https://codecov.io/github/kousuke-nakano/jQMC/graph/badge.svg)
 ![DL](https://img.shields.io/pypi/dm/jqmc)
 ![python_version](https://img.shields.io/pypi/pyversions/jqmc)
 ![pypi_version](https://badge.fury.io/py/jqmc.svg)

--- a/examples/jqmc-workflow-example99/run_test_on_local.py
+++ b/examples/jqmc-workflow-example99/run_test_on_local.py
@@ -53,6 +53,7 @@ TARGET_LRDMC_ERROR = 0.005  # very loose
 ALAT = 0.30  # LRDMC lattice spacing (bohr)
 
 R_VALUES = [0.74, 1.00]
+R_VALUES = [0.74]
 
 # pySCF script template
 PYSCF_TEMPLATE = '''\
@@ -179,7 +180,7 @@ def build_pipeline() -> list[Container]:
                 poll_interval=120,
                 max_continuation=2,
                 target_snr=None,
-                energy_slope_sigma_threshold=1.0,
+                energy_slope_sigma_threshold=None,
             ),
         )
 

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -5971,7 +5971,7 @@ class GFMC_n:
             # E: jackknife mean and std
             sum_E_local = np.sum(E_jackknife_binned_local)
             sumsq_E_local = np.sum(E_jackknife_binned_local**2)
-            
+
             # E: global sums
             sum_E_global = mpi_comm.allreduce(sum_E_local, op=MPI.SUM)
             sumsq_E_global = mpi_comm.allreduce(sumsq_E_local, op=MPI.SUM)
@@ -5983,7 +5983,7 @@ class GFMC_n:
             # Var: jackknife mean and std
             sum_Var_local = np.sum(Var_jackknife_binned_local)
             sumsq_Var_local = np.sum(Var_jackknife_binned_local**2)
-            
+
             # Var: global sums
             sum_Var_global = mpi_comm.allreduce(sum_Var_local, op=MPI.SUM)
             sumsq_Var_global = mpi_comm.allreduce(sumsq_Var_local, op=MPI.SUM)

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -2053,9 +2053,9 @@ class GFMC_t:
                 w_L_e_L2_binned_local = np.array(w_L_e_L2_binned)
 
                 ## local sum
-                w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-                w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
-                w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local, axis=0)
+                w_L_binned_local_sum = np.sum(w_L_binned_local)
+                w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
+                w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local)
 
                 ## jackknie binned samples
                 M_local = w_L_binned_local.size
@@ -2140,19 +2140,14 @@ class GFMC_t:
             w_L_e_L2_binned_local = np.array(w_L_e_L2_binned_local)
 
             ## local sum
-            w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
-            w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local, axis=0)
+            w_L_binned_local_sum = np.sum(w_L_binned_local)
+            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
+            w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local)
 
             ## glolbal sum
-            w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-            w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
-            w_L_e_L2_binned_global_sum = np.empty_like(w_L_e_L2_binned_local_sum)
-
-            ## mpi Allreduce
-            mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L2_binned_local_sum, MPI.DOUBLE], [w_L_e_L2_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
+            w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L2_binned_global_sum = mpi_comm.allreduce(w_L_e_L2_binned_local_sum, op=MPI.SUM)
 
             ## jackknie binned samples
             M_local = w_L_binned_local.size
@@ -2178,11 +2173,9 @@ class GFMC_t:
             sum_E_local = np.sum(E_jackknife_binned_local)
             sumsq_E_local = np.sum(E_jackknife_binned_local**2)
 
-            sum_E_global = np.empty_like(sum_E_local)
-            sumsq_E_global = np.empty_like(sumsq_E_local)
-
-            mpi_comm.Allreduce([sum_E_local, MPI.DOUBLE], [sum_E_global, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([sumsq_E_local, MPI.DOUBLE], [sumsq_E_global, MPI.DOUBLE], op=MPI.SUM)
+            # E: global sum
+            sum_E_global = mpi_comm.allreduce(sum_E_local, op=MPI.SUM)
+            sumsq_E_global = mpi_comm.allreduce(sumsq_E_local, op=MPI.SUM)
 
             E_mean = sum_E_global / M_total
             E_var = (sumsq_E_global / M_total) - (sum_E_global / M_total) ** 2
@@ -2192,11 +2185,9 @@ class GFMC_t:
             sum_Var_local = np.sum(Var_jackknife_binned_local)
             sumsq_Var_local = np.sum(Var_jackknife_binned_local**2)
 
-            sum_Var_global = np.empty_like(sum_Var_local)
-            sumsq_Var_global = np.empty_like(sumsq_Var_local)
-
-            mpi_comm.Allreduce([sum_Var_local, MPI.DOUBLE], [sum_Var_global, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([sumsq_Var_local, MPI.DOUBLE], [sumsq_Var_global, MPI.DOUBLE], op=MPI.SUM)
+            # Var: global sum
+            sum_Var_global = mpi_comm.allreduce(sum_Var_local, op=MPI.SUM)
+            sumsq_Var_global = mpi_comm.allreduce(sumsq_Var_local, op=MPI.SUM)
 
             Var_mean = sum_Var_global / M_total
             Var_var = (sumsq_Var_global / M_total) - (sum_Var_global / M_total) ** 2
@@ -2405,22 +2396,21 @@ class GFMC_t:
             w_L_E_L_force_PP_binned_local = np.array(w_L_E_L_force_PP_binned_local)
 
             ## local sum
-            w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
+            w_L_binned_local_sum = np.sum(w_L_binned_local)
+            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
             w_L_force_HF_binned_local_sum = np.sum(w_L_force_HF_binned_local, axis=0)
             w_L_force_PP_binned_local_sum = np.sum(w_L_force_PP_binned_local, axis=0)
             w_L_E_L_force_PP_binned_local_sum = np.sum(w_L_E_L_force_PP_binned_local, axis=0)
 
             ## glolbal sum
-            w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-            w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
+            ### mpi allreduce (scalar)
+            w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+
+            ### mpi Allreduce (array)
             w_L_force_HF_binned_global_sum = np.empty_like(w_L_force_HF_binned_local_sum)
             w_L_force_PP_binned_global_sum = np.empty_like(w_L_force_PP_binned_local_sum)
             w_L_E_L_force_PP_binned_global_sum = np.empty_like(w_L_E_L_force_PP_binned_local_sum)
-
-            ## mpi Allreduce
-            mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
             mpi_comm.Allreduce(
                 [w_L_force_HF_binned_local_sum, MPI.DOUBLE], [w_L_force_HF_binned_global_sum, MPI.DOUBLE], op=MPI.SUM
             )
@@ -5949,19 +5939,14 @@ class GFMC_n:
             w_L_e_L2_binned_local = np.array(w_L_e_L2_binned_local)
 
             ## local sum
-            w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
-            w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local, axis=0)
+            w_L_binned_local_sum = np.sum(w_L_binned_local)
+            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
+            w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local)
 
             ## glolbal sum
-            w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-            w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
-            w_L_e_L2_binned_global_sum = np.empty_like(w_L_e_L2_binned_local_sum)
-
-            ## mpi Allreduce
-            mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L2_binned_local_sum, MPI.DOUBLE], [w_L_e_L2_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
+            w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L2_binned_global_sum = mpi_comm.allreduce(w_L_e_L2_binned_local_sum, op=MPI.SUM)
 
             ## jackknie binned samples
             M_local = w_L_binned_local.size
@@ -5986,12 +5971,10 @@ class GFMC_n:
             # E: jackknife mean and std
             sum_E_local = np.sum(E_jackknife_binned_local)
             sumsq_E_local = np.sum(E_jackknife_binned_local**2)
-
-            sum_E_global = np.empty_like(sum_E_local)
-            sumsq_E_global = np.empty_like(sumsq_E_local)
-
-            mpi_comm.Allreduce([sum_E_local, MPI.DOUBLE], [sum_E_global, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([sumsq_E_local, MPI.DOUBLE], [sumsq_E_global, MPI.DOUBLE], op=MPI.SUM)
+            
+            # E: global sums
+            sum_E_global = mpi_comm.allreduce(sum_E_local, op=MPI.SUM)
+            sumsq_E_global = mpi_comm.allreduce(sumsq_E_local, op=MPI.SUM)
 
             E_mean = sum_E_global / M_total
             E_var = (sumsq_E_global / M_total) - (sum_E_global / M_total) ** 2
@@ -6000,12 +5983,10 @@ class GFMC_n:
             # Var: jackknife mean and std
             sum_Var_local = np.sum(Var_jackknife_binned_local)
             sumsq_Var_local = np.sum(Var_jackknife_binned_local**2)
-
-            sum_Var_global = np.empty_like(sum_Var_local)
-            sumsq_Var_global = np.empty_like(sumsq_Var_local)
-
-            mpi_comm.Allreduce([sum_Var_local, MPI.DOUBLE], [sum_Var_global, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([sumsq_Var_local, MPI.DOUBLE], [sumsq_Var_global, MPI.DOUBLE], op=MPI.SUM)
+            
+            # Var: global sums
+            sum_Var_global = mpi_comm.allreduce(sum_Var_local, op=MPI.SUM)
+            sumsq_Var_global = mpi_comm.allreduce(sumsq_Var_local, op=MPI.SUM)
 
             Var_mean = sum_Var_global / M_total
             Var_var = (sumsq_Var_global / M_total) - (sum_Var_global / M_total) ** 2
@@ -6083,8 +6064,8 @@ class GFMC_n:
                 w_L_E_L_force_PP_binned_local = np.array(w_L_E_L_force_PP_binned)
 
                 ## local sum
-                w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-                w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
+                w_L_binned_local_sum = np.sum(w_L_binned_local)
+                w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
                 w_L_force_HF_binned_local_sum = np.sum(w_L_force_HF_binned_local, axis=0)
                 w_L_force_PP_binned_local_sum = np.sum(w_L_force_PP_binned_local, axis=0)
                 w_L_E_L_force_PP_binned_local_sum = np.sum(w_L_E_L_force_PP_binned_local, axis=0)
@@ -6217,22 +6198,21 @@ class GFMC_n:
             w_L_E_L_force_PP_binned_local = np.array(w_L_E_L_force_PP_binned_local)
 
             ## local sum
-            w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
+            w_L_binned_local_sum = np.sum(w_L_binned_local)
+            w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
             w_L_force_HF_binned_local_sum = np.sum(w_L_force_HF_binned_local, axis=0)
             w_L_force_PP_binned_local_sum = np.sum(w_L_force_PP_binned_local, axis=0)
             w_L_E_L_force_PP_binned_local_sum = np.sum(w_L_E_L_force_PP_binned_local, axis=0)
 
             ## glolbal sum
-            w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-            w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
+            ### mpi allreduce(scalar)
+            w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+            w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+
+            ### mpi Allreduce(array)
             w_L_force_HF_binned_global_sum = np.empty_like(w_L_force_HF_binned_local_sum)
             w_L_force_PP_binned_global_sum = np.empty_like(w_L_force_PP_binned_local_sum)
             w_L_E_L_force_PP_binned_global_sum = np.empty_like(w_L_E_L_force_PP_binned_local_sum)
-
-            ## mpi Allreduce
-            mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-            mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
             mpi_comm.Allreduce(
                 [w_L_force_HF_binned_local_sum, MPI.DOUBLE], [w_L_force_HF_binned_global_sum, MPI.DOUBLE], op=MPI.SUM
             )

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -2151,11 +2151,11 @@ class MCMC:
             if not opt_lambda_param:
                 raise ValueError("opt_with_projected_MOs=True requires opt_lambda_param=True.")
 
-            if any([opt_J3_basis_exp, opt_J3_basis_coeff, opt_lambda_basis_exp, opt_lambda_basis_coeff]):
+            if any([opt_lambda_basis_exp, opt_lambda_basis_coeff]):
                 raise ValueError(
-                    "AO basis optimization (opt_J3_basis_exp/coeff, opt_lambda_basis_exp/coeff) "
+                    "Geminal AO basis optimization (opt_lambda_basis_exp/coeff) "
                     "cannot be combined with opt_with_projected_MOs. "
-                    "Changing AO exponents/coefficients invalidates the overlap matrix "
+                    "Changing Geminal AO exponents/coefficients invalidates the overlap matrix "
                     "used by the MO projection operators."
                 )
 

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -1064,20 +1064,15 @@ class MCMC:
         w_L_e_L2_binned_local = np.array(w_L_e_L2_binned_local)
 
         ## local sum
-        w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
-        w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local, axis=0)
+        w_L_binned_local_sum = np.sum(w_L_binned_local)
+        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
+        w_L_e_L2_binned_local_sum = np.sum(w_L_e_L2_binned_local)
 
         ## glolbal sum
-        w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-        w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
-        w_L_e_L2_binned_global_sum = np.empty_like(w_L_e_L2_binned_local_sum)
-
-        ## mpi Allreduce
-        mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([w_L_e_L2_binned_local_sum, MPI.DOUBLE], [w_L_e_L2_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-
+        w_L_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_binned_local), op=MPI.SUM)
+        w_L_e_L_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_e_L_binned_local), op=MPI.SUM)
+        w_L_e_L2_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_e_L2_binned_local), op=MPI.SUM)
+        
         ## jackknie binned samples
         M_local = w_L_binned_local.size
         M_total = mpi_comm.allreduce(M_local, op=MPI.SUM)
@@ -1102,11 +1097,9 @@ class MCMC:
         sum_E_local = np.sum(E_jackknife_binned_local)
         sumsq_E_local = np.sum(E_jackknife_binned_local**2)
 
-        sum_E_global = np.empty_like(sum_E_local)
-        sumsq_E_global = np.empty_like(sumsq_E_local)
-
-        mpi_comm.Allreduce([sum_E_local, MPI.DOUBLE], [sum_E_global, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([sumsq_E_local, MPI.DOUBLE], [sumsq_E_global, MPI.DOUBLE], op=MPI.SUM)
+        # E: global sums
+        sum_E_global = mpi_comm.allreduce(sum_E_local, op=MPI.SUM)
+        sumsq_E_global = mpi_comm.allreduce(sumsq_E_local, op=MPI.SUM)
 
         E_mean = sum_E_global / M_total
         E_var = (sumsq_E_global / M_total) - (sum_E_global / M_total) ** 2
@@ -1116,12 +1109,10 @@ class MCMC:
         sum_Var_local = np.sum(Var_jackknife_binned_local)
         sumsq_Var_local = np.sum(Var_jackknife_binned_local**2)
 
-        sum_Var_global = np.empty_like(sum_Var_local)
-        sumsq_Var_global = np.empty_like(sumsq_Var_local)
-
-        mpi_comm.Allreduce([sum_Var_local, MPI.DOUBLE], [sum_Var_global, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([sumsq_Var_local, MPI.DOUBLE], [sumsq_Var_global, MPI.DOUBLE], op=MPI.SUM)
-
+        # Var: global sums
+        sum_Var_global = mpi_comm.allreduce(sum_Var_local, op=MPI.SUM)
+        sumsq_Var_global = mpi_comm.allreduce(sumsq_Var_local, op=MPI.SUM)
+        
         Var_mean = sum_Var_global / M_total
         Var_var = (sumsq_Var_global / M_total) - (sum_Var_global / M_total) ** 2
         Var_std = np.sqrt((M_total - 1) * Var_var)
@@ -1202,22 +1193,21 @@ class MCMC:
         w_L_E_L_force_PP_binned_local = np.array(w_L_E_L_force_PP_binned_local)
 
         ## local sum
-        w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
+        w_L_binned_local_sum = np.sum(w_L_binned_local)
+        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
         w_L_force_HF_binned_local_sum = np.sum(w_L_force_HF_binned_local, axis=0)
         w_L_force_PP_binned_local_sum = np.sum(w_L_force_PP_binned_local, axis=0)
         w_L_E_L_force_PP_binned_local_sum = np.sum(w_L_E_L_force_PP_binned_local, axis=0)
 
         ## glolbal sum
-        w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-        w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
+        ### mpi allreduce (scalar)
+        w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+        w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+        
+        ### mpi Allreduce (array)
         w_L_force_HF_binned_global_sum = np.empty_like(w_L_force_HF_binned_local_sum)
         w_L_force_PP_binned_global_sum = np.empty_like(w_L_force_PP_binned_local_sum)
         w_L_E_L_force_PP_binned_global_sum = np.empty_like(w_L_E_L_force_PP_binned_local_sum)
-
-        ## mpi Allreduce
-        mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
         mpi_comm.Allreduce(
             [w_L_force_HF_binned_local_sum, MPI.DOUBLE], [w_L_force_HF_binned_global_sum, MPI.DOUBLE], op=MPI.SUM
         )
@@ -1473,20 +1463,19 @@ class MCMC:
         w_L_e_L_O_matrix_binned_local = np.array(w_L_e_L_O_matrix_binned_local)
 
         ## local sum
-        w_L_binned_local_sum = np.sum(w_L_binned_local, axis=0)
-        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local, axis=0)
+        w_L_binned_local_sum = np.sum(w_L_binned_local)
+        w_L_e_L_binned_local_sum = np.sum(w_L_e_L_binned_local)
         w_L_O_matrix_binned_local_sum = np.sum(w_L_O_matrix_binned_local, axis=0)
         w_L_e_L_O_matrix_binned_local_sum = np.sum(w_L_e_L_O_matrix_binned_local, axis=0)
 
         ## glolbal sum
-        w_L_binned_global_sum = np.empty_like(w_L_binned_local_sum)
-        w_L_e_L_binned_global_sum = np.empty_like(w_L_e_L_binned_local_sum)
+        ### allreduce (scalar)
+        w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
+        w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
+
+        ### Allreduce (array)
         w_L_O_matrix_binned_global_sum = np.empty_like(w_L_O_matrix_binned_local_sum)
         w_L_e_L_O_matrix_binned_global_sum = np.empty_like(w_L_e_L_O_matrix_binned_local_sum)
-
-        ## mpi Allreduce
-        mpi_comm.Allreduce([w_L_binned_local_sum, MPI.DOUBLE], [w_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
-        mpi_comm.Allreduce([w_L_e_L_binned_local_sum, MPI.DOUBLE], [w_L_e_L_binned_global_sum, MPI.DOUBLE], op=MPI.SUM)
         mpi_comm.Allreduce(
             [w_L_O_matrix_binned_local_sum, MPI.DOUBLE], [w_L_O_matrix_binned_global_sum, MPI.DOUBLE], op=MPI.SUM
         )

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -1072,7 +1072,7 @@ class MCMC:
         w_L_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_binned_local), op=MPI.SUM)
         w_L_e_L_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_e_L_binned_local), op=MPI.SUM)
         w_L_e_L2_binned_global_sum = mpi_comm.allreduce(np.sum(w_L_e_L2_binned_local), op=MPI.SUM)
-        
+
         ## jackknie binned samples
         M_local = w_L_binned_local.size
         M_total = mpi_comm.allreduce(M_local, op=MPI.SUM)
@@ -1112,7 +1112,7 @@ class MCMC:
         # Var: global sums
         sum_Var_global = mpi_comm.allreduce(sum_Var_local, op=MPI.SUM)
         sumsq_Var_global = mpi_comm.allreduce(sumsq_Var_local, op=MPI.SUM)
-        
+
         Var_mean = sum_Var_global / M_total
         Var_var = (sumsq_Var_global / M_total) - (sum_Var_global / M_total) ** 2
         Var_std = np.sqrt((M_total - 1) * Var_var)
@@ -1203,7 +1203,7 @@ class MCMC:
         ### mpi allreduce (scalar)
         w_L_binned_global_sum = mpi_comm.allreduce(w_L_binned_local_sum, op=MPI.SUM)
         w_L_e_L_binned_global_sum = mpi_comm.allreduce(w_L_e_L_binned_local_sum, op=MPI.SUM)
-        
+
         ### mpi Allreduce (array)
         w_L_force_HF_binned_global_sum = np.empty_like(w_L_force_HF_binned_local_sum)
         w_L_force_PP_binned_global_sum = np.empty_like(w_L_force_PP_binned_local_sum)

--- a/jqmc/jqmc_tool.py
+++ b/jqmc/jqmc_tool.py
@@ -789,9 +789,9 @@ def mcmc_compute_energy(
         e_L = obs["e_L"][num_mcmc_warmup_steps:]
         w_L = obs["w_L"][num_mcmc_warmup_steps:]
         w_L_split = np.array_split(w_L, num_mcmc_bin_blocks, axis=0)
-        w_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_split]))
+        w_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_split]))
         w_L_e_L_split = np.array_split(w_L * e_L, num_mcmc_bin_blocks, axis=0)
-        w_L_e_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_e_L_split]))
+        w_L_e_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_e_L_split]))
         w_L_binned_list += w_L_binned
         w_L_e_L_binned_list += w_L_e_L_binned
 
@@ -1072,9 +1072,9 @@ def lrdmc_compute_energy(
             e_L = raw_e_L[k:][num_mcmc_warmup_steps:]
             w_L = compute_accumulated_weights(raw_w_L, k)[num_mcmc_warmup_steps:]
             w_L_split = np.array_split(w_L, num_mcmc_bin_blocks, axis=0)
-            w_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_split]))
+            w_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_split]))
             w_L_e_L_split = np.array_split(w_L * e_L, num_mcmc_bin_blocks, axis=0)
-            w_L_e_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_e_L_split]))
+            w_L_e_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_e_L_split]))
             w_L_binned_list += w_L_binned
             w_L_e_L_binned_list += w_L_e_L_binned
 
@@ -1315,9 +1315,9 @@ def lrdmc_extrapolate_energy(
                 e_L = raw_e_L[k:][num_mcmc_warmup_steps:]
                 w_L = compute_accumulated_weights(obs["w_L"], k)[num_mcmc_warmup_steps:]
                 w_L_split = np.array_split(w_L, num_mcmc_bin_blocks, axis=0)
-                w_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_split]))
+                w_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_split]))
                 w_L_e_L_split = np.array_split(w_L * e_L, num_mcmc_bin_blocks, axis=0)
-                w_L_e_L_binned = list(np.ravel([np.mean(arr, axis=0) for arr in w_L_e_L_split]))
+                w_L_e_L_binned = list(np.ravel([np.sum(arr, axis=0) for arr in w_L_e_L_split]))
                 w_L_binned_list += w_L_binned
                 w_L_e_L_binned_list += w_L_e_L_binned
 

--- a/jqmc_workflow/__init__.py
+++ b/jqmc_workflow/__init__.py
@@ -55,6 +55,7 @@ try:
 except Exception:
     __version__ = "unknown"
 
+from ._machine import list_machines, probe_environment
 from ._output_parser import (
     parse_input_params,
     parse_lrdmc_ext_output,
@@ -62,6 +63,15 @@ from ._output_parser import (
     parse_mcmc_output,
     parse_vmc_output,
     repair_forces_from_output,
+)
+from ._phase import (
+    PHASE_ALLOWED_ACTIONS,
+    PHASE_TRANSITIONS,
+    ScientificPhase,
+    advance_phase,
+    allowed_actions,
+    can_advance,
+    rollback_phase,
 )
 from ._results import (
     Input_Parameters,
@@ -71,25 +81,16 @@ from ._results import (
     VMC_Diagnostic_Data,
     VMC_Step_Data,
 )
-from ._phase import (
-    ScientificPhase,
-    PHASE_TRANSITIONS,
-    PHASE_ALLOWED_ACTIONS,
-    can_advance,
-    allowed_actions,
-    advance_phase,
-    rollback_phase,
-)
 from ._state import (
-    WorkflowStatus,
     JobStatus,
+    WorkflowStatus,
     get_all_workflow_statuses,
-    get_workflow_summary,
-    set_error,
-    set_job_accounting,
-    register_artifact,
     get_artifact_lineage,
     get_artifact_registry,
+    get_workflow_summary,
+    register_artifact,
+    set_error,
+    set_job_accounting,
 )
 from .launcher import Launcher
 from .lrdmc_ext_workflow import LRDMC_Ext_Workflow
@@ -148,4 +149,7 @@ __all__ = [
     "allowed_actions",
     "advance_phase",
     "rollback_phase",
+    # Machine catalog
+    "list_machines",
+    "probe_environment",
 ]

--- a/jqmc_workflow/__init__.py
+++ b/jqmc_workflow/__init__.py
@@ -71,7 +71,26 @@ from ._results import (
     VMC_Diagnostic_Data,
     VMC_Step_Data,
 )
-from ._state import get_all_workflow_statuses, get_workflow_summary
+from ._phase import (
+    ScientificPhase,
+    PHASE_TRANSITIONS,
+    PHASE_ALLOWED_ACTIONS,
+    can_advance,
+    allowed_actions,
+    advance_phase,
+    rollback_phase,
+)
+from ._state import (
+    WorkflowStatus,
+    JobStatus,
+    get_all_workflow_statuses,
+    get_workflow_summary,
+    set_error,
+    set_job_accounting,
+    register_artifact,
+    get_artifact_lineage,
+    get_artifact_registry,
+)
 from .launcher import Launcher
 from .lrdmc_ext_workflow import LRDMC_Ext_Workflow
 from .lrdmc_workflow import LRDMC_Workflow
@@ -113,4 +132,20 @@ __all__ = [
     # State queries
     "get_all_workflow_statuses",
     "get_workflow_summary",
+    "set_error",
+    "set_job_accounting",
+    "register_artifact",
+    "get_artifact_lineage",
+    "get_artifact_registry",
+    # Enums
+    "WorkflowStatus",
+    "JobStatus",
+    # Phase management
+    "ScientificPhase",
+    "PHASE_TRANSITIONS",
+    "PHASE_ALLOWED_ACTIONS",
+    "can_advance",
+    "allowed_actions",
+    "advance_phase",
+    "rollback_phase",
 ]

--- a/jqmc_workflow/__init__.py
+++ b/jqmc_workflow/__init__.py
@@ -89,8 +89,8 @@ from ._state import (
     get_artifact_registry,
     get_workflow_summary,
     register_artifact,
+    save_job_accounting,
     set_error,
-    set_job_accounting,
 )
 from .launcher import Launcher
 from .lrdmc_ext_workflow import LRDMC_Ext_Workflow
@@ -134,7 +134,7 @@ __all__ = [
     "get_all_workflow_statuses",
     "get_workflow_summary",
     "set_error",
-    "set_job_accounting",
+    "save_job_accounting",
     "register_artifact",
     "get_artifact_lineage",
     "get_artifact_registry",

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -103,6 +103,7 @@ class JobSubmission:
         output_file: str = "out.o",
         queue_label: str = "default",
         jobname: str = "jqmc-wf",
+        run_id: str = "",
         safe_mode: bool = False,
     ):
         self.server_machine = Machine(server_machine_name)
@@ -140,6 +141,7 @@ class JobSubmission:
 
         # ── Job parameters ────────────────────────────────────────
         self.jobname = jobname
+        self.run_id = run_id
         self.input_file = input_file
         self.output_file = output_file
         self.safe_mode = safe_mode
@@ -153,8 +155,9 @@ class JobSubmission:
         self.job_check_last_time = None
         self.job_fetch_date = None
         # ── Scheduler stdout/stderr file paths (TASK 9) ──────────
-        self.job_stdout: str = f"job_{jobname}.o"
-        self.job_stderr: str = f"job_{jobname}.e"
+        _id_suffix = f"_{run_id}" if run_id else ""
+        self.job_stdout: str = f"job_{jobname}{_id_suffix}.o"
+        self.job_stderr: str = f"job_{jobname}{_id_suffix}.e"
 
     # ── Script generation ─────────────────────────────────────────
 

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -153,8 +153,8 @@ class JobSubmission:
         self.job_check_last_time = None
         self.job_fetch_date = None
         # ── Scheduler stdout/stderr file paths (TASK 9) ──────────
-        self.job_stdout: str = ""
-        self.job_stderr: str = ""
+        self.job_stdout: str = f"job_{jobname}.o"
+        self.job_stderr: str = f"job_{jobname}.e"
 
     # ── Script generation ─────────────────────────────────────────
 
@@ -185,12 +185,6 @@ class JobSubmission:
                 idx = lines.index(b)
                 lines[idx] = lines[idx].replace(keyword.replace("\\", ""), str(value))
             return lines
-
-        # Default scheduler output filenames (derived from jobname)
-        if not self.job_stdout:
-            self.job_stdout = f"job_{self.jobname}.o"
-        if not self.job_stderr:
-            self.job_stderr = f"job_{self.jobname}.e"
 
         # Standard replacements (jqmc-specific)
         lines = replace_kw(lines, "_INPUT_", self.input_file)

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -152,6 +152,9 @@ class JobSubmission:
         self.job_submit_date = None
         self.job_check_last_time = None
         self.job_fetch_date = None
+        # ── Scheduler stdout/stderr file paths (TASK 9) ──────────
+        self.job_stdout: str = ""
+        self.job_stderr: str = ""
 
     # ── Script generation ─────────────────────────────────────────
 
@@ -183,10 +186,18 @@ class JobSubmission:
                 lines[idx] = lines[idx].replace(keyword.replace("\\", ""), str(value))
             return lines
 
+        # Default scheduler output filenames (derived from jobname)
+        if not self.job_stdout:
+            self.job_stdout = f"job_{self.jobname}.o"
+        if not self.job_stderr:
+            self.job_stderr = f"job_{self.jobname}.e"
+
         # Standard replacements (jqmc-specific)
         lines = replace_kw(lines, "_INPUT_", self.input_file)
         lines = replace_kw(lines, "_OUTPUT_", self.output_file)
         lines = replace_kw(lines, "_JOBNAME_", self.jobname)
+        lines = replace_kw(lines, "_JOB_STDOUT_", self.job_stdout)
+        lines = replace_kw(lines, "_JOB_STDERR_", self.job_stderr)
 
         # Queue-specific variables from queue_data.toml
         _SKIP_KEYS = {"submit_template", "max_job_submit"}
@@ -360,6 +371,36 @@ class JobSubmission:
         self.server_machine.delete_job(jobid=self.job_number)
         self.job_running = False
         self._close_ssh()
+
+    # ── Job accounting (TASK 8) ────────────────────────────────
+
+    def job_acct(self) -> tuple[str, str, str] | None:
+        """Run the scheduler accounting command and return raw output.
+
+        Reads the ``jobacct`` field from ``machine_data.yaml`` and
+        executes ``{jobacct} {job_id}``.  No parsing or flag-injection
+        is performed — the user specifies the complete command with
+        flags in the config.
+
+        Returns
+        -------
+        tuple[str, str, str] | None
+            ``(command, stdout, stderr)`` on success.
+            ``None`` if ``jobacct`` is not configured, the machine does
+            not use a queuing system, or the command fails.
+        """
+        if not self.server_machine.queuing:
+            return None
+        jobacct_cmd = self.server_machine._get("jobacct", default=None)
+        if not jobacct_cmd or not self.job_number:
+            return None
+        try:
+            command = f"{jobacct_cmd} {self.job_number}"
+            stdout, stderr = self.server_machine.run_command(command)
+            return command, stdout, stderr
+        except Exception as e:
+            logger.warning(f"job_acct failed for job {self.job_number}: {e}")
+            return None
 
     # ── Helper ────────────────────────────────────────────────────
 

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -336,7 +336,7 @@ class JobSubmission:
 
     # ── Fetch results ─────────────────────────────────────────────
 
-    def fetch_job(self, from_objects=None, exclude_patterns=None, *, work_dir=None):
+    def fetch_job(self, from_objects=None, exclude_patterns=None, *, work_dir=None, optional_patterns=None):
         """Fetch job results from the remote machine.
 
         Parameters
@@ -348,15 +348,21 @@ class JobSubmission:
         work_dir : str, optional
             Absolute path to the local job directory.  When *None*,
             falls back to ``os.getcwd()`` for backward compatibility.
+        optional_patterns : list[str], optional
+            Basenames or glob patterns of non-essential files.
+            Missing files matching these patterns produce a warning
+            instead of an error.
         """
         from_objects = from_objects or []
         exclude_patterns = exclude_patterns or []
+        optional_patterns = optional_patterns or []
 
         if self.server_machine.machine_type != "local":
             self.data_transfer.get_objects(
                 from_objects=from_objects,
                 exclude_patterns=exclude_patterns,
                 work_dir=work_dir,
+                optional_patterns=optional_patterns,
             )
 
         self.job_fetch_date = datetime.today()

--- a/jqmc_workflow/_machine.py
+++ b/jqmc_workflow/_machine.py
@@ -198,11 +198,13 @@ class Machine:
 
     # ── Properties (read from machine_data.yaml) ──────────────────
 
-    def _get(self, key, default=None):
+    _MISSING = object()  # sentinel for _get() default detection
+
+    def _get(self, key, default=_MISSING):
         try:
             return self.data[key]
         except KeyError:
-            if default is not None:
+            if default is not self._MISSING:
                 return default
             raise KeyError(f"'{key}' not found for machine '{self.name}'")
 
@@ -478,3 +480,53 @@ class Machines_handler:
                 self._get_sftp_dir(from_path, to_path, exclude_patterns)
             else:
                 self._get_sftp_file(from_path, to_path, exclude_patterns)
+
+
+# ── Machine catalog (MCP adapter helpers) ─────────────────────────
+
+
+def list_machines() -> list[dict]:
+    """Return a summary of all machines defined in ``machine_data.yaml``.
+
+    Each entry contains the machine name and key configuration fields.
+    Returns an empty list if the config file does not exist.
+    """
+    machine_data_path = os.path.join(get_config_dir(), "machine_data.yaml")
+    if not os.path.isfile(machine_data_path):
+        return []
+    with open(machine_data_path) as f:
+        data = yaml.safe_load(f)
+    if not data:
+        return []
+    return [
+        {
+            "name": name,
+            "machine_type": cfg.get("machine_type", "local"),
+            "queuing": cfg.get("queuing", False),
+            "ssh_host": cfg.get("ssh_host", ""),
+            "workspace_root": cfg.get("workspace_root", ""),
+        }
+        for name, cfg in data.items()
+    ]
+
+
+def probe_environment(machine_name: str) -> dict:
+    """Test connectivity to the named machine.
+
+    For remote machines an SSH connection is attempted; for local machines
+    reachability is always ``True``.  No software detection (jqmc, JAX, etc.)
+    is performed — that responsibility belongs to the MCP agent.
+    """
+    machine = Machine(machine_name)
+    result: dict = {"machine_name": machine_name, "machine_type": machine.machine_type}
+    try:
+        if machine.machine_type == "remote":
+            machine.ssh_open()
+        result["reachable"] = True
+    except Exception as e:
+        result["reachable"] = False
+        result["error"] = str(e)
+    finally:
+        if machine.machine_type == "remote" and machine.ssh_status:
+            machine.ssh_close()
+    return result

--- a/jqmc_workflow/_output_parser.py
+++ b/jqmc_workflow/_output_parser.py
@@ -188,7 +188,7 @@ def parse_force_table(text: str):
 
 
 def repair_forces_from_output(work_dir: str) -> bool:
-    """Re-parse forces from ``out_*.o`` files and update ``workflow_state.toml``.
+    """Re-parse forces from output files and update ``workflow_state.toml``.
 
     This repairs corrupted force data caused by the pre-fix
     ``parse_ufloat_short`` that ignored scientific notation (e.g.
@@ -200,8 +200,7 @@ def repair_forces_from_output(work_dir: str) -> bool:
     if not os.path.isfile(state_path):
         return False
 
-    # Find the last out_*.o file
-    out_files = sorted(glob.glob(os.path.join(work_dir, "out_*.o")))
+    out_files = _find_output_files(work_dir)
     if not out_files:
         return False
     last_out = out_files[-1]
@@ -656,8 +655,8 @@ def _parse_vmc_log_text(text: str) -> list:
 def parse_vmc_output(work_dir: str) -> VMC_Diagnostic_Data:
     """Parse VMC optimization output from *work_dir*.
 
-    Discovers output files (``out_vmc``, ``out_vmc_0``, etc.) in the
-    directory, parses per-step data, and looks for
+    Discovers output files from ``workflow_state.toml`` ``[[jobs]]``
+    records, parses per-step data, and looks for
     ``hamiltonian_data_opt_step_*.h5``.
 
     Parameters

--- a/jqmc_workflow/_output_parser.py
+++ b/jqmc_workflow/_output_parser.py
@@ -383,19 +383,38 @@ def _tail(text: str, max_lines: int = _STDERR_TAIL_LINES) -> str:
     return "".join(lines[-max_lines:])
 
 
-def _find_hamiltonian_h5(work_dir: str) -> Optional[str]:
-    """Extract ``[control] hamiltonian_h5`` from TOML input files in *work_dir*.
+def _find_input_files(work_dir: str) -> list:
+    """Return jQMC input TOML files in *work_dir*, sorted by step index.
 
-    Searches ``input_*.toml`` files and returns the value from the last one
-    that contains ``[control] hamiltonian_h5``.  Returns *None* if not found.
+    Reads ``workflow_state.toml`` ``[[jobs]]`` records and returns the
+    ``input_file`` paths that exist on disk, ordered by ``step``.
     """
-    toml_files = sorted(glob.glob(os.path.join(work_dir, "input_*.toml")))
-    if not toml_files:
-        # Fallback: any .toml that is not workflow_state.toml
-        toml_files = sorted(
-            f for f in glob.glob(os.path.join(work_dir, "*.toml")) if os.path.basename(f) != "workflow_state.toml"
-        )
-    for fpath in reversed(toml_files):
+    state_path = os.path.join(work_dir, "workflow_state.toml")
+    if not os.path.isfile(state_path):
+        return []
+    try:
+        state = toml.load(state_path)
+    except Exception:
+        return []
+    files = []
+    for job in state.get("jobs", []):
+        name = job.get("input_file", "")
+        if name:
+            path = os.path.join(work_dir, name)
+            if os.path.isfile(path):
+                files.append((job.get("step", 0), path))
+    files.sort()
+    return [path for _, path in files]
+
+
+def _find_hamiltonian_h5(work_dir: str) -> Optional[str]:
+    """Extract ``[control] hamiltonian_h5`` from input TOML files in *work_dir*.
+
+    Uses ``workflow_state.toml`` ``[[jobs]]`` to locate input files.
+    Returns the value from the last input that contains
+    ``[control] hamiltonian_h5``, or *None* if not found.
+    """
+    for fpath in reversed(_find_input_files(work_dir)):
         try:
             data = toml.load(fpath)
             h5 = data.get("control", {}).get("hamiltonian_h5")
@@ -478,32 +497,28 @@ def _apply_run_metadata(result, meta: dict) -> None:
     result.jax_devices = meta["jax_devices"]
 
 
-def _find_output_files(work_dir: str, prefix: str = "out_") -> list:
-    """Find jQMC output files in *work_dir*, sorted by suffix number.
+def _find_output_files(work_dir: str) -> list:
+    """Return jQMC stdout files in *work_dir*, sorted by step index.
 
-    Handles patterns like ``out_vmc``, ``out_vmc_0``, ``out_vmc_1``, ...
-    as well as ``out_mcmc``, ``out_lrdmc``, etc.
-
-    Returns a list of absolute paths sorted by (base, suffix_number).
+    Reads ``workflow_state.toml`` ``[[jobs]]`` records and returns the
+    ``output_file`` paths that exist on disk, ordered by ``step``.
     """
+    state_path = os.path.join(work_dir, "workflow_state.toml")
+    if not os.path.isfile(state_path):
+        return []
+    try:
+        state = toml.load(state_path)
+    except Exception:
+        return []
     files = []
-    for name in os.listdir(work_dir):
-        if name.startswith(prefix):
-            files.append(os.path.join(work_dir, name))
-    if not files:
-        # Fallback: try *.log files
-        for name in os.listdir(work_dir):
-            if name.endswith(".log"):
-                files.append(os.path.join(work_dir, name))
-
-    def _sort_key(path: str):
-        base = os.path.basename(path)
-        # Extract trailing number: "out_vmc_2" -> 2, "out_vmc" -> -1
-        m = re.search(r"_(\d+)$", base)
-        return (base, int(m.group(1)) if m else -1)
-
-    files.sort(key=_sort_key)
-    return files
+    for job in state.get("jobs", []):
+        name = job.get("output_file", "")
+        if name:
+            path = os.path.join(work_dir, name)
+            if os.path.isfile(path):
+                files.append((job.get("step", 0), path))
+    files.sort()
+    return [path for _, path in files]
 
 
 # ── VMC parser ────────────────────────────────────────────────────
@@ -662,7 +677,7 @@ def parse_vmc_output(work_dir: str) -> VMC_Diagnostic_Data:
         return result
 
     # ── Discover and parse stdout files ──
-    output_files = _find_output_files(work_dir, prefix="out_")
+    output_files = _find_output_files(work_dir)
     all_steps: list[VMC_Step_Data] = []
 
     for fpath in output_files:
@@ -778,7 +793,7 @@ def parse_mcmc_output(work_dir: str) -> MCMC_Diagnostic_Data:
         logger.warning("parse_mcmc_output: directory not found: %s", work_dir)
         return result
 
-    output_files = _find_output_files(work_dir, prefix="out_")
+    output_files = _find_output_files(work_dir)
 
     # ── Run-level metadata (MPI, walkers, JAX) from first output file ──
     if output_files:
@@ -888,7 +903,7 @@ def parse_lrdmc_output(work_dir: str) -> LRDMC_Diagnostic_Data:
         logger.warning("parse_lrdmc_output: directory not found: %s", work_dir)
         return result
 
-    output_files = _find_output_files(work_dir, prefix="out_")
+    output_files = _find_output_files(work_dir)
 
     # ── Run-level metadata (MPI, walkers, JAX) from first output file ──
     if output_files:
@@ -1001,7 +1016,7 @@ def parse_lrdmc_ext_output(work_dir: str) -> LRDMC_Ext_Diagnostic_Data:
         logger.warning("parse_lrdmc_ext_output: directory not found: %s", work_dir)
         return result
 
-    output_files = _find_output_files(work_dir, prefix="out_")
+    output_files = _find_output_files(work_dir)
 
     for fpath in reversed(output_files):
         text = _read_text(fpath)

--- a/jqmc_workflow/_phase.py
+++ b/jqmc_workflow/_phase.py
@@ -1,0 +1,283 @@
+"""Scientific phase definitions and transition rules.
+
+Each QMC workflow session progresses through a sequence of scientific phases
+(SCF → wavefunction build → VMC → MCMC → LRDMC → fit).  This module defines
+the allowed phase transitions and the actions permitted in each phase/status
+combination.
+
+The transition graph and action lists are consumed by:
+  - *jqmc-workflow* itself (guard-rail enforcement via :func:`require_action`)
+  - *jqmc-mcp* (to expose ``allowed_actions`` as an MCP resource)
+"""
+# Copyright (C) 2024- Kosuke Nakano
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# * Neither the name of the jqmc project nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import annotations
+
+from enum import Enum
+
+from ._state import WorkflowStatus
+
+# ---------------------------------------------------------------------------
+# Scientific phases
+# ---------------------------------------------------------------------------
+
+
+class ScientificPhase(str, Enum):
+    """Scientific phases of a QMC workflow session."""
+
+    INIT = "init"
+    SCF = "scf"
+    WF_BUILD = "wf_build"
+    VMC_PILOT = "vmc_pilot"
+    VMC = "vmc"
+    MCMC_PILOT = "mcmc_pilot"
+    MCMC = "mcmc"
+    LRDMC_PILOT = "lrdmc_pilot"
+    LRDMC = "lrdmc"
+    LRDMC_FIT = "lrdmc_fit"
+    COMPLETED = "completed"
+
+
+# ---------------------------------------------------------------------------
+# Allowed phase transitions
+# ---------------------------------------------------------------------------
+
+PHASE_TRANSITIONS: dict[ScientificPhase, set[ScientificPhase]] = {
+    ScientificPhase.INIT: {ScientificPhase.SCF, ScientificPhase.WF_BUILD},
+    ScientificPhase.SCF: {ScientificPhase.WF_BUILD},
+    ScientificPhase.WF_BUILD: {
+        ScientificPhase.VMC_PILOT,
+        ScientificPhase.VMC,
+        ScientificPhase.MCMC_PILOT,
+        ScientificPhase.MCMC,
+    },
+    ScientificPhase.VMC_PILOT: {ScientificPhase.VMC},
+    ScientificPhase.VMC: {
+        ScientificPhase.VMC_PILOT,
+        ScientificPhase.VMC,
+        ScientificPhase.MCMC_PILOT,
+        ScientificPhase.MCMC,
+        ScientificPhase.LRDMC_PILOT,
+        ScientificPhase.LRDMC,
+        ScientificPhase.COMPLETED,
+    },
+    ScientificPhase.MCMC_PILOT: {ScientificPhase.MCMC},
+    ScientificPhase.MCMC: {
+        ScientificPhase.VMC_PILOT,
+        ScientificPhase.VMC,
+        ScientificPhase.MCMC_PILOT,
+        ScientificPhase.MCMC,
+        ScientificPhase.LRDMC_PILOT,
+        ScientificPhase.LRDMC,
+        ScientificPhase.COMPLETED,
+    },
+    ScientificPhase.LRDMC_PILOT: {ScientificPhase.LRDMC},
+    ScientificPhase.LRDMC: {
+        ScientificPhase.VMC_PILOT,
+        ScientificPhase.VMC,
+        ScientificPhase.MCMC_PILOT,
+        ScientificPhase.MCMC,
+        ScientificPhase.LRDMC_PILOT,
+        ScientificPhase.LRDMC,
+        ScientificPhase.LRDMC_FIT,
+        ScientificPhase.COMPLETED,
+    },
+    ScientificPhase.LRDMC_FIT: {ScientificPhase.COMPLETED},
+    ScientificPhase.COMPLETED: set(),
+}
+
+
+# ---------------------------------------------------------------------------
+# Allowed actions per phase
+# ---------------------------------------------------------------------------
+
+PHASE_ALLOWED_ACTIONS: dict[ScientificPhase, list[str]] = {
+    ScientificPhase.INIT: [
+        "configure_scf",
+        "configure_wavefunction",
+        "select_machine",
+    ],
+    ScientificPhase.SCF: [
+        "run_scf",
+        "recover_scf",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.WF_BUILD: [
+        "configure_wavefunction",
+        "build_wavefunction",
+        "recover_wf",
+        "poll_job",
+        "fetch_job_outputs",
+    ],
+    ScientificPhase.VMC_PILOT: [
+        "configure_vmc_pilot",
+        "run_vmc_pilot",
+        "recover_vmc_pilot",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.VMC: [
+        "configure_vmc",
+        "run_vmc",
+        "recover_vmc",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.MCMC_PILOT: [
+        "configure_mcmc_pilot",
+        "run_mcmc_pilot",
+        "recover_mcmc_pilot",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.MCMC: [
+        "configure_mcmc",
+        "run_mcmc",
+        "recover_mcmc",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.LRDMC_PILOT: [
+        "configure_lrdmc_pilot",
+        "run_lrdmc_pilot",
+        "recover_lrdmc_pilot",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.LRDMC: [
+        "configure_lrdmc",
+        "run_lrdmc_point",
+        "recover_lrdmc_point",
+        "poll_job",
+        "fetch_job_outputs",
+        "cancel_job",
+    ],
+    ScientificPhase.LRDMC_FIT: [
+        "run_lrdmc_fit",
+        "recover_lrdmc_fit",
+    ],
+    ScientificPhase.COMPLETED: [],
+}
+
+ALWAYS_ALLOWED_ACTIONS: list[str] = [
+    "advance_phase",
+    "rollback_phase",
+    "close_session",
+    "register_artifact",
+    "mark_unhealthy",
+]
+
+
+# ---------------------------------------------------------------------------
+# Query helpers
+# ---------------------------------------------------------------------------
+
+
+def can_advance(current: ScientificPhase, target: ScientificPhase) -> bool:
+    """Return ``True`` if *target* is a valid successor of *current*."""
+    return target in PHASE_TRANSITIONS.get(current, set())
+
+
+def allowed_actions(
+    phase: ScientificPhase,
+    status: WorkflowStatus,
+) -> list[str]:
+    """Return the list of actions allowed for the given *phase* / *status*.
+
+    When *status* is ``FAILED`` only ``recover_*`` and ``rollback_phase``
+    actions are kept.  When *status* is ``RUNNING`` configuration actions
+    are excluded.
+    """
+    phase_actions = list(PHASE_ALLOWED_ACTIONS.get(phase, []))
+    if status == WorkflowStatus.FAILED:
+        phase_actions = [a for a in phase_actions if a.startswith("recover_")]
+        phase_actions.append("rollback_phase")
+    if status == WorkflowStatus.RUNNING:
+        phase_actions = [a for a in phase_actions if not a.startswith("configure_")]
+    return phase_actions + ALWAYS_ALLOWED_ACTIONS
+
+
+def require_action(
+    action: str,
+    phase: ScientificPhase,
+    status: WorkflowStatus,
+) -> None:
+    """Raise :class:`ValueError` if *action* is not allowed in *phase*/*status*.
+
+    Call this at the entry of every MCP-tool → workflow-method boundary to
+    enforce the guard-rail.
+    """
+    allowed = allowed_actions(phase, status)
+    if action not in allowed:
+        raise ValueError(
+            f"Action {action!r} is not allowed in phase={phase.value!r}, status={status.value!r}. Allowed: {allowed}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase mutation
+# ---------------------------------------------------------------------------
+
+
+def advance_phase(
+    current: ScientificPhase,
+    target: ScientificPhase,
+) -> ScientificPhase:
+    """Validate and return *target* as the new phase.
+
+    Raises :class:`ValueError` if the transition is not allowed.
+    """
+    if not can_advance(current, target):
+        raise ValueError(
+            f"Cannot advance from {current.value!r} to {target.value!r}. "
+            f"Allowed: {sorted(p.value for p in PHASE_TRANSITIONS.get(current, set()))}"
+        )
+    return target
+
+
+def rollback_phase(current: ScientificPhase) -> ScientificPhase:
+    """Return the most recent predecessor of *current*.
+
+    Raises :class:`ValueError` if *current* has no predecessor (i.e. INIT).
+    """
+    predecessors = [p for p, targets in PHASE_TRANSITIONS.items() if current in targets]
+    if not predecessors:
+        raise ValueError(f"Cannot rollback from {current.value!r}: no predecessor.")
+    return predecessors[-1]

--- a/jqmc_workflow/_state.py
+++ b/jqmc_workflow/_state.py
@@ -259,6 +259,8 @@ def add_job(
     status: str = "submitted",
     step: int = None,
     run_id: str = "",
+    job_stdout: str = "",
+    job_stderr: str = "",
 ) -> dict:
     """Append a new job record to the ``[[jobs]]`` list.
 
@@ -282,6 +284,10 @@ def add_job(
         job["step"] = step
     if run_id:
         job["run_id"] = run_id
+    if job_stdout:
+        job["job_stdout"] = job_stdout
+    if job_stderr:
+        job["job_stderr"] = job_stderr
     state["jobs"].append(job)
     state.setdefault("workflow", {})["updated_at"] = _now_iso()
     _write(directory, state)
@@ -425,11 +431,10 @@ def get_workflow_summary(directory: str) -> dict:
     - ``allowed_actions`` – list of permitted MCP actions
     - ``result``   – any stored results (energy, etc.)
     - ``estimation`` – step-estimation data (if present)
-    - ``jobs``     – list of job records with their statuses
+    - ``jobs``     – list of job records (each includes accounting
+      and scheduler file info when available)
     - ``num_jobs`` – total number of job records
     - ``error``    – ``[error]`` section or ``None``
-    - ``job_accounting`` – ``[job_accounting]`` section or ``None``
-    - ``job_files`` – ``[job_files]`` section or ``None``
     - ``artifacts`` – ``[[artifacts]]`` list
 
     Returns an empty dict if no ``workflow_state.toml`` is found.
@@ -459,8 +464,6 @@ def get_workflow_summary(directory: str) -> dict:
         "jobs": jobs,
         "num_jobs": len(jobs),
         "error": state.get("error", None),
-        "job_accounting": state.get("job_accounting", None),
-        "job_files": state.get("job_files", None),
         "artifacts": state.get("artifacts", []),
     }
 
@@ -484,21 +487,18 @@ def set_error(directory: str, message: str, **context) -> None:
     _write(directory, state)
 
 
-def set_job_accounting(
+def save_job_accounting(
     directory: str,
     command: str,
     stdout: str,
     stderr: str = "",
     job_id: str = "",
-) -> None:
-    """Record scheduler accounting raw output.
+) -> tuple:
+    """Write scheduler accounting to a text file.
 
-    The raw stdout is written to a separate file
-    ``job_accounting_{job_id}.txt`` next to ``workflow_state.toml``.
-    The ``[job_accounting]`` section stores only the command and a
-    reference to that file.  No parsing or interpretation is performed.
+    Returns ``(acct_command, acct_filename)`` so the caller can store
+    them in the ``[[jobs]]`` record via :func:`update_job`.
     """
-    # Write raw output to a separate file
     if job_id:
         acct_filename = f"job_accounting_{job_id}.txt"
     else:
@@ -513,15 +513,7 @@ def set_job_accounting(
         if stderr:
             f.write("\n--- stderr ---\n")
             f.write(stderr)
-
-    # Record reference in toml
-    state = read_state(directory)
-    state["job_accounting"] = {
-        "command": command,
-        "file": acct_filename,
-    }
-    state.setdefault("workflow", {})["updated_at"] = _now_iso()
-    _write(directory, state)
+    return command, acct_filename
 
 
 def register_artifact(

--- a/jqmc_workflow/_state.py
+++ b/jqmc_workflow/_state.py
@@ -53,23 +53,39 @@ Per-job statuses (stored in ``[[jobs]]``):
 
 import os
 from datetime import datetime
+from enum import Enum
 from logging import getLogger
 
 import toml
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
 
-VALID_STATUSES = {
-    "pending",
-    "copying",
-    "submitted",
-    "running",
-    "completed",
-    "failed",
-    "cancelled",
-}
 
-VALID_JOB_STATUSES = {"submitted", "completed", "fetched", "failed"}
+class WorkflowStatus(str, Enum):
+    """Workflow-level status values."""
+
+    PENDING = "pending"
+    COPYING = "copying"
+    SUBMITTED = "submitted"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class JobStatus(str, Enum):
+    """Per-job status values stored in ``[[jobs]]``."""
+
+    SUBMITTED = "submitted"
+    COMPLETED = "completed"
+    FETCHED = "fetched"
+    FAILED = "failed"
+
+
+# Legacy sets — kept for backward compatibility during transition.
+# New code should use WorkflowStatus / JobStatus enums.
+VALID_STATUSES = {s.value for s in WorkflowStatus}
+VALID_JOB_STATUSES = {s.value for s in JobStatus}
 
 STATE_FILENAME = "workflow_state.toml"
 
@@ -166,8 +182,26 @@ def _check_normal_termination(directory: str, jobs: list) -> list[str]:
     return abnormal
 
 
-def update_status(directory: str, status: str, **extra_fields):
+def update_status(
+    directory: str,
+    status: str | WorkflowStatus,
+    phase: str | None = None,
+    **extra_fields,
+):
     """Update the status field (and optional extra fields) in workflow_state.toml.
+
+    Parameters
+    ----------
+    directory : str
+        Working directory containing workflow_state.toml.
+    status : str or WorkflowStatus
+        New workflow status.
+    phase : str or None
+        Scientific phase to record.  If given, written to
+        ``[workflow] phase``.
+    **extra_fields
+        Additional fields.  Keys starting with ``result_`` go into
+        ``[result]``; everything else goes into ``[workflow]``.
 
     When *status* is ``"completed"``, every fetched output file listed in
     the ``[[jobs]]`` table is checked for the ``Program ends`` footer.  If
@@ -176,27 +210,31 @@ def update_status(directory: str, status: str, **extra_fields):
     recorded, because the absence almost certainly indicates abnormal
     termination (e.g. wall-time expiration on a supercomputer).
     """
-    if status not in VALID_STATUSES:
-        raise ValueError(f"Invalid status '{status}'. Must be one of {VALID_STATUSES}")
-
+    # Ensure we work with raw string for VALID_STATUSES check
+    status_str = status.value if isinstance(status, WorkflowStatus) else status
+    if status_str not in VALID_STATUSES:
+        raise ValueError(f"Invalid status '{status_str}'. Must be one of {VALID_STATUSES}")
     state = read_state(directory)
     if not state:
         logger.warning(f"No workflow_state.toml in {directory}; creating minimal one.")
         state = {"workflow": {}, "jobs": [], "result": {}}
 
     # ── Abnormal-termination guard ────────────────────────────────
-    if status == "completed":
+    if status_str == "completed":
         abnormal = _check_normal_termination(directory, state.get("jobs", []))
         if abnormal:
             files_str = ", ".join(abnormal)
             error_msg = f"Abnormal termination detected: 'Program ends' marker missing in output file(s): {files_str}"
             logger.error(error_msg)
-            status = "failed"
+            status_str = "failed"
             extra_fields.setdefault("error", error_msg)
 
     state.setdefault("workflow", {})
-    state["workflow"]["status"] = status
+    state["workflow"]["status"] = status_str
     state["workflow"]["updated_at"] = _now_iso()
+
+    if phase is not None:
+        state["workflow"]["phase"] = phase.value if hasattr(phase, "value") else phase
 
     # Merge extra fields into appropriate sections
     for key, value in extra_fields.items():
@@ -365,10 +403,16 @@ def get_workflow_summary(directory: str) -> dict:
     The returned dict contains:
 
     - ``workflow`` – label, type, status, timestamps
-    - ``result``  – any stored results (energy, etc.)
+    - ``phase``    – current scientific phase (str or ``"init"``)
+    - ``allowed_actions`` – list of permitted MCP actions
+    - ``result``   – any stored results (energy, etc.)
     - ``estimation`` – step-estimation data (if present)
-    - ``jobs``    – list of job records with their statuses
+    - ``jobs``     – list of job records with their statuses
     - ``num_jobs`` – total number of job records
+    - ``error``    – ``[error]`` section or ``None``
+    - ``job_accounting`` – ``[job_accounting]`` section or ``None``
+    - ``job_files`` – ``[job_files]`` section or ``None``
+    - ``artifacts`` – ``[[artifacts]]`` list
 
     Returns an empty dict if no ``workflow_state.toml`` is found.
     """
@@ -377,13 +421,128 @@ def get_workflow_summary(directory: str) -> dict:
         return {}
 
     jobs = state.get("jobs", [])
+    phase_str = state.get("workflow", {}).get("phase", "init")
+    status_str = state.get("workflow", {}).get("status", "pending")
+
+    # Compute allowed_actions (lazy import to avoid circular dependency)
+    try:
+        from ._phase import ScientificPhase, allowed_actions
+
+        aa = allowed_actions(ScientificPhase(phase_str), WorkflowStatus(status_str))
+    except (ValueError, ImportError):
+        aa = []
+
     return {
         "workflow": state.get("workflow", {}),
+        "phase": phase_str,
+        "allowed_actions": aa,
         "result": state.get("result", {}),
         "estimation": state.get("estimation", {}),
         "jobs": jobs,
         "num_jobs": len(jobs),
+        "error": state.get("error", None),
+        "job_accounting": state.get("job_accounting", None),
+        "job_files": state.get("job_files", None),
+        "artifacts": state.get("artifacts", []),
     }
+
+
+# ── Error / accounting / artifact helpers ─────────────────────────
+
+
+def set_error(directory: str, message: str, **context) -> None:
+    """Write error information to the ``[error]`` section.
+
+    Parameters
+    ----------
+    message : str
+        Human-readable error description (exception message, etc.).
+    **context
+        Arbitrary extra fields (``traceback``, ``exception_type``, …).
+    """
+    state = read_state(directory)
+    state["error"] = {"message": message, **context}
+    state.setdefault("workflow", {})["updated_at"] = _now_iso()
+    _write(directory, state)
+
+
+def set_job_accounting(
+    directory: str,
+    command: str,
+    stdout: str,
+    stderr: str = "",
+    job_id: str = "",
+) -> None:
+    """Record scheduler accounting raw output.
+
+    The raw stdout is written to a separate file
+    ``job_accounting_{job_id}.txt`` next to ``workflow_state.toml``.
+    The ``[job_accounting]`` section stores only the command and a
+    reference to that file.  No parsing or interpretation is performed.
+    """
+    # Write raw output to a separate file
+    if job_id:
+        acct_filename = f"job_accounting_{job_id}.txt"
+    else:
+        acct_filename = "job_accounting.txt"
+    acct_path = os.path.join(directory, acct_filename)
+    os.makedirs(directory, exist_ok=True)
+    with open(acct_path, "w") as f:
+        f.write(f"# command: {command}\n")
+        f.write(f"# job_id: {job_id}\n\n")
+        f.write("--- stdout ---\n")
+        f.write(stdout)
+        if stderr:
+            f.write("\n--- stderr ---\n")
+            f.write(stderr)
+
+    # Record reference in toml
+    state = read_state(directory)
+    state["job_accounting"] = {
+        "command": command,
+        "file": acct_filename,
+    }
+    state.setdefault("workflow", {})["updated_at"] = _now_iso()
+    _write(directory, state)
+
+
+def register_artifact(
+    directory: str,
+    filename: str,
+    produced_by_job: str = "",
+    artifact_type: str = "file",
+    upstream: list[dict] | None = None,
+) -> None:
+    """Register (or update) a file artifact in ``[[artifacts]]``."""
+    state = read_state(directory)
+    artifacts = state.setdefault("artifacts", [])
+    # Replace existing entry for the same filename
+    artifacts[:] = [a for a in artifacts if a.get("filename") != filename]
+    entry: dict = {
+        "filename": filename,
+        "produced_by_job": produced_by_job,
+        "produced_at": _now_iso(),
+        "artifact_type": artifact_type,
+    }
+    if upstream:
+        entry["upstream"] = upstream
+    artifacts.append(entry)
+    state["artifacts"] = artifacts
+    state.setdefault("workflow", {})["updated_at"] = _now_iso()
+    _write(directory, state)
+
+
+def get_artifact_lineage(directory: str, filename: str) -> dict | None:
+    """Return the artifact record for *filename*, or ``None``."""
+    for a in read_state(directory).get("artifacts", []):
+        if a.get("filename") == filename:
+            return a
+    return None
+
+
+def get_artifact_registry(directory: str) -> list[dict]:
+    """Return all artifact records from ``[[artifacts]]``."""
+    return read_state(directory).get("artifacts", [])
 
 
 def _write(directory: str, state: dict):

--- a/jqmc_workflow/_state.py
+++ b/jqmc_workflow/_state.py
@@ -257,6 +257,8 @@ def add_job(
     job_id: str,
     server_machine: str,
     status: str = "submitted",
+    step: int = None,
+    run_id: str = "",
 ) -> dict:
     """Append a new job record to the ``[[jobs]]`` list.
 
@@ -276,6 +278,10 @@ def add_job(
         "status": status,
         "submitted_at": _now_iso(),
     }
+    if step is not None:
+        job["step"] = step
+    if run_id:
+        job["run_id"] = run_id
     state["jobs"].append(job)
     state.setdefault("workflow", {})["updated_at"] = _now_iso()
     _write(directory, state)
@@ -314,6 +320,18 @@ def get_job(directory: str, input_file: str) -> dict:
     state = read_state(directory)
     for j in reversed(state.get("jobs", [])):
         if j.get("input_file") == input_file:
+            return j
+    return {}
+
+
+def get_job_by_step(directory: str, step: int) -> dict:
+    """Get the latest job record for *step*, regardless of run_id.
+
+    Returns an empty dict if no matching record is found.
+    """
+    state = read_state(directory)
+    for j in reversed(state.get("jobs", [])):
+        if j.get("step") == step:
             return j
     return {}
 

--- a/jqmc_workflow/_state.py
+++ b/jqmc_workflow/_state.py
@@ -555,6 +555,25 @@ def get_artifact_registry(directory: str) -> list[dict]:
     return read_state(directory).get("artifacts", [])
 
 
+def set_input_fingerprints(directory: str, fingerprints: dict[str, dict]) -> None:
+    """Record input-file fingerprints in ``[input_fingerprints]``.
+
+    Parameters
+    ----------
+    fingerprints : dict[str, dict]
+        Mapping ``{basename: {"size": int, "mtime": float}}``.
+    """
+    state = read_state(directory)
+    state["input_fingerprints"] = fingerprints
+    state.setdefault("workflow", {})["updated_at"] = _now_iso()
+    _write(directory, state)
+
+
+def get_input_fingerprints(directory: str) -> dict[str, dict]:
+    """Return the recorded input-file fingerprints, or empty dict."""
+    return read_state(directory).get("input_fingerprints", {})
+
+
 def _write(directory: str, state: dict):
     """Write state dict to workflow_state.toml."""
     path = os.path.join(directory, STATE_FILENAME)

--- a/jqmc_workflow/_transfer.py
+++ b/jqmc_workflow/_transfer.py
@@ -154,7 +154,7 @@ class Data_transfer:
 
     # ── get (remote → local) ──────────────────────────────────────
 
-    def get_objects(self, from_objects=None, exclude_patterns=None, *, work_dir=None):
+    def get_objects(self, from_objects=None, exclude_patterns=None, *, work_dir=None, optional_patterns=None):
         """Download files from the remote directory to *work_dir*.
 
         Parameters
@@ -169,9 +169,15 @@ class Data_transfer:
             *None*, falls back to ``os.getcwd()`` for backward
             compatibility, but callers should always pass this
             explicitly.
+        optional_patterns : list[str], optional
+            Basenames or glob patterns of files that are non-essential.
+            When a file matching one of these patterns is missing on
+            the server, a warning is logged instead of raising
+            ``FileNotFoundError``.
         """
         from_objects = from_objects or []
         exclude_patterns = exclude_patterns or []
+        optional_patterns = optional_patterns or []
 
         local_root = self._local_root
         server_root = self.server_machine.workspace_root
@@ -215,6 +221,9 @@ class Data_transfer:
             for obj in expanded:
                 from_path = os.path.join(server_dir, obj)
                 if not self.server_machine.exist(object_name=from_path):
+                    if any(fnmatch.fnmatch(obj, pat) for pat in optional_patterns):
+                        logger.warning(f"Optional file not found on server (skipped): {from_path}")
+                        continue
                     raise FileNotFoundError(f"{from_path} not found on server.")
                 to_path = from_path.replace(server_root, local_root)
                 if self.server_machine.is_file(file_name=from_path):

--- a/jqmc_workflow/launcher.py
+++ b/jqmc_workflow/launcher.py
@@ -293,6 +293,72 @@ class Launcher:
         G.render("dependency_graph", cleanup=True)
         logger.info("Dependency graph saved to dependency_graph.png")
 
+    # ── Session / job queries (MCP adapter layer) ───────────────
+
+    def get_session_state(self) -> dict:
+        """Aggregate the status of all workflows, dependency graph, and progress.
+
+        Returns a dict suitable for the ``workflow/current_state`` MCP resource.
+        """
+        from ._state import get_workflow_summary
+
+        workflows = {}
+        completed = failed = 0
+        running_labels: list[str] = []
+        pending_labels: list[str] = []
+
+        for cw in self.workflows:
+            if cw.project_dir:
+                summary = get_workflow_summary(cw.project_dir)
+            else:
+                summary = {}
+            workflows[cw.label] = summary
+            s = summary.get("status", "pending")
+            if s == "completed":
+                completed += 1
+            elif s == "failed":
+                failed += 1
+            elif s in ("running", "submitted"):
+                running_labels.append(cw.label)
+            else:
+                pending_labels.append(cw.label)
+
+        return {
+            "workflows": workflows,
+            "dependency_graph": {label: list(deps) for label, deps in self.dependency_dict.items()},
+            "progress": {
+                "completed": completed,
+                "failed": failed,
+                "running": running_labels,
+                "pending": pending_labels,
+                "total": len(self.workflows),
+            },
+        }
+
+    def get_current_job(self) -> dict | None:
+        """Return the first workflow that is currently running/submitted, or ``None``."""
+        from ._state import get_workflow_summary
+
+        for cw in self.workflows:
+            if cw.project_dir:
+                summary = get_workflow_summary(cw.project_dir)
+                if summary.get("status") in ("running", "submitted"):
+                    return {"label": cw.label, "project_dir": cw.project_dir, **summary}
+        return None
+
+    def get_job_history(self) -> list[dict]:
+        """Return a flat, chronologically-sorted list of all jobs across all workflows."""
+        from ._state import get_jobs
+
+        history: list[dict] = []
+        for cw in self.workflows:
+            if cw.project_dir:
+                for j in get_jobs(cw.project_dir):
+                    j["workflow_label"] = cw.label
+                    history.append(j)
+        history.sort(key=lambda j: j.get("submitted_at", ""))
+        return history
+
     # ── Variable resolution ───────────────────────────────────────
 
     def _get_value(self, dep_obj):

--- a/jqmc_workflow/launcher.py
+++ b/jqmc_workflow/launcher.py
@@ -367,7 +367,16 @@ class Launcher:
         cw = self.workflows_by_label[label]
 
         if isinstance(dep_obj, FileFrom):
-            filepath = os.path.join(cw.dirname, dep_obj.filename)
+            filename = dep_obj.filename
+            # Resolve dynamic filename (ValueFrom inside FileFrom)
+            if isinstance(filename, ValueFrom):
+                filename = self._get_value(filename)
+                if filename is None:
+                    raise ValueError(
+                        f"[{dep_obj.label}] ValueFrom({filename!r}) resolved to None. "
+                        f"Upstream workflow may not have set the output_values key."
+                    )
+            filepath = os.path.join(cw.dirname, filename)
             p = pathlib.Path(filepath)
             return p.resolve().relative_to(pathlib.Path(self.root_dir).resolve())
 

--- a/jqmc_workflow/lrdmc_ext_workflow.py
+++ b/jqmc_workflow/lrdmc_ext_workflow.py
@@ -193,6 +193,21 @@ class LRDMC_Ext_Workflow(Workflow):
             ),
         )
 
+    Output Values
+    -------------
+    After ``launch()`` completes, ``output_values`` may contain:
+
+    extrapolated_energy : float
+        Continuum-limit (a²→0) extrapolated energy (Ha).
+    extrapolated_energy_error : float
+        Statistical error on ``extrapolated_energy`` (Ha).
+    per_alat_results : dict
+        Per-alat energy/error results keyed by ``alat``.
+    errors : list[str]
+        Error messages for alat runs that failed.
+    error : str
+        Top-level error message (only on failure).
+
     Notes
     -----
     * At least two ``alat`` values are required for extrapolation.

--- a/jqmc_workflow/lrdmc_ext_workflow.py
+++ b/jqmc_workflow/lrdmc_ext_workflow.py
@@ -54,8 +54,8 @@ from ._setting import (
     GFMC_MIN_COLLECT_STEPS,
     GFMC_MIN_WARMUP_STEPS,
 )
-from .lrdmc_workflow import LRDMC_Workflow
 from ._state import WorkflowStatus
+from .lrdmc_workflow import LRDMC_Workflow
 from .workflow import Container, Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)

--- a/jqmc_workflow/lrdmc_ext_workflow.py
+++ b/jqmc_workflow/lrdmc_ext_workflow.py
@@ -55,6 +55,7 @@ from ._setting import (
     GFMC_MIN_WARMUP_STEPS,
 )
 from .lrdmc_workflow import LRDMC_Workflow
+from ._state import WorkflowStatus
 from .workflow import Container, Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -328,7 +329,20 @@ class LRDMC_Ext_Workflow(Workflow):
         )
         return enc
 
-    async def async_launch(self):
+    def configure(self) -> dict:
+        """Validate parameters and return configuration summary."""
+        return {
+            "alat_list": self.alat_list,
+            "polynomial_order": self.polynomial_order,
+            "hamiltonian_file": self.hamiltonian_file,
+            "server_machine": self.server_machine_name,
+            "number_of_walkers": self.number_of_walkers,
+            "max_time": self.max_time,
+            "target_error": self.target_error,
+            "max_continuation": self.max_continuation,
+        }
+
+    async def run(self) -> tuple:
         """Run LRDMC at each alat, then extrapolate to a²→0.
 
         Every ``alat`` value is launched in parallel.  Each child
@@ -377,7 +391,7 @@ class LRDMC_Ext_Workflow(Workflow):
                 logger.error(f"[{enc.label}] failed: {error}")
                 errors.append(str(error))
                 continue
-            if status != "success":
+            if status not in ("success", "completed", WorkflowStatus.COMPLETED):
                 logger.error(f"[{enc.label}] returned status={status}")
                 errors.append(f"{enc.label}: status={status}")
                 continue
@@ -398,7 +412,7 @@ class LRDMC_Ext_Workflow(Workflow):
             )
 
         if errors:
-            self.status = "failed"
+            self.status = WorkflowStatus.FAILED
             self.output_values["errors"] = errors
             return self.status, [], {"error": "; ".join(errors)}
 
@@ -414,13 +428,13 @@ class LRDMC_Ext_Workflow(Workflow):
         else:
             msg = f"Only {len(restart_chks)} checkpoint(s) found; cannot extrapolate."
             logger.error(msg)
-            self.status = "failed"
+            self.status = WorkflowStatus.FAILED
             self.output_values["error"] = msg
             return self.status, [], {"error": msg}
 
         self.output_values["per_alat_results"] = per_alat_results
         self.output_files = restart_chks
-        self.status = "success"
+        self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     def _extrapolate_energy(self, restart_chks: List[str]):

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -1018,8 +1018,7 @@ class LRDMC_Workflow(Workflow):
                             f"{self.target_error:.6g} Ha -- "
                             f"max_continuation ({self.max_continuation}) reached"
                         )
-                        logger.error(msg)
-                        self.status = WorkflowStatus.FAILED
+                        logger.warning(msg)
 
         # ── Final energy computation ─────────────────────────────
         last_output = step_files[last_run][1] if last_run in step_files else None

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -77,6 +77,7 @@ from ._setting import (
     GFMC_MIN_WARMUP_STEPS,
 )
 from ._state import get_estimation, get_job, set_estimation
+from ._state import WorkflowStatus
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -434,9 +435,23 @@ class LRDMC_Workflow(Workflow):
     # ── Submit / poll / fetch ─────────────────────────────────────
     # _submit_and_wait() and _make_job() are inherited from Workflow.
 
-    # ── Launch ────────────────────────────────────────────────────
+    # ── configure / run ──────────────────────────────────────────
 
-    async def async_launch(self):
+    def configure(self) -> dict:
+        """Validate parameters and return configuration summary."""
+        return {
+            "input_file": self.input_file,
+            "alat": self.alat,
+            "target_error": self.target_error,
+            "hamiltonian_file": self.hamiltonian_file,
+            "server_machine": self.server_machine_name,
+            "number_of_walkers": self.number_of_walkers,
+            "max_time": self.max_time,
+            "pilot_steps": self.pilot_steps,
+            "max_continuation": self.max_continuation,
+        }
+
+    async def run(self) -> tuple:
         """Run the LRDMC workflow.
 
         **Fixed-step mode** (``num_gfmc_projections`` is set):
@@ -591,7 +606,7 @@ class LRDMC_Workflow(Workflow):
         else:
             self.output_values["time_projection_tau"] = self.time_projection_tau
 
-        self.status = "success"
+        self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     async def _run_calibration(self, _wd):
@@ -860,7 +875,7 @@ class LRDMC_Workflow(Workflow):
                     if forces is not None:
                         self.output_values["forces"] = forces
                 self.output_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-                self.status = "success"
+                self.status = WorkflowStatus.COMPLETED
                 return self.status, self.output_files, self.output_values
 
         # ── Production runs (phase 1..N) ──────────────────────────
@@ -983,7 +998,7 @@ class LRDMC_Workflow(Workflow):
                             f"max_continuation ({self.max_continuation}) reached"
                         )
                         logger.error(msg)
-                        self.status = "failed"
+                        self.status = WorkflowStatus.FAILED
 
         # ── Final energy computation ─────────────────────────────
         last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
@@ -1022,7 +1037,7 @@ class LRDMC_Workflow(Workflow):
         else:
             self.output_values["time_projection_tau"] = self.time_projection_tau
 
-        self.status = self.status or "success"
+        self.status = self.status or WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -61,7 +61,6 @@ from ._error_estimator import (
     estimate_additional_steps,
     estimate_required_steps,
     parse_net_time,
-    suffixed_name,
 )
 from ._input_generator import generate_input_toml, resolve_with_defaults
 from ._job import get_num_mpi, load_queue_data
@@ -76,8 +75,7 @@ from ._setting import (
     GFMC_MIN_COLLECT_STEPS,
     GFMC_MIN_WARMUP_STEPS,
 )
-from ._state import get_estimation, get_job, set_estimation
-from ._state import WorkflowStatus
+from ._state import WorkflowStatus, get_estimation, get_job_by_step, set_estimation
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -266,8 +264,6 @@ class LRDMC_Workflow(Workflow):
         server_machine_name: str = "localhost",
         alat: float = 0.30,
         hamiltonian_file: str = "hamiltonian_data.h5",
-        input_file: str = "input.toml",
-        output_file: str = "out.o",
         queue_label: str = "default",
         jobname: str = "jqmc-lrdmc",
         number_of_walkers: int = 4,
@@ -298,8 +294,6 @@ class LRDMC_Workflow(Workflow):
         self.server_machine_name = server_machine_name
         self.alat = alat
         self.hamiltonian_file = hamiltonian_file
-        self.input_file = input_file
-        self.output_file = output_file
         self.queue_label = queue_label
         self.jobname = jobname
         self.number_of_walkers = number_of_walkers
@@ -440,7 +434,7 @@ class LRDMC_Workflow(Workflow):
     def configure(self) -> dict:
         """Validate parameters and return configuration summary."""
         return {
-            "input_file": self.input_file,
+            "jobname": self.jobname,
             "alat": self.alat,
             "target_error": self.target_error,
             "hamiltonian_file": self.hamiltonian_file,
@@ -504,19 +498,26 @@ class LRDMC_Workflow(Workflow):
             f"  {mode_info}"
         )
 
+        step_files = {}  # {step: (input, output, run_id)}
         last_run = 0
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
+            recorded = get_job_by_step(_wd, i)
+            status_i = recorded.get("status")
 
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    last_run = i
-                    continue
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            if status_i == "fetched":
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                last_run = i
+                continue
+            elif status_i in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status_i}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
                 else:
@@ -533,6 +534,7 @@ class LRDMC_Workflow(Workflow):
                 logger.info(f"-- LRDMC Production run {i}/{self.max_continuation} (a={self.alat}) " + "-" * 10)
                 logger.info(f"  {input_i}: {estimated_steps} steps")
 
+            step_files[i] = (input_i, output_i, run_id_i)
             restart_chk = self._find_restart_chk(_wd) if i > 1 else None
             if i > 1 and restart_chk is None:
                 raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
@@ -543,6 +545,8 @@ class LRDMC_Workflow(Workflow):
                 output_i,
                 work_dir=_wd,
                 extra_from_objects=extra_from,
+                step=i,
+                run_id=run_id_i,
             )
             last_run = i
 
@@ -570,7 +574,7 @@ class LRDMC_Workflow(Workflow):
                     )
 
         # ── Final energy computation ─────────────────────────────
-        last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
+        last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
             energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=last_output)
@@ -594,11 +598,7 @@ class LRDMC_Workflow(Workflow):
 
         # ── Collect outputs ───────────────────────────────────────
         chk_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = chk_files + output_logs
         self.output_values["estimated_steps"] = estimated_steps
         if self._use_gfmc_n:
@@ -634,29 +634,34 @@ class LRDMC_Workflow(Workflow):
             if os.path.isfile(h5_src) and not os.path.exists(h5_link):
                 os.symlink(h5_src, h5_link)
 
-            inp = suffixed_name(self.input_file, 0)
-            out = suffixed_name(self.output_file, 0)
-
-            async def _run_calib(sub_dir, inp_f, out_f, nmpm_v, _idx=idx):
-                rec = get_job(sub_dir, inp_f)
-                if rec.get("status") not in (
-                    "submitted",
-                    "completed",
-                    "fetched",
-                ):
+            async def _run_calib(sub_dir, nmpm_v, _idx=idx):
+                rec = get_job_by_step(sub_dir, 0)
+                status_c = rec.get("status")
+                if status_c in ("fetched", "submitted", "completed"):
+                    inp_f = rec["input_file"]
+                    out_f = rec["output_file"]
+                    run_id_c = rec.get("run_id", "")
+                    if status_c == "fetched":
+                        logger.info(f"  {inp_f} (nmpm={nmpm_v}): already fetched. Skipping.")
+                    else:
+                        logger.info(f"  {inp_f} (nmpm={nmpm_v}): already {status_c}. Resuming...")
+                else:
+                    run_id_c = self._new_run_id()
+                    inp_f = self._input_filename(0, run_id_c)
+                    out_f = self._output_filename(0, run_id_c)
                     self._generate_input(
                         self.pilot_steps,
                         os.path.join(sub_dir, inp_f),
                         num_projection_per_measurement=nmpm_v,
                     )
-                else:
-                    logger.info(f"  {inp_f} (nmpm={nmpm_v}): already {rec['status']}. Resuming...")
                 logger.info(f"  _pilot{_idx}: nmpm={nmpm_v}, {self.pilot_steps} steps")
                 await self._submit_and_wait(
                     inp_f,
                     out_f,
                     work_dir=sub_dir,
                     queue_label=self.pilot_queue_label,
+                    step=0,
+                    run_id=run_id_c,
                 )
                 # Parse survived walkers ratio from output
                 out_path = os.path.join(sub_dir, out_f)
@@ -664,7 +669,7 @@ class LRDMC_Workflow(Workflow):
                 logger.info(f"  _pilot{_idx} (nmpm={nmpm_v}): survived ratio = {ratio:.4f}" if ratio else "N/A")
                 return nmpm_v, ratio
 
-            calib_tasks.append(asyncio.create_task(_run_calib(calib_sub, inp, out, nmpm_val)))
+            calib_tasks.append(asyncio.create_task(_run_calib(calib_sub, nmpm_val)))
 
         calib_results = await asyncio.gather(*calib_tasks)
 
@@ -729,25 +734,34 @@ class LRDMC_Workflow(Workflow):
             if os.path.isfile(h5_src) and not os.path.exists(h5_link_b):
                 os.symlink(h5_src, h5_link_b)
 
-            input_pb = suffixed_name(self.input_file, 0)
-            output_pb = suffixed_name(self.output_file, 0)
+            input_pb = None
+            output_pb = None
+            run_id_pb = ""
 
-            recorded_pb = get_job(pilot_b_dir, input_pb)
-            if recorded_pb.get("status") not in (
-                "submitted",
-                "completed",
-                "fetched",
-            ):
-                self._generate_input(self.pilot_steps, os.path.join(pilot_b_dir, input_pb))
+            recorded_pb = get_job_by_step(pilot_b_dir, 0)
+            status_pb = recorded_pb.get("status")
+            if status_pb in ("fetched", "submitted", "completed"):
+                input_pb = recorded_pb["input_file"]
+                output_pb = recorded_pb["output_file"]
+                run_id_pb = recorded_pb.get("run_id", "")
+                if status_pb == "fetched":
+                    logger.info(f"  {input_pb}: already fetched. Skipping pilot_b.")
+                else:
+                    logger.info(f"  {input_pb}: already {status_pb}. Resuming...")
             else:
-                logger.info(f"  {input_pb}: already {recorded_pb['status']}. Resuming...")
+                run_id_pb = self._new_run_id()
+                input_pb = self._input_filename(0, run_id_pb)
+                output_pb = self._output_filename(0, run_id_pb)
+                self._generate_input(self.pilot_steps, os.path.join(pilot_b_dir, input_pb))
             mode_info = f"nmpm={self.num_projection_per_measurement}" if self._use_gfmc_n else f"tau={self.time_projection_tau}"
             logger.info("")
             logger.info(f"-- LRDMC Phase B: Error-bar Pilot (a={self.alat}) " + "-" * 12)
             logger.info(f"  {input_pb}: {self.pilot_steps} steps, {mode_info} (queue: {self.pilot_queue_label})")
 
             pilot_t0 = time.monotonic()
-            await self._submit_and_wait(input_pb, output_pb, work_dir=pilot_b_dir, queue_label=self.pilot_queue_label)
+            await self._submit_and_wait(
+                input_pb, output_pb, work_dir=pilot_b_dir, queue_label=self.pilot_queue_label, step=0, run_id=run_id_pb
+            )
             pilot_wall_sec = time.monotonic() - pilot_t0
 
             restart_chk = self._find_restart_chk(pilot_b_dir)
@@ -879,24 +893,30 @@ class LRDMC_Workflow(Workflow):
                 return self.status, self.output_files, self.output_values
 
         # ── Production runs (phase 1..N) ──────────────────────────
+        step_files = {}  # {step: (input, output, run_id)}
         accumulated_steps = 0
         last_run = 0
         _prev_run_steps = None  # tracks the step count of the last completed run
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
+            recorded = get_job_by_step(_wd, i)
+            status_i = recorded.get("status")
 
-            # Skip input generation if this step already has a job record
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    accumulated_steps += estimated_steps
-                    _prev_run_steps = estimated_steps
-                    last_run = i
-                    continue
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            if status_i == "fetched":
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                accumulated_steps += estimated_steps
+                _prev_run_steps = estimated_steps
+                last_run = i
+                continue
+            elif status_i in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status_i}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
                 else:
@@ -913,6 +933,7 @@ class LRDMC_Workflow(Workflow):
                 logger.info(f"-- LRDMC Phase 1: Production run {i}/{self.max_continuation} (a={self.alat}) " + "-" * 10)
                 logger.info(f"  {input_i}: {estimated_steps} steps")
 
+            step_files[i] = (input_i, output_i, run_id_i)
             restart_chk = self._find_restart_chk(_wd) if i > 1 else None
             if i > 1 and restart_chk is None:
                 raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
@@ -921,7 +942,9 @@ class LRDMC_Workflow(Workflow):
             # Estimate run time from the latest available output
             _ref_net = None
             for _j in range(i - 1, 0, -1):
-                _ref_net = parse_net_time(os.path.join(_wd, suffixed_name(self.output_file, _j)))
+                if _j not in step_files:
+                    continue
+                _ref_net = parse_net_time(os.path.join(_wd, step_files[_j][1]))
                 if _ref_net and _ref_net > 0:
                     _ref_steps = _prev_run_steps if _prev_run_steps else estimated_steps
                     _est_sec = _ref_net * (estimated_steps / _ref_steps) if _ref_steps > 0 else _ref_net
@@ -929,8 +952,8 @@ class LRDMC_Workflow(Workflow):
                     break
             else:
                 # First production run: use pilot output
-                _pilot_out = os.path.join(_wd, "_pilot_b", suffixed_name(self.output_file, 0))
-                _ref_net = parse_net_time(_pilot_out)
+                _pilot_outs = sorted(glob.glob(os.path.join(_wd, "_pilot_b", "*.out")))
+                _ref_net = parse_net_time(_pilot_outs[-1]) if _pilot_outs else None
                 if _ref_net and _ref_net > 0:
                     _p_steps = estimation.get("pilot_steps") or self.pilot_steps
                     if _p_steps > 0:
@@ -943,6 +966,8 @@ class LRDMC_Workflow(Workflow):
                 output_i,
                 work_dir=_wd,
                 extra_from_objects=extra_from,
+                step=i,
+                run_id=run_id_i,
             )
             accumulated_steps += estimated_steps
             _prev_run_steps = estimated_steps
@@ -1001,7 +1026,7 @@ class LRDMC_Workflow(Workflow):
                         self.status = WorkflowStatus.FAILED
 
         # ── Final energy computation ─────────────────────────────
-        last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
+        last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
             energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=last_output)
@@ -1025,11 +1050,7 @@ class LRDMC_Workflow(Workflow):
 
         # ── Collect outputs ───────────────────────────────────────
         chk_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = chk_files + output_logs
         self.output_values["estimated_steps"] = estimated_steps
         if self._use_gfmc_n:
@@ -1037,7 +1058,8 @@ class LRDMC_Workflow(Workflow):
         else:
             self.output_values["time_projection_tau"] = self.time_projection_tau
 
-        self.status = self.status or WorkflowStatus.COMPLETED
+        if self.status != WorkflowStatus.FAILED:
+            self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -890,7 +890,8 @@ class LRDMC_Workflow(Workflow):
 
         # ── Production runs (phase 1..N) ──────────────────────────
         step_files = {}  # {step: (input, output, run_id)}
-        accumulated_steps = 0
+        warmup = self.num_gfmc_warmup_steps
+        accumulated_steps = 0  # measurement steps only (excluding warmup)
         last_run = 0
         _prev_run_steps = None  # tracks the step count of the last completed run
         _did_reestimate_from_fetched = False
@@ -901,7 +902,7 @@ class LRDMC_Workflow(Workflow):
             if status_i == "fetched":
                 step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
                 logger.info(f"  step {i}: already fetched. Skipping.")
-                accumulated_steps += estimated_steps
+                accumulated_steps += estimated_steps - warmup
                 _prev_run_steps = estimated_steps
                 last_run = i
                 continue
@@ -934,17 +935,19 @@ class LRDMC_Workflow(Workflow):
                                     if forces is not None:
                                         self.output_values["forces"] = forces
                                 break
-                            estimated_steps = estimate_additional_steps(
+                            _additional = estimate_additional_steps(
                                 accumulated_steps,
                                 _re_error,
                                 self.target_error,
                             )
+                            estimated_steps = _additional + warmup
                             logger.info(
                                 f"  Re-estimated from accumulated data: "
                                 f"error={_re_error:.6g} Ha > target "
                                 f"{self.target_error:.6g} Ha -> "
-                                f"{estimated_steps} additional steps "
-                                f"(accumulated: {accumulated_steps})"
+                                f"{estimated_steps} steps "
+                                f"(measurement: {_additional}, warmup: {warmup}, "
+                                f"accumulated measurement: {accumulated_steps})"
                             )
 
                 run_id_i = self._new_run_id()
@@ -1002,7 +1005,7 @@ class LRDMC_Workflow(Workflow):
                 step=i,
                 run_id=run_id_i,
             )
-            accumulated_steps += estimated_steps
+            accumulated_steps += estimated_steps - warmup
             _prev_run_steps = estimated_steps
             last_run = i
 
@@ -1040,14 +1043,16 @@ class LRDMC_Workflow(Workflow):
                         break
                     elif i < self.max_continuation:
                         old_steps = estimated_steps
-                        estimated_steps = estimate_additional_steps(
+                        _additional = estimate_additional_steps(
                             accumulated_steps,
                             error,
                             self.target_error,
                         )
+                        estimated_steps = _additional + warmup
                         logger.info(
-                            f"  Re-estimated: {old_steps} -> {estimated_steps} "
-                            f"additional steps (accumulated so far: {accumulated_steps})"
+                            f"  Re-estimated: {old_steps} -> {estimated_steps} steps "
+                            f"(measurement: {_additional}, warmup: {warmup}, "
+                            f"accumulated measurement: {accumulated_steps})"
                         )
                     else:
                         msg = (

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -893,6 +893,7 @@ class LRDMC_Workflow(Workflow):
         accumulated_steps = 0
         last_run = 0
         _prev_run_steps = None  # tracks the step count of the last completed run
+        _did_reestimate_from_fetched = False
         for i in range(1, self.max_continuation + 1):
             recorded = get_job_by_step(_wd, i)
             status_i = recorded.get("status")
@@ -910,6 +911,42 @@ class LRDMC_Workflow(Workflow):
                 run_id_i = recorded.get("run_id", "")
                 logger.info(f"  step {i}: already {status_i}. Resuming...")
             else:
+                # ── Re-estimate if resuming after fetched runs ────
+                if accumulated_steps > 0 and not _did_reestimate_from_fetched:
+                    _did_reestimate_from_fetched = True
+                    _re_chk = self._find_restart_chk(_wd)
+                    if _re_chk:
+                        _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
+                        if _re_energy is not None and _re_error is not None:
+                            if _re_error <= self.target_error * 1.20:
+                                logger.info(
+                                    f"  Target already met after fetched runs: "
+                                    f"{_re_error:.6g} <= {self.target_error * 1.20:.6g} Ha"
+                                )
+                                self.output_values.update(
+                                    energy=_re_energy,
+                                    energy_error=_re_error,
+                                    alat=self.alat,
+                                    restart_chk=_re_chk,
+                                )
+                                if self.atomic_force:
+                                    forces = self._compute_force(_re_chk, work_dir=_wd)
+                                    if forces is not None:
+                                        self.output_values["forces"] = forces
+                                break
+                            estimated_steps = estimate_additional_steps(
+                                accumulated_steps,
+                                _re_error,
+                                self.target_error,
+                            )
+                            logger.info(
+                                f"  Re-estimated from accumulated data: "
+                                f"error={_re_error:.6g} Ha > target "
+                                f"{self.target_error:.6g} Ha -> "
+                                f"{estimated_steps} additional steps "
+                                f"(accumulated: {accumulated_steps})"
+                            )
+
                 run_id_i = self._new_run_id()
                 input_i = self._input_filename(i, run_id_i)
                 output_i = self._output_filename(i, run_id_i)

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -131,10 +131,6 @@ class LRDMC_Workflow(Workflow):
         Lattice discretization parameter (bohr).
     hamiltonian_file : str
         Input ``hamiltonian_data.h5``.
-    input_file : str
-        Generated TOML input filename.
-    output_file : str
-        Stdout capture filename.
     queue_label : str
         Queue/partition label.
     jobname : str

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -889,80 +889,103 @@ class LRDMC_Workflow(Workflow):
                 return self.status, self.output_files, self.output_values
 
         # ── Production runs (phase 1..N) ──────────────────────────
-        step_files = {}  # {step: (input, output, run_id)}
+        # Three phases:
+        #   A. Scan existing runs → find resume point
+        #   B. Re-estimate from accumulated data (if resuming)
+        #   C. Production loop for remaining runs
+        #
+        # Checkpoint preserves all accumulated statistics across
+        # production restarts.  accumulated_measurement tracks
+        # total measurement steps (excluding warmup) and is
+        # persisted in estimation state for correct resume.
+
         warmup = self.num_gfmc_warmup_steps
-        accumulated_steps = 0  # measurement steps only (excluding warmup)
+        step_files = {}  # {step: (input, output, run_id)}
         last_run = 0
-        _prev_run_steps = None  # tracks the step count of the last completed run
-        _did_reestimate_from_fetched = False
+        first_new_run = self.max_continuation + 1  # assume all done
+
+        # ── Phase A: scan existing runs ──
         for i in range(1, self.max_continuation + 1):
             recorded = get_job_by_step(_wd, i)
             status_i = recorded.get("status")
-
             if status_i == "fetched":
                 step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
                 logger.info(f"  step {i}: already fetched. Skipping.")
-                accumulated_steps += estimated_steps - warmup
-                _prev_run_steps = estimated_steps
                 last_run = i
-                continue
-            elif status_i in ("submitted", "completed"):
+            else:
+                first_new_run = i
+                break
+
+        # ── Phase B: re-estimate from accumulated data ──
+        accumulated_measurement = 0  # measurement steps only (excl. warmup)
+        if first_new_run > 1:
+            cached_accum = estimation.get("accumulated_measurement_steps")
+            if cached_accum is not None:
+                accumulated_measurement = int(cached_accum)
+            else:
+                accumulated_measurement = (first_new_run - 1) * max(estimated_steps - warmup, 0)
+
+            _re_chk = self._find_restart_chk(_wd)
+            if _re_chk:
+                _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
+                if _re_energy is not None and _re_error is not None:
+                    if _re_error <= self.target_error * 1.20:
+                        logger.info(
+                            f"  Target already met after prior runs: {_re_error:.6g} <= {self.target_error * 1.20:.6g} Ha"
+                        )
+                        self.output_values.update(
+                            energy=_re_energy,
+                            energy_error=_re_error,
+                            alat=self.alat,
+                            restart_chk=_re_chk,
+                        )
+                        if self.atomic_force:
+                            forces = self._compute_force(_re_chk, work_dir=_wd)
+                            if forces is not None:
+                                self.output_values["forces"] = forces
+                        first_new_run = self.max_continuation + 1  # skip loop
+                    else:
+                        _additional = estimate_additional_steps(
+                            accumulated_measurement,
+                            _re_error,
+                            self.target_error,
+                        )
+                        estimated_steps = _additional + warmup
+                        logger.info(
+                            f"  Resuming after {first_new_run - 1} prior run(s): "
+                            f"error={_re_error:.6g} Ha > target "
+                            f"{self.target_error:.6g} Ha -> "
+                            f"{estimated_steps} steps "
+                            f"(measurement: {_additional}, warmup: {warmup}, "
+                            f"accumulated measurement: {accumulated_measurement})"
+                        )
+
+        # ── Phase C: production loop ──
+        _prev_run_steps = None
+        for i in range(first_new_run, self.max_continuation + 1):
+            recorded = get_job_by_step(_wd, i)
+            status_i = recorded.get("status")
+
+            if status_i in ("submitted", "completed"):
                 input_i = recorded["input_file"]
                 output_i = recorded["output_file"]
                 run_id_i = recorded.get("run_id", "")
                 logger.info(f"  step {i}: already {status_i}. Resuming...")
             else:
-                # ── Re-estimate if resuming after fetched runs ────
-                if accumulated_steps > 0 and not _did_reestimate_from_fetched:
-                    _did_reestimate_from_fetched = True
-                    _re_chk = self._find_restart_chk(_wd)
-                    if _re_chk:
-                        _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
-                        if _re_energy is not None and _re_error is not None:
-                            if _re_error <= self.target_error * 1.20:
-                                logger.info(
-                                    f"  Target already met after fetched runs: "
-                                    f"{_re_error:.6g} <= {self.target_error * 1.20:.6g} Ha"
-                                )
-                                self.output_values.update(
-                                    energy=_re_energy,
-                                    energy_error=_re_error,
-                                    alat=self.alat,
-                                    restart_chk=_re_chk,
-                                )
-                                if self.atomic_force:
-                                    forces = self._compute_force(_re_chk, work_dir=_wd)
-                                    if forces is not None:
-                                        self.output_values["forces"] = forces
-                                break
-                            _additional = estimate_additional_steps(
-                                accumulated_steps,
-                                _re_error,
-                                self.target_error,
-                            )
-                            estimated_steps = _additional + warmup
-                            logger.info(
-                                f"  Re-estimated from accumulated data: "
-                                f"error={_re_error:.6g} Ha > target "
-                                f"{self.target_error:.6g} Ha -> "
-                                f"{estimated_steps} steps "
-                                f"(measurement: {_additional}, warmup: {warmup}, "
-                                f"accumulated measurement: {accumulated_steps})"
-                            )
-
                 run_id_i = self._new_run_id()
                 input_i = self._input_filename(i, run_id_i)
                 output_i = self._output_filename(i, run_id_i)
-                if i == 1:
+                # First-ever production run starts fresh; all others restart
+                if i == 1 and first_new_run == 1:
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
                 else:
                     restart_chk = self._find_restart_chk(_wd)
                     if restart_chk is None:
-                        raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
+                        raise RuntimeError(f"No restart checkpoint found for run {i}. Expected .h5 file in {_wd}")
                     self._generate_input(
                         estimated_steps,
                         os.path.join(_wd, input_i),
-                        restart=bool(restart_chk),
+                        restart=True,
                         restart_chk=restart_chk,
                     )
                 logger.info("")
@@ -970,9 +993,10 @@ class LRDMC_Workflow(Workflow):
                 logger.info(f"  {input_i}: {estimated_steps} steps")
 
             step_files[i] = (input_i, output_i, run_id_i)
-            restart_chk = self._find_restart_chk(_wd) if i > 1 else None
-            if i > 1 and restart_chk is None:
-                raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
+            need_restart = i > 1 or first_new_run > 1
+            restart_chk = self._find_restart_chk(_wd) if need_restart else None
+            if need_restart and restart_chk is None:
+                raise RuntimeError(f"No restart checkpoint found for run {i}. Expected .h5 file in {_wd}")
             extra_from = [restart_chk] if restart_chk else []
 
             # Estimate run time from the latest available output
@@ -987,7 +1011,6 @@ class LRDMC_Workflow(Workflow):
                     logger.info(f"  est. Net run time (w/o JAX compilation) = {_format_duration(_est_sec)}")
                     break
             else:
-                # First production run: use pilot output
                 _pilot_outs = sorted(glob.glob(os.path.join(_wd, "_pilot_b", "*.out")))
                 _ref_net = parse_net_time(_pilot_outs[-1]) if _pilot_outs else None
                 if _ref_net and _ref_net > 0:
@@ -1005,11 +1028,11 @@ class LRDMC_Workflow(Workflow):
                 step=i,
                 run_id=run_id_i,
             )
-            accumulated_steps += estimated_steps - warmup
+            accumulated_measurement += estimated_steps - warmup
             _prev_run_steps = estimated_steps
             last_run = i
 
-            # Check convergence
+            # ── Convergence check (single estimation point) ──
             restart_chk = self._find_restart_chk(_wd)
             if restart_chk:
                 energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=output_i)
@@ -1024,11 +1047,11 @@ class LRDMC_Workflow(Workflow):
                         if forces is not None:
                             self.output_values["forces"] = forces
 
-                    # Cache for restart
                     set_estimation(
                         _wd,
                         last_energy=energy,
                         last_energy_error=error,
+                        accumulated_measurement_steps=accumulated_measurement,
                         last_num_gfmc_bin_blocks=self.num_gfmc_bin_blocks,
                         last_num_gfmc_warmup_steps=self.num_gfmc_warmup_steps,
                         last_num_gfmc_collect_steps=self.num_gfmc_collect_steps,
@@ -1044,7 +1067,7 @@ class LRDMC_Workflow(Workflow):
                     elif i < self.max_continuation:
                         old_steps = estimated_steps
                         _additional = estimate_additional_steps(
-                            accumulated_steps,
+                            accumulated_measurement,
                             error,
                             self.target_error,
                         )
@@ -1052,17 +1075,16 @@ class LRDMC_Workflow(Workflow):
                         logger.info(
                             f"  Re-estimated: {old_steps} -> {estimated_steps} steps "
                             f"(measurement: {_additional}, warmup: {warmup}, "
-                            f"accumulated measurement: {accumulated_steps})"
+                            f"accumulated measurement: {accumulated_measurement})"
                         )
                     else:
-                        msg = (
+                        logger.warning(
                             f"Error {error:.6g} > target "
                             f"{self.target_error:.6g} Ha -- "
                             f"max_continuation ({self.max_continuation}) reached"
                         )
-                        logger.warning(msg)
 
-        # ── Final energy computation ─────────────────────────────
+        # ── Final energy computation (safety net) ─────────────────
         last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
@@ -1080,6 +1102,7 @@ class LRDMC_Workflow(Workflow):
                     _wd,
                     last_energy=energy,
                     last_energy_error=error,
+                    accumulated_measurement_steps=accumulated_measurement,
                     last_num_gfmc_bin_blocks=self.num_gfmc_bin_blocks,
                     last_num_gfmc_warmup_steps=self.num_gfmc_warmup_steps,
                     last_num_gfmc_collect_steps=self.num_gfmc_collect_steps,

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -241,6 +241,28 @@ class LRDMC_Workflow(Workflow):
             ),
         )
 
+    Output Values
+    -------------
+    After ``launch()`` completes, ``output_values`` may contain:
+
+    energy : float
+        DMC energy (Ha).
+    energy_error : float
+        Statistical error on ``energy`` (Ha).
+    alat : float
+        Lattice spacing used for this run.
+    restart_chk : str
+        Basename of the restart checkpoint file.
+    forces : object
+        Atomic forces (only when ``atomic_force=True``).
+    estimated_steps : int
+        Estimated total measurement steps.
+    num_projection_per_measurement : int
+        Number of GFMC projections per measurement
+        (GFMC_n mode only).
+    time_projection_tau : float
+        Imaginary-time projection step (GFMC_t mode only).
+
     Notes
     -----
     * For a²→0 continuum-limit extrapolation, use

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -94,10 +94,6 @@ class MCMC_Workflow(Workflow):
         Name of the target machine (configured in ``~/.jqmc_setting/``).
     hamiltonian_file : str
         Input ``hamiltonian_data.h5``.
-    input_file : str
-        Generated TOML input filename.
-    output_file : str
-        Stdout capture filename.
     queue_label : str
         Queue/partition label.
     jobname : str

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -605,7 +605,8 @@ class MCMC_Workflow(Workflow):
         # Production starts from scratch (no restart from pilot).
         # Checkpoint preserves all accumulated statistics across
         # production restarts.
-        accumulated_steps = 0
+        warmup = self.num_mcmc_warmup_steps
+        accumulated_steps = 0  # measurement steps only (excluding warmup)
         last_run = 0
         step_files = {}  # {step: (input, output, run_id)}
         _prev_run_steps = None  # tracks the step count of the last completed run
@@ -617,7 +618,7 @@ class MCMC_Workflow(Workflow):
             if status == "fetched":
                 logger.info(f"  step {i}: already fetched. Skipping.")
                 step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
-                accumulated_steps += estimated_steps
+                accumulated_steps += estimated_steps - warmup
                 _prev_run_steps = estimated_steps
                 last_run = i
                 continue
@@ -649,17 +650,19 @@ class MCMC_Workflow(Workflow):
                                     if forces is not None:
                                         self.output_values["forces"] = forces
                                 break
-                            estimated_steps = estimate_additional_steps(
+                            _additional = estimate_additional_steps(
                                 accumulated_steps,
                                 _re_error,
                                 self.target_error,
                             )
+                            estimated_steps = _additional + warmup
                             logger.info(
                                 f"  Re-estimated from accumulated data: "
                                 f"error={_re_error:.6g} Ha > target "
                                 f"{self.target_error:.6g} Ha -> "
-                                f"{estimated_steps} additional steps "
-                                f"(accumulated: {accumulated_steps})"
+                                f"{estimated_steps} steps "
+                                f"(measurement: {_additional}, warmup: {warmup}, "
+                                f"accumulated measurement: {accumulated_steps})"
                             )
 
                 run_id_i = self._new_run_id()
@@ -718,7 +721,7 @@ class MCMC_Workflow(Workflow):
                 run_id=run_id_i,
             )
             step_files[i] = (input_i, output_i, run_id_i)
-            accumulated_steps += estimated_steps
+            accumulated_steps += estimated_steps - warmup
             _prev_run_steps = estimated_steps
             last_run = i
 
@@ -754,13 +757,16 @@ class MCMC_Workflow(Workflow):
                         break
                     elif i < self.max_continuation:
                         old_steps = estimated_steps
-                        estimated_steps = estimate_additional_steps(
+                        _additional = estimate_additional_steps(
                             accumulated_steps,
                             error,
                             self.target_error,
                         )
+                        estimated_steps = _additional + warmup
                         logger.info(
-                            f"  Re-estimated: {old_steps} -> {estimated_steps} additional steps (accumulated so far: {accumulated_steps})"
+                            f"  Re-estimated: {old_steps} -> {estimated_steps} steps "
+                            f"(measurement: {_additional}, warmup: {warmup}, "
+                            f"accumulated measurement: {accumulated_steps})"
                         )
                     else:
                         msg = (

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -732,8 +732,7 @@ class MCMC_Workflow(Workflow):
                             f"{self.target_error:.6g} Ha -- "
                             f"max_continuation ({self.max_continuation}) reached"
                         )
-                        logger.error(msg)
-                        self.status = WorkflowStatus.FAILED
+                        logger.warning(msg)
 
         # ── Final energy computation ─────────────────────────────
         last_output = step_files[last_run][1] if last_run in step_files else None

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -50,13 +50,11 @@ from ._error_estimator import (
     estimate_additional_steps,
     estimate_required_steps,
     parse_net_time,
-    suffixed_name,
 )
 from ._input_generator import generate_input_toml, resolve_with_defaults
 from ._job import get_num_mpi, load_queue_data
 from ._output_parser import parse_force_table
-from ._state import get_estimation, get_job, set_estimation
-from ._state import WorkflowStatus
+from ._state import WorkflowStatus, get_estimation, get_job_by_step, set_estimation
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -198,8 +196,6 @@ class MCMC_Workflow(Workflow):
         self,
         server_machine_name: str = "localhost",
         hamiltonian_file: str = "hamiltonian_data.h5",
-        input_file: str = "input.toml",
-        output_file: str = "out.o",
         queue_label: str = "default",
         jobname: str = "jqmc-mcmc",
         number_of_walkers: int = 4,
@@ -226,8 +222,6 @@ class MCMC_Workflow(Workflow):
         super().__init__()
         self.server_machine_name = server_machine_name
         self.hamiltonian_file = hamiltonian_file
-        self.input_file = input_file
-        self.output_file = output_file
         self.queue_label = queue_label
         self.jobname = jobname
         self.number_of_walkers = number_of_walkers
@@ -306,7 +300,7 @@ class MCMC_Workflow(Workflow):
         """Validate parameters and return configuration summary."""
         mode = "fixed" if self.num_mcmc_steps is not None else "auto"
         return {
-            "input_file": self.input_file,
+            "jobname": self.jobname,
             "target_error": self.target_error,
             "mode": mode,
             "hamiltonian_file": self.hamiltonian_file,
@@ -352,18 +346,24 @@ class MCMC_Workflow(Workflow):
         logger.info(f"  num_mcmc_steps    = {estimated_steps}\n  max_continuation  = {self.max_continuation}")
 
         last_run = 0
+        step_files = {}  # {step: (input, output, run_id)}
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
-
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    last_run = i
-                    continue
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            recorded = get_job_by_step(_wd, i)
+            status = recorded.get("status")
+            if status == "fetched":
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                last_run = i
+                continue
+            elif status in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
                 else:
@@ -390,7 +390,10 @@ class MCMC_Workflow(Workflow):
                 output_i,
                 work_dir=_wd,
                 extra_from_objects=extra_from,
+                step=i,
+                run_id=run_id_i,
             )
+            step_files[i] = (input_i, output_i, run_id_i)
             last_run = i
 
             # Post-process energy (informational only, no convergence check)
@@ -415,7 +418,7 @@ class MCMC_Workflow(Workflow):
                     )
 
         # ── Final energy computation ─────────────────────────────
-        last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
+        last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
             energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=last_output)
@@ -437,11 +440,7 @@ class MCMC_Workflow(Workflow):
 
         # ── Collect outputs ───────────────────────────────────────
         chk_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = chk_files + output_logs
         self.output_values["num_mcmc_steps"] = estimated_steps
 
@@ -467,20 +466,29 @@ class MCMC_Workflow(Workflow):
             if os.path.isfile(h5_src) and not os.path.exists(h5_dst):
                 os.symlink(h5_src, h5_dst)
 
-            input_0 = suffixed_name(self.input_file, 0)
-            output_0 = suffixed_name(self.output_file, 0)
-
-            recorded_0 = get_job(pilot_dir, input_0)
-            if recorded_0.get("status") not in ("submitted", "completed", "fetched"):
-                self._generate_input(self.pilot_steps, os.path.join(pilot_dir, input_0))
+            recorded_0 = get_job_by_step(pilot_dir, 0)
+            status_0 = recorded_0.get("status")
+            if status_0 in ("fetched", "submitted", "completed"):
+                input_0 = recorded_0["input_file"]
+                output_0 = recorded_0["output_file"]
+                run_id_0 = recorded_0.get("run_id", "")
+                if status_0 == "fetched":
+                    logger.info(f"  {input_0}: already fetched. Skipping pilot.")
+                else:
+                    logger.info(f"  {input_0}: already {status_0}. Resuming...")
             else:
-                logger.info(f"  {input_0}: already {recorded_0['status']}. Resuming...")
+                run_id_0 = self._new_run_id()
+                input_0 = self._input_filename(0, run_id_0)
+                output_0 = self._output_filename(0, run_id_0)
+                self._generate_input(self.pilot_steps, os.path.join(pilot_dir, input_0))
             logger.info("")
             logger.info("-- MCMC Phase 0: Pilot " + "-" * 27)
             logger.info(f"  {input_0}: {self.pilot_steps} steps (queue: {self.pilot_queue_label})")
 
             pilot_t0 = time.monotonic()
-            await self._submit_and_wait(input_0, output_0, work_dir=pilot_dir, queue_label=self.pilot_queue_label)
+            await self._submit_and_wait(
+                input_0, output_0, work_dir=pilot_dir, queue_label=self.pilot_queue_label, step=0, run_id=run_id_0
+            )
             pilot_wall_sec = time.monotonic() - pilot_t0
 
             restart_chk = self._find_restart_chk(pilot_dir)
@@ -603,22 +611,28 @@ class MCMC_Workflow(Workflow):
         # production restarts.
         accumulated_steps = 0
         last_run = 0
+        step_files = {}  # {step: (input, output, run_id)}
         _prev_run_steps = None  # tracks the step count of the last completed run
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
-
             # Skip input generation if this step already has a job record
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    accumulated_steps += estimated_steps
-                    _prev_run_steps = estimated_steps
-                    last_run = i
-                    continue
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            recorded = get_job_by_step(_wd, i)
+            status = recorded.get("status")
+            if status == "fetched":
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                accumulated_steps += estimated_steps
+                _prev_run_steps = estimated_steps
+                last_run = i
+                continue
+            elif status in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     # First production run: start from scratch
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
@@ -644,7 +658,9 @@ class MCMC_Workflow(Workflow):
             # Estimate run time from the latest available output
             _ref_net = None
             for _j in range(i - 1, 0, -1):
-                _ref_net = parse_net_time(os.path.join(_wd, suffixed_name(self.output_file, _j)))
+                if _j not in step_files:
+                    continue
+                _ref_net = parse_net_time(os.path.join(_wd, step_files[_j][1]))
                 if _ref_net and _ref_net > 0:
                     _ref_steps = _prev_run_steps if _prev_run_steps else estimated_steps
                     _est_sec = _ref_net * (estimated_steps / _ref_steps) if _ref_steps > 0 else _ref_net
@@ -652,8 +668,8 @@ class MCMC_Workflow(Workflow):
                     break
             else:
                 # First production run: use pilot output
-                _pilot_out = os.path.join(_wd, "_pilot", suffixed_name(self.output_file, 0))
-                _ref_net = parse_net_time(_pilot_out)
+                _pilot_outs = sorted(glob.glob(os.path.join(_wd, "_pilot", "*.out")))
+                _ref_net = parse_net_time(_pilot_outs[-1]) if _pilot_outs else None
                 if _ref_net and _ref_net > 0:
                     _p_steps = estimation.get("pilot_steps") or self.pilot_steps
                     if _p_steps > 0:
@@ -666,7 +682,10 @@ class MCMC_Workflow(Workflow):
                 output_i,
                 work_dir=_wd,
                 extra_from_objects=extra_from,
+                step=i,
+                run_id=run_id_i,
             )
+            step_files[i] = (input_i, output_i, run_id_i)
             accumulated_steps += estimated_steps
             _prev_run_steps = estimated_steps
             last_run = i
@@ -721,7 +740,7 @@ class MCMC_Workflow(Workflow):
                         self.status = WorkflowStatus.FAILED
 
         # ── Final energy computation ─────────────────────────────
-        last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
+        last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
             energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=last_output)
@@ -743,15 +762,12 @@ class MCMC_Workflow(Workflow):
 
         # ── Collect outputs ───────────────────────────────────────
         chk_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = chk_files + output_logs
         self.output_values["estimated_steps"] = estimated_steps
 
-        self.status = self.status or WorkflowStatus.COMPLETED
+        if self.status != WorkflowStatus.FAILED:
+            self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -175,6 +175,22 @@ class MCMC_Workflow(Workflow):
             ),
         )
 
+    Output Values
+    -------------
+    After ``launch()`` completes, ``output_values`` may contain:
+
+    energy : float
+        VMC energy (Ha).
+    energy_error : float
+        Statistical error on ``energy`` (Ha).
+    restart_chk : str
+        Basename of the restart checkpoint file.
+    forces : object
+        Atomic forces (only when ``atomic_force=True``).
+    num_mcmc_steps : int
+        Estimated total measurement steps (automatic mode).
+        In fixed-step mode this key is ``estimated_steps``.
+
     Notes
     -----
     * The pilot run is skipped on re-entrance if an estimation already

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -602,92 +602,112 @@ class MCMC_Workflow(Workflow):
                 return self.status, self.output_files, self.output_values
 
         # ── Production runs (phase 1..N) ──────────────────────────
-        # Production starts from scratch (no restart from pilot).
+        # Three phases:
+        #   A. Scan existing runs → find resume point
+        #   B. Re-estimate from accumulated data (if resuming)
+        #   C. Production loop for remaining runs
+        #
         # Checkpoint preserves all accumulated statistics across
-        # production restarts.
+        # production restarts.  accumulated_measurement tracks
+        # total measurement steps (excluding warmup) and is
+        # persisted in estimation state for correct resume.
+
         warmup = self.num_mcmc_warmup_steps
-        accumulated_steps = 0  # measurement steps only (excluding warmup)
-        last_run = 0
         step_files = {}  # {step: (input, output, run_id)}
-        _prev_run_steps = None  # tracks the step count of the last completed run
-        _did_reestimate_from_fetched = False
+        last_run = 0
+        first_new_run = self.max_continuation + 1  # assume all done
+
+        # ── Phase A: scan existing runs ──
         for i in range(1, self.max_continuation + 1):
-            # Skip input generation if this step already has a job record
             recorded = get_job_by_step(_wd, i)
             status = recorded.get("status")
             if status == "fetched":
-                logger.info(f"  step {i}: already fetched. Skipping.")
                 step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
-                accumulated_steps += estimated_steps - warmup
-                _prev_run_steps = estimated_steps
+                logger.info(f"  step {i}: already fetched. Skipping.")
                 last_run = i
-                continue
-            elif status in ("submitted", "completed"):
+            else:
+                first_new_run = i
+                break
+
+        # ── Phase B: re-estimate from accumulated data ──
+        accumulated_measurement = 0  # measurement steps only (excl. warmup)
+        if first_new_run > 1:
+            cached_accum = estimation.get("accumulated_measurement_steps")
+            if cached_accum is not None:
+                accumulated_measurement = int(cached_accum)
+            else:
+                accumulated_measurement = (first_new_run - 1) * max(estimated_steps - warmup, 0)
+
+            _re_chk = self._find_restart_chk(_wd)
+            if _re_chk:
+                _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
+                if _re_energy is not None and _re_error is not None:
+                    if _re_error <= self.target_error * 1.05:
+                        logger.info(
+                            f"  Target already met after prior runs: {_re_error:.6g} <= {self.target_error * 1.05:.6g} Ha"
+                        )
+                        self.output_values.update(
+                            energy=_re_energy,
+                            energy_error=_re_error,
+                            restart_chk=_re_chk,
+                        )
+                        if self.atomic_force:
+                            forces = self._compute_force(_re_chk, work_dir=_wd)
+                            if forces is not None:
+                                self.output_values["forces"] = forces
+                        first_new_run = self.max_continuation + 1  # skip loop
+                    else:
+                        _additional = estimate_additional_steps(
+                            accumulated_measurement,
+                            _re_error,
+                            self.target_error,
+                        )
+                        estimated_steps = _additional + warmup
+                        logger.info(
+                            f"  Resuming after {first_new_run - 1} prior run(s): "
+                            f"error={_re_error:.6g} Ha > target "
+                            f"{self.target_error:.6g} Ha -> "
+                            f"{estimated_steps} steps "
+                            f"(measurement: {_additional}, warmup: {warmup}, "
+                            f"accumulated measurement: {accumulated_measurement})"
+                        )
+
+        # ── Phase C: production loop ──
+        _prev_run_steps = None
+        for i in range(first_new_run, self.max_continuation + 1):
+            recorded = get_job_by_step(_wd, i)
+            status = recorded.get("status")
+
+            if status in ("submitted", "completed"):
                 input_i = recorded["input_file"]
                 output_i = recorded["output_file"]
                 run_id_i = recorded.get("run_id", "")
                 logger.info(f"  step {i}: already {status}. Resuming...")
             else:
-                # ── Re-estimate if resuming after fetched runs ────
-                if accumulated_steps > 0 and not _did_reestimate_from_fetched:
-                    _did_reestimate_from_fetched = True
-                    _re_chk = self._find_restart_chk(_wd)
-                    if _re_chk:
-                        _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
-                        if _re_energy is not None and _re_error is not None:
-                            if _re_error <= self.target_error * 1.05:
-                                logger.info(
-                                    f"  Target already met after fetched runs: "
-                                    f"{_re_error:.6g} <= {self.target_error * 1.05:.6g} Ha"
-                                )
-                                self.output_values.update(
-                                    energy=_re_energy,
-                                    energy_error=_re_error,
-                                    restart_chk=_re_chk,
-                                )
-                                if self.atomic_force:
-                                    forces = self._compute_force(_re_chk, work_dir=_wd)
-                                    if forces is not None:
-                                        self.output_values["forces"] = forces
-                                break
-                            _additional = estimate_additional_steps(
-                                accumulated_steps,
-                                _re_error,
-                                self.target_error,
-                            )
-                            estimated_steps = _additional + warmup
-                            logger.info(
-                                f"  Re-estimated from accumulated data: "
-                                f"error={_re_error:.6g} Ha > target "
-                                f"{self.target_error:.6g} Ha -> "
-                                f"{estimated_steps} steps "
-                                f"(measurement: {_additional}, warmup: {warmup}, "
-                                f"accumulated measurement: {accumulated_steps})"
-                            )
-
                 run_id_i = self._new_run_id()
                 input_i = self._input_filename(i, run_id_i)
                 output_i = self._output_filename(i, run_id_i)
-                if i == 1:
-                    # First production run: start from scratch
+                # First-ever production run starts fresh; all others restart
+                if i == 1 and first_new_run == 1:
                     self._generate_input(estimated_steps, os.path.join(_wd, input_i))
                 else:
                     restart_chk = self._find_restart_chk(_wd)
                     if restart_chk is None:
-                        raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
+                        raise RuntimeError(f"No restart checkpoint found for run {i}. Expected .h5 file in {_wd}")
                     self._generate_input(
                         estimated_steps,
                         os.path.join(_wd, input_i),
-                        restart=bool(restart_chk),
+                        restart=True,
                         restart_chk=restart_chk,
                     )
                 logger.info("")
                 logger.info(f"-- MCMC Phase 1: Production run {i}/{self.max_continuation} " + "-" * 10)
                 logger.info(f"  {input_i}: {estimated_steps} steps")
 
-            restart_chk = self._find_restart_chk(_wd) if i > 1 else None
-            if i > 1 and restart_chk is None:
-                raise RuntimeError(f"No restart checkpoint found for continuation run {i}. Expected .h5 file in {_wd}")
+            need_restart = i > 1 or first_new_run > 1
+            restart_chk = self._find_restart_chk(_wd) if need_restart else None
+            if need_restart and restart_chk is None:
+                raise RuntimeError(f"No restart checkpoint found for run {i}. Expected .h5 file in {_wd}")
             extra_from = [restart_chk] if restart_chk else []
 
             # Estimate run time from the latest available output
@@ -702,7 +722,6 @@ class MCMC_Workflow(Workflow):
                     logger.info(f"  est. Net run time (w/o JAX compilation) = {_format_duration(_est_sec)}")
                     break
             else:
-                # First production run: use pilot output
                 _pilot_outs = sorted(glob.glob(os.path.join(_wd, "_pilot", "*.out")))
                 _ref_net = parse_net_time(_pilot_outs[-1]) if _pilot_outs else None
                 if _ref_net and _ref_net > 0:
@@ -721,11 +740,11 @@ class MCMC_Workflow(Workflow):
                 run_id=run_id_i,
             )
             step_files[i] = (input_i, output_i, run_id_i)
-            accumulated_steps += estimated_steps - warmup
+            accumulated_measurement += estimated_steps - warmup
             _prev_run_steps = estimated_steps
             last_run = i
 
-            # Check convergence
+            # ── Convergence check (single estimation point) ──
             restart_chk = self._find_restart_chk(_wd)
             if restart_chk:
                 energy, error = self._compute_energy(restart_chk, work_dir=_wd, output_file=output_i)
@@ -739,11 +758,11 @@ class MCMC_Workflow(Workflow):
                         if forces is not None:
                             self.output_values["forces"] = forces
 
-                    # Cache for restart
                     set_estimation(
                         _wd,
                         last_energy=energy,
                         last_energy_error=error,
+                        accumulated_measurement_steps=accumulated_measurement,
                         last_num_mcmc_bin_blocks=self.num_mcmc_bin_blocks,
                         last_num_mcmc_warmup_steps=self.num_mcmc_warmup_steps,
                     )
@@ -758,7 +777,7 @@ class MCMC_Workflow(Workflow):
                     elif i < self.max_continuation:
                         old_steps = estimated_steps
                         _additional = estimate_additional_steps(
-                            accumulated_steps,
+                            accumulated_measurement,
                             error,
                             self.target_error,
                         )
@@ -766,17 +785,16 @@ class MCMC_Workflow(Workflow):
                         logger.info(
                             f"  Re-estimated: {old_steps} -> {estimated_steps} steps "
                             f"(measurement: {_additional}, warmup: {warmup}, "
-                            f"accumulated measurement: {accumulated_steps})"
+                            f"accumulated measurement: {accumulated_measurement})"
                         )
                     else:
-                        msg = (
+                        logger.warning(
                             f"Error {error:.6g} > target "
                             f"{self.target_error:.6g} Ha -- "
                             f"max_continuation ({self.max_continuation}) reached"
                         )
-                        logger.warning(msg)
 
-        # ── Final energy computation ─────────────────────────────
+        # ── Final energy computation (safety net) ─────────────────
         last_output = step_files[last_run][1] if last_run in step_files else None
         restart_chk = self._find_restart_chk(_wd)
         if restart_chk:
@@ -793,6 +811,7 @@ class MCMC_Workflow(Workflow):
                     _wd,
                     last_energy=energy,
                     last_energy_error=error,
+                    accumulated_measurement_steps=accumulated_measurement,
                     last_num_mcmc_bin_blocks=self.num_mcmc_bin_blocks,
                     last_num_mcmc_warmup_steps=self.num_mcmc_warmup_steps,
                 )

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -56,6 +56,7 @@ from ._input_generator import generate_input_toml, resolve_with_defaults
 from ._job import get_num_mpi, load_queue_data
 from ._output_parser import parse_force_table
 from ._state import get_estimation, get_job, set_estimation
+from ._state import WorkflowStatus
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -299,9 +300,24 @@ class MCMC_Workflow(Workflow):
     # ── Submit / poll / fetch ─────────────────────────────────────
     # _submit_and_wait() and _make_job() are inherited from Workflow.
 
-    # ── Launch ────────────────────────────────────────────────────
+    # ── configure / run ──────────────────────────────────────────
 
-    async def async_launch(self):
+    def configure(self) -> dict:
+        """Validate parameters and return configuration summary."""
+        mode = "fixed" if self.num_mcmc_steps is not None else "auto"
+        return {
+            "input_file": self.input_file,
+            "target_error": self.target_error,
+            "mode": mode,
+            "hamiltonian_file": self.hamiltonian_file,
+            "server_machine": self.server_machine_name,
+            "number_of_walkers": self.number_of_walkers,
+            "max_time": self.max_time,
+            "pilot_steps": self.pilot_steps,
+            "max_continuation": self.max_continuation,
+        }
+
+    async def run(self) -> tuple:
         """Run the MCMC workflow.
 
         **Fixed-step mode** (``num_mcmc_steps`` is set):
@@ -429,7 +445,7 @@ class MCMC_Workflow(Workflow):
         self.output_files = chk_files + output_logs
         self.output_values["num_mcmc_steps"] = estimated_steps
 
-        self.status = "success"
+        self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     async def _launch_auto(self, _wd):
@@ -578,7 +594,7 @@ class MCMC_Workflow(Workflow):
                     if forces is not None:
                         self.output_values["forces"] = forces
                 self.output_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-                self.status = "success"
+                self.status = WorkflowStatus.COMPLETED
                 return self.status, self.output_files, self.output_values
 
         # ── Production runs (phase 1..N) ──────────────────────────
@@ -702,7 +718,7 @@ class MCMC_Workflow(Workflow):
                             f"max_continuation ({self.max_continuation}) reached"
                         )
                         logger.error(msg)
-                        self.status = "failed"
+                        self.status = WorkflowStatus.FAILED
 
         # ── Final energy computation ─────────────────────────────
         last_output = suffixed_name(self.output_file, last_run) if last_run > 0 else None
@@ -735,7 +751,7 @@ class MCMC_Workflow(Workflow):
         self.output_files = chk_files + output_logs
         self.output_values["estimated_steps"] = estimated_steps
 
-        self.status = self.status or "success"
+        self.status = self.status or WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -609,6 +609,7 @@ class MCMC_Workflow(Workflow):
         last_run = 0
         step_files = {}  # {step: (input, output, run_id)}
         _prev_run_steps = None  # tracks the step count of the last completed run
+        _did_reestimate_from_fetched = False
         for i in range(1, self.max_continuation + 1):
             # Skip input generation if this step already has a job record
             recorded = get_job_by_step(_wd, i)
@@ -626,6 +627,41 @@ class MCMC_Workflow(Workflow):
                 run_id_i = recorded.get("run_id", "")
                 logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                # ── Re-estimate if resuming after fetched runs ────
+                if accumulated_steps > 0 and not _did_reestimate_from_fetched:
+                    _did_reestimate_from_fetched = True
+                    _re_chk = self._find_restart_chk(_wd)
+                    if _re_chk:
+                        _re_energy, _re_error = self._compute_energy(_re_chk, work_dir=_wd)
+                        if _re_energy is not None and _re_error is not None:
+                            if _re_error <= self.target_error * 1.05:
+                                logger.info(
+                                    f"  Target already met after fetched runs: "
+                                    f"{_re_error:.6g} <= {self.target_error * 1.05:.6g} Ha"
+                                )
+                                self.output_values.update(
+                                    energy=_re_energy,
+                                    energy_error=_re_error,
+                                    restart_chk=_re_chk,
+                                )
+                                if self.atomic_force:
+                                    forces = self._compute_force(_re_chk, work_dir=_wd)
+                                    if forces is not None:
+                                        self.output_values["forces"] = forces
+                                break
+                            estimated_steps = estimate_additional_steps(
+                                accumulated_steps,
+                                _re_error,
+                                self.target_error,
+                            )
+                            logger.info(
+                                f"  Re-estimated from accumulated data: "
+                                f"error={_re_error:.6g} Ha > target "
+                                f"{self.target_error:.6g} Ha -> "
+                                f"{estimated_steps} additional steps "
+                                f"(accumulated: {accumulated_steps})"
+                            )
+
                 run_id_i = self._new_run_id()
                 input_i = self._input_filename(i, run_id_i)
                 output_i = self._output_filename(i, run_id_i)

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -702,6 +702,7 @@ class VMC_Workflow(Workflow):
         last_run = 0
         step_files = {}  # {step: (input, output, run_id)}
         _checked_fetched_convergence = False
+        converged = converged_snr = converged_slope = None
         for i in range(1, self.max_continuation + 1):
             # Skip input generation if this step already has a job record
             recorded = get_job_by_step(_wd, i)
@@ -720,12 +721,12 @@ class VMC_Workflow(Workflow):
                 # ── Re-evaluate convergence from fetched runs ─────
                 if _has_convergence_criteria and last_run > 0 and not _checked_fetched_convergence:
                     _checked_fetched_convergence = True
-                    _conv, _, _ = self._check_convergence(
+                    converged, converged_snr, converged_slope = self._check_convergence(
                         _wd,
                         step_files,
                         last_run,
                     )
-                    if _conv:
+                    if converged:
                         logger.info(f"  Convergence already met after fetched runs (step {last_run}). No further runs needed.")
                         break
 
@@ -785,17 +786,18 @@ class VMC_Workflow(Workflow):
             await self._submit_and_wait(input_i, output_i, work_dir=_wd, extra_from_objects=extra_from, step=i, run_id=run_id_i)
             step_files[i] = (input_i, output_i, run_id_i)
             last_run = i
+            converged = converged_snr = converged_slope = None
 
             logger.info(f"  VMC production run {i}/{self.max_continuation} completed.")
 
             # ── Early exit if convergence criteria met ────────────
             if _has_convergence_criteria and i < self.max_continuation:
-                _conv, _, _ = self._check_convergence(
+                converged, converged_snr, converged_slope = self._check_convergence(
                     _wd,
                     step_files,
                     last_run,
                 )
-                if _conv:
+                if converged:
                     logger.info(f"  Convergence achieved at run {i}/{self.max_continuation}. Stopping early.")
                     break
 
@@ -818,11 +820,12 @@ class VMC_Workflow(Workflow):
             self._parse_output(last_output)
 
         # ── Final convergence check ───────────────────────────────
-        converged, converged_snr, converged_slope = self._check_convergence(
-            _wd,
-            step_files,
-            last_run,
-        )
+        if converged is None:
+            converged, converged_snr, converged_slope = self._check_convergence(
+                _wd,
+                step_files,
+                last_run,
+            )
         if not _has_convergence_criteria:
             logger.info("  No convergence criteria set; treating as converged.")
         elif converged:

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -48,12 +48,10 @@ from ._error_estimator import (
     _format_duration,
     estimate_required_steps,
     parse_net_time,
-    suffixed_name,
 )
 from ._input_generator import generate_input_toml, resolve_with_defaults
 from ._job import get_num_mpi, load_queue_data
-from ._state import get_estimation, get_job, set_estimation
-from ._state import WorkflowStatus
+from ._state import WorkflowStatus, get_estimation, get_job_by_step, set_estimation
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -235,8 +233,6 @@ class VMC_Workflow(Workflow):
         server_machine_name: str = "localhost",
         num_opt_steps: int = 20,
         hamiltonian_file: str = "hamiltonian_data.h5",
-        input_file: str = "input.toml",
-        output_file: str = "out.o",
         queue_label: str = "default",
         jobname: str = "jqmc-vmc",
         number_of_walkers: int = 4,
@@ -277,8 +273,6 @@ class VMC_Workflow(Workflow):
         self.server_machine_name = server_machine_name
         self.num_opt_steps = num_opt_steps
         self.hamiltonian_file = hamiltonian_file
-        self.input_file = input_file
-        self.output_file = output_file
         self.queue_label = queue_label
         self.jobname = jobname
         self.number_of_walkers = number_of_walkers
@@ -394,7 +388,7 @@ class VMC_Workflow(Workflow):
         """Validate parameters and return configuration summary."""
         mode = "fixed" if self.num_mcmc_steps is not None else "auto"
         return {
-            "input_file": self.input_file,
+            "jobname": self.jobname,
             "num_opt_steps": self.num_opt_steps,
             "num_mcmc_steps": self.num_mcmc_steps,
             "target_error": self.target_error,
@@ -450,18 +444,24 @@ class VMC_Workflow(Workflow):
         )
 
         last_run = 0
+        step_files = {}  # {step: (input, output, run_id)}
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
-
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    last_run = i
-                    continue
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            recorded = get_job_by_step(_wd, i)
+            status = recorded.get("status")
+            if status == "fetched":
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                last_run = i
+                continue
+            elif status in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     self._generate_input(
                         estimated_mcmc_steps,
@@ -493,18 +493,17 @@ class VMC_Workflow(Workflow):
                 output_i,
                 work_dir=_wd,
                 extra_from_objects=extra_from,
+                step=i,
+                run_id=run_id_i,
             )
+            step_files[i] = (input_i, output_i, run_id_i)
             last_run = i
 
             logger.info(f"  VMC production run {i}/{self.max_continuation} completed.")
 
         # ── Collect outputs ───────────────────────────────────────
         h5_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = h5_files + output_logs
 
         opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")))
@@ -516,8 +515,9 @@ class VMC_Workflow(Workflow):
         self.output_values["num_mcmc_steps"] = estimated_mcmc_steps
 
         # Parse last production output for energy
-        last_output = os.path.join(_wd, suffixed_name(self.output_file, last_run))
-        self._parse_output(last_output)
+        if last_run in step_files:
+            last_output = os.path.join(_wd, step_files[last_run][1])
+            self._parse_output(last_output)
 
         self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
@@ -544,18 +544,25 @@ class VMC_Workflow(Workflow):
             if os.path.isfile(h5_src) and not os.path.exists(h5_dst):
                 os.symlink(h5_src, h5_dst)
 
-            input_0 = suffixed_name(self.input_file, 0)
-            output_0 = suffixed_name(self.output_file, 0)
-
-            recorded_0 = get_job(pilot_dir, input_0)
-            if recorded_0.get("status") not in ("submitted", "completed", "fetched"):
+            recorded_0 = get_job_by_step(pilot_dir, 0)
+            status_0 = recorded_0.get("status")
+            if status_0 in ("fetched", "submitted", "completed"):
+                input_0 = recorded_0["input_file"]
+                output_0 = recorded_0["output_file"]
+                run_id_0 = recorded_0.get("run_id", "")
+                if status_0 == "fetched":
+                    logger.info(f"  {input_0}: already fetched. Skipping pilot.")
+                else:
+                    logger.info(f"  {input_0}: already {status_0}. Resuming...")
+            else:
+                run_id_0 = self._new_run_id()
+                input_0 = self._input_filename(0, run_id_0)
+                output_0 = self._output_filename(0, run_id_0)
                 self._generate_input(
                     self.pilot_mcmc_steps,
                     self.pilot_vmc_steps,
                     os.path.join(pilot_dir, input_0),
                 )
-            else:
-                logger.info(f"  {input_0}: already {recorded_0['status']}. Resuming...")
             logger.info("")
             logger.info("-- VMC Phase 0: Pilot " + "-" * 28)
             logger.info(
@@ -563,7 +570,9 @@ class VMC_Workflow(Workflow):
             )
 
             pilot_t0 = time.monotonic()
-            await self._submit_and_wait(input_0, output_0, work_dir=pilot_dir, queue_label=self.pilot_queue_label)
+            await self._submit_and_wait(
+                input_0, output_0, work_dir=pilot_dir, queue_label=self.pilot_queue_label, step=0, run_id=run_id_0
+            )
             pilot_wall_sec = time.monotonic() - pilot_t0
 
             # Parse the last optimization step's error from pilot output
@@ -644,20 +653,25 @@ class VMC_Workflow(Workflow):
 
         # ── Production runs (phase 1..N) ──────────────────────────
         last_run = 0
+        step_files = {}  # {step: (input, output, run_id)}
         for i in range(1, self.max_continuation + 1):
-            input_i = suffixed_name(self.input_file, i)
-            output_i = suffixed_name(self.output_file, i)
-
             # Skip input generation if this step already has a job record
-            recorded = get_job(_wd, input_i)
-            if recorded.get("status") in ("submitted", "completed", "fetched"):
-                if recorded["status"] == "fetched":
-                    logger.info(f"  {input_i}: already fetched. Skipping.")
-                    last_run = i
-                    continue
-                # submitted or completed -- let _submit_and_wait handle resume
-                logger.info(f"  {input_i}: already {recorded['status']}. Resuming...")
+            recorded = get_job_by_step(_wd, i)
+            status = recorded.get("status")
+            if status == "fetched":
+                logger.info(f"  step {i}: already fetched. Skipping.")
+                step_files[i] = (recorded["input_file"], recorded["output_file"], recorded.get("run_id", ""))
+                last_run = i
+                continue
+            elif status in ("submitted", "completed"):
+                input_i = recorded["input_file"]
+                output_i = recorded["output_file"]
+                run_id_i = recorded.get("run_id", "")
+                logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                run_id_i = self._new_run_id()
+                input_i = self._input_filename(i, run_id_i)
+                output_i = self._output_filename(i, run_id_i)
                 if i == 1:
                     self._generate_input(
                         estimated_mcmc_steps,
@@ -688,15 +702,17 @@ class VMC_Workflow(Workflow):
             _prod_cost = self.num_opt_steps * estimated_mcmc_steps
             _ref_net = None
             for _j in range(i - 1, 0, -1):
-                _ref_net = parse_net_time(os.path.join(_wd, suffixed_name(self.output_file, _j)))
+                if _j not in step_files:
+                    continue
+                _ref_net = parse_net_time(os.path.join(_wd, step_files[_j][1]))
                 if _ref_net and _ref_net > 0:
                     # All production runs have the same step count
                     logger.info(f"  est. Net run time (w/o JAX compilation) = {_format_duration(_ref_net)}")
                     break
             else:
                 # First production run: use pilot output
-                _pilot_out = os.path.join(_wd, "_pilot", suffixed_name(self.output_file, 0))
-                _ref_net = parse_net_time(_pilot_out)
+                _pilot_outs = sorted(glob.glob(os.path.join(_wd, "_pilot", "*.out")))
+                _ref_net = parse_net_time(_pilot_outs[-1]) if _pilot_outs else None
                 if _ref_net and _ref_net > 0:
                     _p_vmc = estimation.get("pilot_vmc_steps") or self.pilot_vmc_steps
                     _p_mcmc = estimation.get("pilot_mcmc_steps") or self.pilot_mcmc_steps
@@ -706,18 +722,15 @@ class VMC_Workflow(Workflow):
                             f"  est. Net run time (w/o JAX compilation) = {_format_duration(_ref_net * _prod_cost / _pilot_cost)}"
                         )
 
-            await self._submit_and_wait(input_i, output_i, work_dir=_wd, extra_from_objects=extra_from)
+            await self._submit_and_wait(input_i, output_i, work_dir=_wd, extra_from_objects=extra_from, step=i, run_id=run_id_i)
+            step_files[i] = (input_i, output_i, run_id_i)
             last_run = i
 
             logger.info(f"  VMC production run {i}/{self.max_continuation} completed.")
 
         # ── Collect outputs ───────────────────────────────────────
         h5_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
-        output_logs = [
-            suffixed_name(self.output_file, j)
-            for j in range(last_run + 1)
-            if os.path.isfile(os.path.join(_wd, suffixed_name(self.output_file, j)))
-        ]
+        output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = h5_files + output_logs
 
         opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")))
@@ -729,8 +742,9 @@ class VMC_Workflow(Workflow):
         self.output_values["estimated_mcmc_steps"] = estimated_mcmc_steps
 
         # Parse last production output for energy
-        last_output = os.path.join(_wd, suffixed_name(self.output_file, last_run))
-        self._parse_output(last_output)
+        if last_run in step_files:
+            last_output = os.path.join(_wd, step_files[last_run][1])
+            self._parse_output(last_output)
 
         # ── Final convergence check ───────────────────────────────
         converged_snr = True  # None means unconditional pass
@@ -740,7 +754,9 @@ class VMC_Workflow(Workflow):
         if self.target_snr is not None:
             all_snr = []
             for j in range(last_run, 0, -1):
-                out_j = os.path.join(_wd, suffixed_name(self.output_file, j))
+                if j not in step_files:
+                    continue
+                out_j = os.path.join(_wd, step_files[j][1])
                 all_snr = self._parse_all_snr(out_j) + all_snr
                 if len(all_snr) >= self.snr_avg_window:
                     break
@@ -759,7 +775,9 @@ class VMC_Workflow(Workflow):
         if self.energy_slope_sigma_threshold is not None:
             all_energies: list[tuple[float, float]] = []
             for j in range(last_run, 0, -1):
-                out_j = os.path.join(_wd, suffixed_name(self.output_file, j))
+                if j not in step_files:
+                    continue
+                out_j = os.path.join(_wd, step_files[j][1])
                 all_energies = self._parse_all_energies(out_j) + all_energies
                 if len(all_energies) >= self.energy_slope_window_size:
                     break
@@ -806,7 +824,8 @@ class VMC_Workflow(Workflow):
             logger.error(f"  {msg}")
             self.status = WorkflowStatus.FAILED
 
-        self.status = self.status or WorkflowStatus.COMPLETED
+        if self.status != WorkflowStatus.FAILED:
+            self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────
@@ -824,7 +843,7 @@ class VMC_Workflow(Workflow):
     def _parse_output(self, output_file=None):
         """Extract the last optimization energy from *output_file*."""
         if output_file is None:
-            output_file = self.output_file
+            return
         if not os.path.isfile(output_file):
             return
 

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -95,10 +95,6 @@ class VMC_Workflow(Workflow):
         Number of optimization iterations for production runs.
     hamiltonian_file : str
         Input ``hamiltonian_data.h5``.
-    input_file : str
-        Name of the generated TOML input file.
-    output_file : str
-        Name of the stdout capture file.
     queue_label : str
         Queue/partition label from ``queue_data.toml``.
     jobname : str

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -53,6 +53,7 @@ from ._error_estimator import (
 from ._input_generator import generate_input_toml, resolve_with_defaults
 from ._job import get_num_mpi, load_queue_data
 from ._state import get_estimation, get_job, set_estimation
+from ._state import WorkflowStatus
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -387,9 +388,28 @@ class VMC_Workflow(Workflow):
     # ── Submit / poll / fetch ─────────────────────────────────────
     # _submit_and_wait() and _make_job() are inherited from Workflow.
 
-    # ── Launch ────────────────────────────────────────────────────
+    # ── configure / run ──────────────────────────────────────────
 
-    async def async_launch(self):
+    def configure(self) -> dict:
+        """Validate parameters and return configuration summary."""
+        mode = "fixed" if self.num_mcmc_steps is not None else "auto"
+        return {
+            "input_file": self.input_file,
+            "num_opt_steps": self.num_opt_steps,
+            "num_mcmc_steps": self.num_mcmc_steps,
+            "target_error": self.target_error,
+            "mode": mode,
+            "hamiltonian_file": self.hamiltonian_file,
+            "server_machine": self.server_machine_name,
+            "number_of_walkers": self.number_of_walkers,
+            "max_time": self.max_time,
+            "target_snr": self.target_snr,
+            "pilot_mcmc_steps": self.pilot_mcmc_steps,
+            "pilot_vmc_steps": self.pilot_vmc_steps,
+            "max_continuation": self.max_continuation,
+        }
+
+    async def run(self) -> tuple:
         """Run the VMC optimization workflow.
 
         **Fixed-step mode** (``num_mcmc_steps`` is set):
@@ -499,7 +519,7 @@ class VMC_Workflow(Workflow):
         last_output = os.path.join(_wd, suffixed_name(self.output_file, last_run))
         self._parse_output(last_output)
 
-        self.status = "success"
+        self.status = WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     async def _launch_auto(self, _wd):
@@ -784,9 +804,9 @@ class VMC_Workflow(Workflow):
                 )
             msg = f"VMC NOT converged after {self.max_continuation} continuation run(s): {'; '.join(reasons)}"
             logger.error(f"  {msg}")
-            self.status = "failed"
+            self.status = WorkflowStatus.FAILED
 
-        self.status = self.status or "success"
+        self.status = self.status or WorkflowStatus.COMPLETED
         return self.status, self.output_files, self.output_values
 
     # ── Utility methods ───────────────────────────────────────────

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -133,6 +133,14 @@ class VMC_Workflow(Workflow):
         Minimum signal-to-noise ratio ``|f|/|std f|`` for a parameter to be
         updated.  Parameters with SN <= this threshold are frozen.  Applied
         before ``num_param_opt``.  Default from ``jqmc_miscs``.
+    opt_J3_basis_exp : bool, optional
+        Optimize J3 AO Gaussian exponents.  Default from ``jqmc_miscs``.
+    opt_J3_basis_coeff : bool, optional
+        Optimize J3 AO contraction coefficients.  Default from ``jqmc_miscs``.
+    opt_lambda_basis_exp : bool, optional
+        Optimize Geminal AO Gaussian exponents.  Default from ``jqmc_miscs``.
+    opt_lambda_basis_coeff : bool, optional
+        Optimize Geminal AO contraction coefficients.  Default from ``jqmc_miscs``.
     optimizer_kwargs : dict, optional
         Optimizer configuration dict.  Default from ``jqmc_miscs``.
     mcmc_seed : int, optional
@@ -248,6 +256,10 @@ class VMC_Workflow(Workflow):
         opt_with_projected_MOs: Optional[bool] = None,
         num_param_opt: Optional[int] = None,
         opt_filter_min_SN_ratio: Optional[float] = None,
+        opt_J3_basis_exp: Optional[bool] = None,
+        opt_J3_basis_coeff: Optional[bool] = None,
+        opt_lambda_basis_exp: Optional[bool] = None,
+        opt_lambda_basis_coeff: Optional[bool] = None,
         optimizer_kwargs: Optional[dict] = None,
         # -- [control] section parameters --
         mcmc_seed: Optional[int] = None,
@@ -288,6 +300,10 @@ class VMC_Workflow(Workflow):
         self.opt_with_projected_MOs = opt_with_projected_MOs
         self.num_param_opt = num_param_opt
         self.opt_filter_min_SN_ratio = opt_filter_min_SN_ratio
+        self.opt_J3_basis_exp = opt_J3_basis_exp
+        self.opt_J3_basis_coeff = opt_J3_basis_coeff
+        self.opt_lambda_basis_exp = opt_lambda_basis_exp
+        self.opt_lambda_basis_coeff = opt_lambda_basis_coeff
         self.optimizer_kwargs = optimizer_kwargs
         # [control] section
         self.mcmc_seed = mcmc_seed
@@ -362,6 +378,10 @@ class VMC_Workflow(Workflow):
                 "opt_with_projected_MOs": self.opt_with_projected_MOs,
                 "num_param_opt": self.num_param_opt,
                 "opt_filter_min_SN_ratio": self.opt_filter_min_SN_ratio,
+                "opt_J3_basis_exp": self.opt_J3_basis_exp,
+                "opt_J3_basis_coeff": self.opt_J3_basis_coeff,
+                "opt_lambda_basis_exp": self.opt_lambda_basis_exp,
+                "opt_lambda_basis_coeff": self.opt_lambda_basis_coeff,
                 "optimizer_kwargs": self.optimizer_kwargs,
             },
         )

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -217,6 +217,36 @@ class VMC_Workflow(Workflow):
             ),
         )
 
+    Output Values
+    -------------
+    After ``launch()`` completes, ``output_values`` may contain:
+
+    optimized_hamiltonian : str
+        Basename of the last optimised Hamiltonian file
+        (e.g. ``"hamiltonian_data_opt_step_91.h5"``).
+        Use with ``ValueFrom("vmc", "optimized_hamiltonian")``
+        to pass the filename dynamically to downstream workflows.
+    checkpoint : str
+        Basename of the restart checkpoint file.
+    num_mcmc_steps : int
+        Estimated MCMC steps per optimisation step
+        (automatic mode).  In fixed-step mode this key is
+        ``estimated_mcmc_steps`` instead.
+    energy : float
+        Energy from the last optimisation step (Ha).
+    energy_error : float
+        Statistical error on ``energy`` (Ha).
+    signal_to_noise : float
+        Average signal-to-noise ratio over the trailing window
+        (only when force-convergence is enabled).
+    signal_to_noise_last : float
+        Signal-to-noise ratio of the last optimisation step.
+    energy_slope : float
+        Slope of energy vs. step from the trailing window
+        (only when ``energy_slope_sigma_threshold`` is set).
+    energy_slope_std : float
+        Standard deviation of the energy slope.
+
     Notes
     -----
     * The pilot uses a small number of opt steps (``pilot_vmc_steps``)

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -668,8 +668,10 @@ class VMC_Workflow(Workflow):
             )
 
         # ── Production runs (phase 1..N) ──────────────────────────
+        _has_convergence_criteria = self.target_snr is not None or self.energy_slope_sigma_threshold is not None
         last_run = 0
         step_files = {}  # {step: (input, output, run_id)}
+        _checked_fetched_convergence = False
         for i in range(1, self.max_continuation + 1):
             # Skip input generation if this step already has a job record
             recorded = get_job_by_step(_wd, i)
@@ -685,6 +687,18 @@ class VMC_Workflow(Workflow):
                 run_id_i = recorded.get("run_id", "")
                 logger.info(f"  step {i}: already {status}. Resuming...")
             else:
+                # ── Re-evaluate convergence from fetched runs ─────
+                if _has_convergence_criteria and last_run > 0 and not _checked_fetched_convergence:
+                    _checked_fetched_convergence = True
+                    _conv, _, _ = self._check_convergence(
+                        _wd,
+                        step_files,
+                        last_run,
+                    )
+                    if _conv:
+                        logger.info(f"  Convergence already met after fetched runs (step {last_run}). No further runs needed.")
+                        break
+
                 run_id_i = self._new_run_id()
                 input_i = self._input_filename(i, run_id_i)
                 output_i = self._output_filename(i, run_id_i)
@@ -744,6 +758,17 @@ class VMC_Workflow(Workflow):
 
             logger.info(f"  VMC production run {i}/{self.max_continuation} completed.")
 
+            # ── Early exit if convergence criteria met ────────────
+            if _has_convergence_criteria and i < self.max_continuation:
+                _conv, _, _ = self._check_convergence(
+                    _wd,
+                    step_files,
+                    last_run,
+                )
+                if _conv:
+                    logger.info(f"  Convergence achieved at run {i}/{self.max_continuation}. Stopping early.")
+                    break
+
         # ── Collect outputs ───────────────────────────────────────
         h5_files = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.h5")))
         output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
@@ -763,8 +788,46 @@ class VMC_Workflow(Workflow):
             self._parse_output(last_output)
 
         # ── Final convergence check ───────────────────────────────
-        converged_snr = True  # None means unconditional pass
-        converged_slope = True  # None means unconditional pass
+        converged, converged_snr, converged_slope = self._check_convergence(
+            _wd,
+            step_files,
+            last_run,
+        )
+        if not _has_convergence_criteria:
+            logger.info("  No convergence criteria set; treating as converged.")
+        elif converged:
+            logger.info("  VMC converged (all active checks passed).")
+        else:
+            reasons = []
+            if not converged_snr:
+                reasons.append(f"S/N ({self.output_values.get('signal_to_noise', '?'):.3f}) > target ({self.target_snr})")
+            if not converged_slope:
+                reasons.append(
+                    f"energy slope ({self.output_values.get('energy_slope', '?'):.6f} Ha/step) still significantly negative"
+                )
+            msg = f"VMC NOT converged after {self.max_continuation} continuation run(s): {'; '.join(reasons)}"
+            logger.error(f"  {msg}")
+            self.status = WorkflowStatus.FAILED
+
+        if self.status != WorkflowStatus.FAILED:
+            self.status = WorkflowStatus.COMPLETED
+        return self.status, self.output_files, self.output_values
+
+    # ── Utility methods ───────────────────────────────────────────
+
+    def _check_convergence(
+        self,
+        work_dir: str,
+        step_files: dict,
+        last_run: int,
+    ) -> tuple:
+        """Evaluate SNR and energy-slope convergence criteria.
+
+        Returns ``(converged, converged_snr, converged_slope)`` where
+        each flag is *True* when the criterion is met or not active.
+        """
+        converged_snr = True
+        converged_slope = True
 
         # ── (A) SNR check ──
         if self.target_snr is not None:
@@ -772,7 +835,7 @@ class VMC_Workflow(Workflow):
             for j in range(last_run, 0, -1):
                 if j not in step_files:
                     continue
-                out_j = os.path.join(_wd, step_files[j][1])
+                out_j = os.path.join(work_dir, step_files[j][1])
                 all_snr = self._parse_all_snr(out_j) + all_snr
                 if len(all_snr) >= self.snr_avg_window:
                     break
@@ -793,7 +856,7 @@ class VMC_Workflow(Workflow):
             for j in range(last_run, 0, -1):
                 if j not in step_files:
                     continue
-                out_j = os.path.join(_wd, step_files[j][1])
+                out_j = os.path.join(work_dir, step_files[j][1])
                 all_energies = self._parse_all_energies(out_j) + all_energies
                 if len(all_energies) >= self.energy_slope_window_size:
                     break
@@ -805,9 +868,7 @@ class VMC_Workflow(Workflow):
                 slope, slope_std = self._fit_energy_slope(energies, errors)
                 self.output_values["energy_slope"] = slope
                 self.output_values["energy_slope_std"] = slope_std
-                logger.info(f"  Energy slope over last {len(window_e)} step(s): {slope:.6f} ± {slope_std:.6f} Ha/step")
-                # slope < -slope_std * threshold  ⇒ still decreasing (not converged)
-                # slope >= -slope_std * threshold ⇒ plateau (converged)
+                logger.info(f"  Energy slope over last {len(window_e)} step(s): {slope:.6f} \u00b1 {slope_std:.6f} Ha/step")
                 converged_slope = slope >= -slope_std * self.energy_slope_sigma_threshold
                 if converged_slope:
                     logger.info(
@@ -823,28 +884,8 @@ class VMC_Workflow(Workflow):
                 converged_slope = False
                 logger.warning(f"  Not enough energy data for slope check ({len(window_e)} < 2 steps).")
 
-        # ── (C) Combined verdict ──
-        if self.target_snr is None and self.energy_slope_sigma_threshold is None:
-            logger.info("  No convergence criteria set; treating as converged.")
-        elif converged_snr and converged_slope:
-            logger.info("  VMC converged (all active checks passed).")
-        else:
-            reasons = []
-            if not converged_snr:
-                reasons.append(f"S/N ({self.output_values.get('signal_to_noise', '?'):.3f}) > target ({self.target_snr})")
-            if not converged_slope:
-                reasons.append(
-                    f"energy slope ({self.output_values.get('energy_slope', '?'):.6f} Ha/step) still significantly negative"
-                )
-            msg = f"VMC NOT converged after {self.max_continuation} continuation run(s): {'; '.join(reasons)}"
-            logger.error(f"  {msg}")
-            self.status = WorkflowStatus.FAILED
-
-        if self.status != WorkflowStatus.FAILED:
-            self.status = WorkflowStatus.COMPLETED
-        return self.status, self.output_files, self.output_values
-
-    # ── Utility methods ───────────────────────────────────────────
+        converged = converged_snr and converged_slope
+        return converged, converged_snr, converged_slope
 
     def _find_restart_chk(self, work_dir: str) -> Optional[str]:
         """Locate a VMC restart checkpoint file in *work_dir*."""

--- a/jqmc_workflow/wf_workflow.py
+++ b/jqmc_workflow/wf_workflow.py
@@ -45,6 +45,7 @@ import subprocess
 from logging import getLogger
 from typing import List, Optional
 
+from ._state import WorkflowStatus
 from .workflow import Workflow
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -160,7 +161,19 @@ class WF_Workflow(Workflow):
 
         return shlex.join(cmd)
 
-    async def async_launch(self):
+    def configure(self) -> dict:
+        """Validate parameters and return configuration summary."""
+        return {
+            "trexio_file": self.trexio_file,
+            "hamiltonian_file": self.hamiltonian_file,
+            "j1_parameter": self.j1_parameter,
+            "j1_type": self.j1_type,
+            "j2_parameter": self.j2_parameter,
+            "j2_type": self.j2_type,
+            "j3_basis_type": self.j3_basis_type,
+        }
+
+    async def run(self) -> tuple:
         """Run the TREXIO→hamiltonian conversion (locally).
 
         Returns
@@ -188,15 +201,15 @@ class WF_Workflow(Workflow):
                 logger.warning(f"stderr: {result.stderr}")
         except subprocess.CalledProcessError as e:
             logger.error(f"Command failed (rc={e.returncode}): {e.stderr}")
-            self.status = "failed"
+            self.status = WorkflowStatus.FAILED
             return self.status, [], {}
 
         if not os.path.isfile(os.path.join(_wd, self.hamiltonian_file)):
             logger.error(f"Output file not found: {self.hamiltonian_file}")
-            self.status = "failed"
+            self.status = WorkflowStatus.FAILED
             return self.status, [], {}
 
-        self.status = "success"
+        self.status = WorkflowStatus.COMPLETED
         self.output_files = [self.hamiltonian_file]
         self.output_values = {"hamiltonian_file": self.hamiltonian_file}
         return self.status, self.output_files, self.output_values

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -54,8 +54,8 @@ from ._state import (
     get_job_by_step,
     get_workflow_summary,
     read_state,
+    save_job_accounting,
     set_error,
-    set_job_accounting,
     update_job,
     update_status,
 )
@@ -370,32 +370,20 @@ class Workflow:
     # set those attributes.
 
     @staticmethod
-    def _record_job_acct(job: JobSubmission, work_dir: str) -> None:
-        """Run scheduler accounting and save raw output, if configured."""
+    def _collect_job_acct(job: JobSubmission, work_dir: str, input_file: str) -> None:
+        """Run scheduler accounting, save to file, and attach to [[jobs]] record."""
         result = job.job_acct()
         if result is None:
             return
         command, stdout, stderr = result
-        set_job_accounting(
+        acct_cmd, acct_file = save_job_accounting(
             work_dir,
             command=command,
             stdout=stdout,
             stderr=stderr,
             job_id=job.job_number or "",
         )
-
-    @staticmethod
-    def _record_job_files(job: JobSubmission, work_dir: str) -> None:
-        """Record job-related file paths in workflow_state.toml."""
-        from ._state import _write, read_state
-
-        state = read_state(work_dir)
-        job_files = {"output": job.output_file}
-        if job.server_machine.queuing:
-            job_files["job_stdout"] = job.job_stdout
-            job_files["job_stderr"] = job.job_stderr
-        state["job_files"] = job_files
-        _write(work_dir, state)
+        update_job(work_dir, input_file, job_acct_command=acct_cmd, job_acct_file=acct_file)
 
     async def _submit_and_wait(
         self,
@@ -479,7 +467,7 @@ class Workflow:
                 await asyncio.sleep(self.poll_interval)
             logger.info("  Job completed.")
             update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
-            self._record_job_acct(job, work_dir)
+            self._collect_job_acct(job, work_dir, input_file)
             job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
@@ -505,10 +493,9 @@ class Workflow:
             server_machine=self.server_machine_name,
             step=step,
             run_id=run_id,
+            job_stdout=job.job_stdout if job.server_machine.queuing else "",
+            job_stderr=job.job_stderr if job.server_machine.queuing else "",
         )
-
-        # Record job file paths for MCP discoverability
-        self._record_job_files(job, work_dir)
 
         while job.jobcheck():
             logger.info(f"  Job {job_number} still running, waiting {self.poll_interval}s...")
@@ -517,8 +504,8 @@ class Workflow:
         logger.info("  Job completed.")
         update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
 
-        # Collect scheduler accounting before fetch (raw output only)
-        self._record_job_acct(job, work_dir)
+        # Collect scheduler accounting before fetch
+        self._collect_job_acct(job, work_dir, input_file)
 
         job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -433,12 +433,15 @@ class Workflow:
         if fetch_from_objects is None:
             fetch_from_objects = ["*.h5", output_file]
 
-        # Include scheduler stdout/stderr in fetch list when queuing
+        # Include scheduler stdout/stderr in fetch list when queuing.
+        # These are non-essential: warn (not error) if missing on server.
+        optional_fetch = []
         job_tmp = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
         if job_tmp.server_machine.queuing:
             for jf in (job_tmp.job_stdout, job_tmp.job_stderr):
                 if jf and jf not in fetch_from_objects:
                     fetch_from_objects.append(jf)
+                    optional_fetch.append(jf)
 
         # ── Restart detection via job history ─────────────────────
         if step is not None:
@@ -453,7 +456,9 @@ class Workflow:
         if recorded.get("status") == "completed":
             logger.info(f"  {input_file}: completed but not fetched. Fetching...")
             job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
-            job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
+            job.fetch_job(
+                from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
+            )
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
 
@@ -468,7 +473,9 @@ class Workflow:
             logger.info("  Job completed.")
             update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
             self._collect_job_acct(job, work_dir, input_file)
-            job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
+            job.fetch_job(
+                from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
+            )
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
 
@@ -507,7 +514,7 @@ class Workflow:
         # Collect scheduler accounting before fetch
         self._collect_job_acct(job, work_dir, input_file)
 
-        job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
+        job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch)
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
 
     def _make_job(self, input_file, output_file, queue_label=None, run_id=""):

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -82,18 +82,34 @@ class FileFrom:
     ----------
     label : str
         Label of the upstream workflow that produces the file.
-    filename : str
+    filename : str or ValueFrom
         Filename (basename) to pull from the upstream workflow's
-        output directory.
+        output directory.  Can be a plain string when the filename is
+        known at definition time, or a :class:`ValueFrom` for names
+        that are only determined at runtime (e.g. the optimised
+        Hamiltonian whose step number depends on convergence).
 
     Examples
     --------
-    Pass an optimised Hamiltonian from a VMC step to an MCMC step::
+    Static filename (step number known in advance)::
 
         Container(
             label="mcmc-run",
             dirname="mcmc",
             input_files=[FileFrom("vmc-opt", "hamiltonian_data_opt_step_9.h5")],
+            rename_input_files=["hamiltonian_data.h5"],
+            workflow=MCMC_Workflow(...),
+        )
+
+    Dynamic filename (resolved from upstream ``output_values``)::
+
+        Container(
+            label="mcmc-run",
+            dirname="mcmc",
+            input_files=[
+                FileFrom("vmc-opt",
+                         ValueFrom("vmc-opt", "optimized_hamiltonian")),
+            ],
             rename_input_files=["hamiltonian_data.h5"],
             workflow=MCMC_Workflow(...),
         )
@@ -104,7 +120,7 @@ class FileFrom:
     Launcher  : Resolves ``FileFrom`` / ``ValueFrom`` at launch time.
     """
 
-    def __init__(self, label: str, filename: str):
+    def __init__(self, label: str, filename):
         self.label = label
         self.filename = filename
 
@@ -125,6 +141,17 @@ class ValueFrom:
         Label of the upstream workflow that produces the value.
     key : str
         Key name in the upstream workflow's ``output_values`` dict.
+        See the *Output Values* section of each workflow class for
+        available keys:
+
+        * :class:`VMC_Workflow` — ``optimized_hamiltonian``,
+          ``energy``, ``energy_error``, ``checkpoint``, …
+        * :class:`MCMC_Workflow` — ``energy``, ``energy_error``,
+          ``restart_chk``, ``forces``, …
+        * :class:`LRDMC_Workflow` — ``energy``, ``energy_error``,
+          ``alat``, ``restart_chk``, ``forces``, …
+        * :class:`LRDMC_Ext_Workflow` — ``extrapolated_energy``,
+          ``extrapolated_energy_error``, ``per_alat_results``, …
 
     Examples
     --------
@@ -134,6 +161,10 @@ class ValueFrom:
             trial_energy=ValueFrom("mcmc-run", "energy"),
             ...
         )
+
+    Pass the VMC-optimised Hamiltonian dynamically via ``FileFrom``::
+
+        FileFrom("vmc-opt", ValueFrom("vmc-opt", "optimized_hamiltonian"))
 
     See Also
     --------

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -670,7 +670,8 @@ class Container:
             return
 
         if os.path.isdir(self.project_dir):
-            logger.info(f"[{self.label}] Project dir exists, skipping file copy.")
+            logger.info(f"[{self.label}] Project dir exists, ensuring input files are present.")
+            self._ensure_input_files()
         else:
             logger.info(f"[{self.label}] Creating project dir: {self.project_dir}")
             os.makedirs(self.project_dir, exist_ok=False)
@@ -684,6 +685,18 @@ class Container:
             status="pending",
         )
 
+    @staticmethod
+    def _dst_basename(src: str, rename_list: list, index: int) -> str:
+        """Compute the destination basename for the *index*-th input file.
+
+        If *rename_list* has a non-``None`` entry at *index*, that value
+        is used as the destination name; otherwise the source basename
+        is preserved.
+        """
+        if index < len(rename_list) and rename_list[index] is not None:
+            return os.path.basename(str(rename_list[index]))
+        return os.path.basename(src)
+
     def _copy_input_files(self):
         """Copy input files into the project directory.
 
@@ -692,17 +705,12 @@ class Container:
         FileNotFoundError
             If a required input file or directory does not exist.
         """
-        rename = len(self.rename_input_files) > 0 and len(self.rename_input_files) == len(self.input_files)
-
         for i, src in enumerate(self.input_files):
             src = str(src)  # resolve pathlib objects
             # Resolve relative paths against root_dir
             if not os.path.isabs(src):
                 src = os.path.join(self.root_dir, src)
-            if rename:
-                dst_name = os.path.basename(str(self.rename_input_files[i]))
-            else:
-                dst_name = os.path.basename(src)
+            dst_name = self._dst_basename(src, self.rename_input_files, i)
 
             dst = os.path.join(self.project_dir, dst_name)
 
@@ -715,18 +723,78 @@ class Container:
             else:
                 raise FileNotFoundError(f"[{self.label}] Required input not found: {src}")
 
-    def _compute_input_fingerprints(self) -> dict[str, dict]:
-        """Return ``{basename: {sha256: hex_digest}}`` for each resolved input file."""
-        fingerprints: dict[str, dict] = {}
-        rename = len(self.rename_input_files) > 0 and len(self.rename_input_files) == len(self.input_files)
+    def _ensure_input_files(self):
+        """Copy any missing input files into an existing project directory.
+
+        Unlike :meth:`_copy_input_files`, this does *not* overwrite files
+        that already exist in the project directory — it only fills in
+        the gaps (e.g. after a failed first run that created the
+        directory but never completed the copy).
+        """
         for i, src in enumerate(self.input_files):
             src = str(src)
             if not os.path.isabs(src):
                 src = os.path.join(self.root_dir, src)
-            if rename:
-                key = os.path.basename(str(self.rename_input_files[i]))
+            dst_name = self._dst_basename(src, self.rename_input_files, i)
+            dst = os.path.join(self.project_dir, dst_name)
+
+            if os.path.exists(dst):
+                continue  # already present
+
+            if os.path.isfile(src):
+                shutil.copy(src, dst)
+                logger.info(f"[{self.label}] Copied missing input: {dst_name}")
+            elif os.path.isdir(src):
+                shutil.copytree(src, dst)
+                logger.info(f"[{self.label}] Copied missing input dir: {dst_name}")
             else:
-                key = os.path.basename(src)
+                raise FileNotFoundError(f"[{self.label}] Required input not found: {src}")
+
+    def _validate_input_files(self, proj: str):
+        """Verify that all files the workflow expects exist in *proj*.
+
+        Checks:
+        1. Every entry in ``self.input_files`` (after rename) exists in
+           the project directory.
+        2. If the workflow declares ``hamiltonian_file``, that file also
+           exists.
+
+        Raises
+        ------
+        FileNotFoundError
+            With a clear message listing all missing files, raised
+            *before* any job is submitted.
+        """
+        missing = []
+
+        # (1) Check resolved input_files
+        for i, src in enumerate(self.input_files):
+            dst_name = self._dst_basename(str(src), self.rename_input_files, i)
+            if not os.path.exists(os.path.join(proj, dst_name)):
+                missing.append(dst_name)
+
+        # (2) Check the workflow's hamiltonian_file (if declared)
+        h5 = getattr(self.workflow, "hamiltonian_file", None)
+        if h5 and not os.path.exists(os.path.join(proj, h5)):
+            if h5 not in missing:
+                missing.append(h5)
+
+        if missing:
+            raise FileNotFoundError(
+                f"[{self.label}] Required file(s) missing in '{self.dirname}/' "
+                f"before workflow launch: {missing}. "
+                f"Check that input_files and rename_input_files are "
+                f"configured correctly."
+            )
+
+    def _compute_input_fingerprints(self) -> dict[str, dict]:
+        """Return ``{basename: {sha256: hex_digest}}`` for each resolved input file."""
+        fingerprints: dict[str, dict] = {}
+        for i, src in enumerate(self.input_files):
+            src = str(src)
+            if not os.path.isabs(src):
+                src = os.path.join(self.root_dir, src)
+            key = self._dst_basename(src, self.rename_input_files, i)
             if os.path.exists(src):
                 h = hashlib.sha256()
                 with open(src, "rb") as f:
@@ -786,6 +854,9 @@ class Container:
             self.status = WorkflowStatus.COMPLETED
             self._collect_outputs()
             return self.status, self.output_files, self.output_values
+
+        # Validate required files before running.
+        self._validate_input_files(proj)
 
         # Run the workflow — pass project_dir explicitly instead of
         # relying on os.chdir().

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -41,7 +41,7 @@ import os
 import shutil
 import uuid
 from logging import getLogger
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from ._job import JobSubmission
 from ._phase import ScientificPhase, require_action
@@ -705,10 +705,8 @@ class Container:
             update_status(proj, WorkflowStatus.FAILED)
             raise
 
-        # Write completion — but only if the workflow actually succeeded.
-        # Workflows that return a non-success status (e.g. "failed") must
-        # NOT be marked "completed" in the state file.
-        if self.status in ("success", "completed", WorkflowStatus.COMPLETED):
+        # Write completion — but only if the workflow did not fail.
+        if self.status != WorkflowStatus.FAILED:
             result_fields = {}
             for k, v in self.output_values.items():
                 result_fields[f"result_{k}"] = v

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -413,6 +413,13 @@ class Workflow:
         if fetch_from_objects is None:
             fetch_from_objects = ["*.h5", output_file]
 
+        # Include scheduler stdout/stderr in fetch list when queuing
+        job_tmp = self._make_job(input_file, output_file, queue_label=queue_label)
+        if job_tmp.server_machine.queuing:
+            for jf in (job_tmp.job_stdout, job_tmp.job_stderr):
+                if jf and jf not in fetch_from_objects:
+                    fetch_from_objects.append(jf)
+
         # ── Restart detection via job history ─────────────────────
         recorded = get_job(work_dir, input_file)
 

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -50,12 +50,14 @@ from ._state import (
     _now_iso,
     add_job,
     create_state,
+    get_input_fingerprints,
     get_job,
     get_job_by_step,
     get_workflow_summary,
     read_state,
     save_job_accounting,
     set_error,
+    set_input_fingerprints,
     update_job,
     update_status,
 )
@@ -221,17 +223,13 @@ class Workflow:
         """Generate a short random identifier for a single job."""
         return uuid.uuid4().hex[:8]
 
-    def _filename(self, ext: str, index: int, run_id: str) -> str:
-        """Build ``{jobname}_{index}_{run_id}{ext}``."""
-        return f"{self.jobname}_{index}_{run_id}{ext}"
-
     def _input_filename(self, index: int, run_id: str) -> str:
-        """Input TOML filename for step *index*."""
-        return self._filename(".toml", index, run_id)
+        """Input TOML filename: ``input_{jobname}_{index}_{run_id}.toml``."""
+        return f"input_{self.jobname}_{index}_{run_id}.toml"
 
     def _output_filename(self, index: int, run_id: str) -> str:
-        """Stdout-capture filename for step *index*."""
-        return self._filename(".out", index, run_id)
+        """Stdout-capture filename: ``output_{jobname}_{index}_{run_id}.out``."""
+        return f"output_{self.jobname}_{index}_{run_id}.out"
 
     def _submit_script_name(self, run_id: str) -> str:
         return f"submit_{run_id}.sh"
@@ -685,6 +683,47 @@ class Container:
             else:
                 raise FileNotFoundError(f"[{self.label}] Required input not found: {src}")
 
+    def _compute_input_fingerprints(self) -> dict[str, dict]:
+        """Return ``{basename: {size, mtime}}`` for each resolved input file."""
+        fingerprints: dict[str, dict] = {}
+        rename = len(self.rename_input_files) > 0 and len(self.rename_input_files) == len(self.input_files)
+        for i, src in enumerate(self.input_files):
+            src = str(src)
+            if not os.path.isabs(src):
+                src = os.path.join(self.root_dir, src)
+            if rename:
+                key = os.path.basename(str(self.rename_input_files[i]))
+            else:
+                key = os.path.basename(src)
+            if os.path.exists(src):
+                st = os.stat(src)
+                fingerprints[key] = {"size": st.st_size, "mtime": st.st_mtime}
+        return fingerprints
+
+    def _check_input_staleness(self, proj: str) -> bool:
+        """Compare current input fingerprints against the recorded ones.
+
+        Returns ``True`` if any input has changed (stale), ``False``
+        if everything matches or no fingerprints were recorded.
+        """
+        recorded = get_input_fingerprints(proj)
+        if not recorded:
+            return False  # no fingerprints recorded — cannot check
+        current = self._compute_input_fingerprints()
+        for name, cur_fp in current.items():
+            rec_fp = recorded.get(name)
+            if rec_fp is None:
+                # New input file not in original — treat as stale
+                return True
+            if cur_fp["size"] != rec_fp["size"] or cur_fp["mtime"] != rec_fp["mtime"]:
+                logger.warning(
+                    f"[{self.label}] Input '{name}' has changed since last run "
+                    f"(size: {rec_fp['size']}→{cur_fp['size']}, "
+                    f"mtime: {rec_fp['mtime']:.1f}→{cur_fp['mtime']:.1f})."
+                )
+                return True
+        return False
+
     # ── Launch ────────────────────────────────────────────────────
 
     async def async_launch(self):
@@ -695,6 +734,12 @@ class Container:
         # Check if already completed
         state = read_state(proj)
         if state.get("workflow", {}).get("status") == "completed":
+            if self._check_input_staleness(proj):
+                logger.warning(
+                    f"[{self.label}] Inputs have changed but previous results "
+                    f"are still present. Delete '{self.dirname}/' to re-run "
+                    f"with the updated inputs."
+                )
             logger.info(f"[{self.label}] Already completed, no re-run.")
             self.status = WorkflowStatus.COMPLETED
             self._collect_outputs()
@@ -718,6 +763,8 @@ class Container:
             for k, v in self.output_values.items():
                 result_fields[f"result_{k}"] = v
             update_status(proj, WorkflowStatus.COMPLETED, **result_fields)
+            # Record input-file fingerprints for downstream staleness detection
+            set_input_fingerprints(proj, self._compute_input_fingerprints())
         else:
             error_msg = self.output_values.get("error", f"workflow returned status={self.status}")
             set_error(proj, error_msg)

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -53,6 +53,7 @@ from ._state import (
     get_workflow_summary,
     read_state,
     set_error,
+    set_job_accounting,
     update_job,
     update_status,
 )
@@ -344,6 +345,34 @@ class Workflow:
     # They are therefore only callable from concrete subclasses that
     # set those attributes.
 
+    @staticmethod
+    def _record_job_acct(job: JobSubmission, work_dir: str) -> None:
+        """Run scheduler accounting and save raw output, if configured."""
+        result = job.job_acct()
+        if result is None:
+            return
+        command, stdout, stderr = result
+        set_job_accounting(
+            work_dir,
+            command=command,
+            stdout=stdout,
+            stderr=stderr,
+            job_id=job.job_number or "",
+        )
+
+    @staticmethod
+    def _record_job_files(job: JobSubmission, work_dir: str) -> None:
+        """Record job-related file paths in workflow_state.toml."""
+        from ._state import _write, read_state
+
+        state = read_state(work_dir)
+        state["job_files"] = {
+            "output": job.output_file,
+            "job_stdout": job.job_stdout,
+            "job_stderr": job.job_stderr,
+        }
+        _write(work_dir, state)
+
     async def _submit_and_wait(
         self,
         input_file,
@@ -408,6 +437,7 @@ class Workflow:
                 await asyncio.sleep(self.poll_interval)
             logger.info("  Job completed.")
             update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
+            self._record_job_acct(job, work_dir)
             job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
@@ -432,12 +462,19 @@ class Workflow:
             server_machine=self.server_machine_name,
         )
 
+        # Record job file paths for MCP discoverability
+        self._record_job_files(job, work_dir)
+
         while job.jobcheck():
             logger.info(f"  Job {job_number} still running, waiting {self.poll_interval}s...")
             await asyncio.sleep(self.poll_interval)
 
         logger.info("  Job completed.")
         update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
+
+        # Collect scheduler accounting before fetch (raw output only)
+        self._record_job_acct(job, work_dir)
+
         job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
 

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -751,13 +751,12 @@ class Container:
                 raise FileNotFoundError(f"[{self.label}] Required input not found: {src}")
 
     def _validate_input_files(self, proj: str):
-        """Verify that all files the workflow expects exist in *proj*.
+        """Verify that all files listed in ``input_files`` exist in *proj*.
 
-        Checks:
-        1. Every entry in ``self.input_files`` (after rename) exists in
-           the project directory.
-        2. If the workflow declares ``hamiltonian_file``, that file also
-           exists.
+        Only the entries in ``self.input_files`` (after rename) are
+        checked.  Workflow-internal files (e.g. ``hamiltonian_file``)
+        are **not** validated here because some workflows (e.g.
+        ``WF_Workflow``) *produce* them rather than consume them.
 
         Raises
         ------
@@ -767,17 +766,10 @@ class Container:
         """
         missing = []
 
-        # (1) Check resolved input_files
         for i, src in enumerate(self.input_files):
             dst_name = self._dst_basename(str(src), self.rename_input_files, i)
             if not os.path.exists(os.path.join(proj, dst_name)):
                 missing.append(dst_name)
-
-        # (2) Check the workflow's hamiltonian_file (if declared)
-        h5 = getattr(self.workflow, "hamiltonian_file", None)
-        if h5 and not os.path.exists(os.path.join(proj, h5)):
-            if h5 not in missing:
-                missing.append(h5)
 
         if missing:
             raise FileNotFoundError(

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -39,6 +39,7 @@ Dependencies between workflows are declared with FileFrom / ValueFrom.
 import asyncio
 import os
 import shutil
+import uuid
 from logging import getLogger
 from typing import Any, List, Optional
 
@@ -50,6 +51,7 @@ from ._state import (
     add_job,
     create_state,
     get_job,
+    get_job_by_step,
     get_workflow_summary,
     read_state,
     set_error,
@@ -212,6 +214,28 @@ class Workflow:
         self.project_dir: Optional[str] = os.path.abspath(project_dir) if project_dir else None
         self._bg_task: Optional[asyncio.Task] = None
 
+    # ── Filename generation (per-job run_id) ──────────────────────
+
+    @staticmethod
+    def _new_run_id() -> str:
+        """Generate a short random identifier for a single job."""
+        return uuid.uuid4().hex[:8]
+
+    def _filename(self, ext: str, index: int, run_id: str) -> str:
+        """Build ``{jobname}_{index}_{run_id}{ext}``."""
+        return f"{self.jobname}_{index}_{run_id}{ext}"
+
+    def _input_filename(self, index: int, run_id: str) -> str:
+        """Input TOML filename for step *index*."""
+        return self._filename(".toml", index, run_id)
+
+    def _output_filename(self, index: int, run_id: str) -> str:
+        """Stdout-capture filename for step *index*."""
+        return self._filename(".out", index, run_id)
+
+    def _submit_script_name(self, run_id: str) -> str:
+        return f"submit_{run_id}.sh"
+
     def _ensure_project_dir(self):
         """Lazily resolve *project_dir* to CWD when not set explicitly."""
         if self.project_dir is None:
@@ -366,11 +390,11 @@ class Workflow:
         from ._state import _write, read_state
 
         state = read_state(work_dir)
-        state["job_files"] = {
-            "output": job.output_file,
-            "job_stdout": job.job_stdout,
-            "job_stderr": job.job_stderr,
-        }
+        job_files = {"output": job.output_file}
+        if job.server_machine.queuing:
+            job_files["job_stdout"] = job.job_stdout
+            job_files["job_stderr"] = job.job_stderr
+        state["job_files"] = job_files
         _write(work_dir, state)
 
     async def _submit_and_wait(
@@ -381,6 +405,8 @@ class Workflow:
         extra_from_objects=None,
         fetch_from_objects=None,
         queue_label=None,
+        step=None,
+        run_id="",
     ):
         """Submit a job, poll until done, fetch results.
 
@@ -409,27 +435,36 @@ class Workflow:
             ``["*.h5", output_file]``.
         queue_label : str, optional
             Override for the queue label.
+        step : int, optional
+            Step index (0 for pilot, 1+ for production).  Used for
+            cross-run continuation detection.
+        run_id : str
+            Per-job identifier used for scheduler script and stdout/stderr
+            naming.
         """
         if fetch_from_objects is None:
             fetch_from_objects = ["*.h5", output_file]
 
         # Include scheduler stdout/stderr in fetch list when queuing
-        job_tmp = self._make_job(input_file, output_file, queue_label=queue_label)
+        job_tmp = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
         if job_tmp.server_machine.queuing:
             for jf in (job_tmp.job_stdout, job_tmp.job_stderr):
                 if jf and jf not in fetch_from_objects:
                     fetch_from_objects.append(jf)
 
         # ── Restart detection via job history ─────────────────────
-        recorded = get_job(work_dir, input_file)
+        if step is not None:
+            recorded = get_job_by_step(work_dir, step)
+        else:
+            recorded = get_job(work_dir, input_file)
 
         if recorded.get("status") == "fetched":
-            logger.info(f"  {input_file}: already fetched. Skipping.")
+            logger.info(f"  {input_file}: already fetched (step {step}). Skipping.")
             return
 
         if recorded.get("status") == "completed":
             logger.info(f"  {input_file}: completed but not fetched. Fetching...")
-            job = self._make_job(input_file, output_file, queue_label=queue_label)
+            job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
             job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
@@ -437,7 +472,7 @@ class Workflow:
         if recorded.get("status") == "submitted":
             stored_job_id = recorded.get("job_id")
             logger.info(f"  Resuming previously submitted job {stored_job_id}")
-            job = self._make_job(input_file, output_file, queue_label=queue_label)
+            job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
             job.job_number = stored_job_id
             while job.jobcheck():
                 logger.info(f"  Job {stored_job_id} still running, waiting {self.poll_interval}s...")
@@ -450,13 +485,14 @@ class Workflow:
             return
 
         # ── New submission ────────────────────────────────────────
-        job = self._make_job(input_file, output_file, queue_label=queue_label)
-        job.generate_script(work_dir=work_dir)
+        job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
+        submit_sh = self._submit_script_name(run_id)
+        job.generate_script(submission_script=submit_sh, work_dir=work_dir)
 
-        from_objects = [input_file, self.hamiltonian_file, "submit.sh"]
+        from_objects = [input_file, self.hamiltonian_file, submit_sh]
         if extra_from_objects:
             from_objects.extend(extra_from_objects)
-        submitted, job_number = job.job_submit(from_objects=from_objects, work_dir=work_dir)
+        submitted, job_number = job.job_submit(submission_script=submit_sh, from_objects=from_objects, work_dir=work_dir)
         if not submitted:
             raise RuntimeError("Job submission failed (queue limit or error).")
 
@@ -467,6 +503,8 @@ class Workflow:
             output_file=output_file,
             job_id=str(job_number) if job_number else "local",
             server_machine=self.server_machine_name,
+            step=step,
+            run_id=run_id,
         )
 
         # Record job file paths for MCP discoverability
@@ -485,7 +523,7 @@ class Workflow:
         job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir)
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
 
-    def _make_job(self, input_file, output_file, queue_label=None):
+    def _make_job(self, input_file, output_file, queue_label=None, run_id=""):
         """Create a :class:`JobSubmission` with current workflow settings.
 
         Requires *self.server_machine_name*, *self.queue_label*, and
@@ -497,6 +535,7 @@ class Workflow:
             output_file=output_file,
             queue_label=queue_label or self.queue_label,
             jobname=self.jobname,
+            run_id=run_id,
         )
 
 

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -43,12 +43,16 @@ from logging import getLogger
 from typing import Any, List, Optional
 
 from ._job import JobSubmission
+from ._phase import ScientificPhase, require_action
 from ._state import (
+    WorkflowStatus,
     _now_iso,
     add_job,
     create_state,
     get_job,
+    get_workflow_summary,
     read_state,
+    set_error,
     update_job,
     update_status,
 )
@@ -153,23 +157,25 @@ class Workflow:
     """Abstract base class for all jQMC computation workflows.
 
     Every concrete workflow (VMC, MCMC, LRDMC, WF, …) inherits from
-    this class and overrides :meth:`async_launch`.
+    this class and overrides :meth:`configure` and :meth:`run`.
 
     Parameters
     ----------
     project_dir : str, optional
         Absolute path to the working directory for this workflow.
         When *None* (the default), ``project_dir`` is set to the
-        process CWD at the time :meth:`async_launch` is first called.
+        process CWD at the time :meth:`run` is first called.
         :class:`Container` sets this explicitly before launching the
         inner workflow.
 
     Attributes
     ----------
-    status : str
-        Current lifecycle status (``"init"``, ``"success"``, ``"failed"``).
+    status : WorkflowStatus
+        Current lifecycle status.
+    phase : ScientificPhase
+        Current scientific phase.
     output_files : list[str]
-        Filenames produced by the workflow (populated after launch).
+        Filenames produced by the workflow (populated after run).
     output_values : dict
         Scalar results (energy, error, …) produced by the workflow.
     project_dir : str or None
@@ -179,8 +185,8 @@ class Workflow:
     -----
     **Subclass contract:**
 
-    * Override :meth:`async_launch` and return
-      ``(status, output_files, output_values)``.
+    * Override :meth:`configure` and :meth:`run`, return
+      ``(status, output_files, output_values)`` from ``run()``.
     * Call ``super().__init__()`` in your constructor.
 
     Examples
@@ -188,14 +194,18 @@ class Workflow:
     Minimal custom workflow::
 
         class MyWorkflow(Workflow):
-            async def async_launch(self):
+            def configure(self):
+                return {"param": 42}
+
+            async def run(self):
                 # ... do work ...
-                self.status = "success"
+                self.status = WorkflowStatus.COMPLETED
                 return self.status, ["result.h5"], {"energy": -1.23}
     """
 
     def __init__(self, project_dir: Optional[str] = None):
-        self.status = "init"
+        self.status: WorkflowStatus = WorkflowStatus.PENDING
+        self.phase: ScientificPhase = ScientificPhase.INIT
         self.output_files: List[str] = []
         self.output_values: dict = {}
         self.project_dir: Optional[str] = os.path.abspath(project_dir) if project_dir else None
@@ -206,37 +216,58 @@ class Workflow:
         if self.project_dir is None:
             self.project_dir = os.path.abspath(os.getcwd())
 
+    # ── configure / run (new primary interface) ─────────────────────
+
+    def configure(self) -> dict:
+        """Validate parameters and generate inputs (no execution).
+
+        Override in subclass.  Returns a summary dict.
+        """
+        return {}
+
+    async def run(self) -> tuple:
+        """Execute the workflow (submit → poll → fetch → convergence loop).
+
+        Override in subclass.  Must return
+        ``(status, output_files, output_values)``.
+
+        Intermediate progress is written to ``workflow_state.toml``
+        via :func:`update_status`.
+        """
+        self._ensure_project_dir()
+        return self.status, self.output_files, self.output_values
+
     # ── Full lifecycle (backward-compatible) ──────────────────────
 
     async def async_launch(self):
-        """Override in subclass. Must return (status, output_files, output_values)."""
+        """Run configure() + run().  Backward-compatible entry point."""
         self._ensure_project_dir()
-        return self.status, self.output_files, self.output_values
+        self.configure()
+        return await self.run()
 
     def launch(self):
         return asyncio.run(self.async_launch())
 
-    # ── Phased execution (new API for MCP / external orchestration) ──
+    # ── Phased execution (MCP interactive mode) ───────────────────
     #
-    # The default implementation delegates to ``async_launch()`` via a
-    # background ``asyncio.Task``.  Subclasses *may* override for
-    # finer-grained, state-machine-style control; the base-class
-    # versions work out-of-the-box for every workflow.
+    # Used by MCP tools: submit(action) → poll() → collect().
+    # submit() starts run() as a background asyncio.Task.
     #
     # Usage pattern::
     #
-    #     info = await wf.async_submit()
+    #     info = await wf.async_submit(action="run_vmc")
     #     while (status := await wf.async_poll()) == "running":
     #         await asyncio.sleep(60)
     #     result = await wf.async_collect()
 
-    async def async_submit(self) -> dict:
+    async def async_submit(self, action: str = "run") -> dict:
         """Start the workflow in the background and return tracking info.
 
-        The full workflow (pilot ➜ production ➜ post-processing) is
-        executed as an ``asyncio.Task`` wrapping :meth:`async_launch`.
-        Use :meth:`async_poll` to monitor progress and
-        :meth:`async_collect` to retrieve results once completed.
+        Parameters
+        ----------
+        action : str
+            MCP tool name (e.g. ``"run_vmc"``).  Checked against
+            :func:`allowed_actions` for the current phase and status.
 
         Returns
         -------
@@ -245,33 +276,36 @@ class Workflow:
 
         Raises
         ------
+        ValueError
+            If *action* is not allowed in the current phase/status.
         RuntimeError
             If the workflow has already been submitted.
         """
         if self._bg_task is not None and not self._bg_task.done():
             raise RuntimeError("Workflow already submitted and still running.")
+        require_action(action, self.phase, self.status)
         self._ensure_project_dir()
-        self._bg_task = asyncio.create_task(self.async_launch())
+        self.configure()
+        self._bg_task = asyncio.create_task(self.run())
         return {"status": "submitted", "project_dir": self.project_dir}
 
-    async def async_poll(self) -> str:
+    async def async_poll(self) -> dict:
         """Check whether the submitted workflow has completed.
 
         Returns
         -------
-        str
-            ``"running"``  — workflow still executing.
-            ``"completed"`` — finished successfully.
-            ``"failed"``   — finished with an error.
-            ``"not_submitted"`` — :meth:`async_submit` not yet called.
+        dict
+            Status dict.  Includes ``get_workflow_summary()`` when
+            the task is still running.
         """
         if self._bg_task is None:
-            return "not_submitted"
+            return {"status": "not_submitted"}
         if not self._bg_task.done():
-            return "running"
+            summary = get_workflow_summary(self.project_dir) if self.project_dir else {}
+            return {"status": "running", **summary}
         if self._bg_task.exception() is not None:
-            return "failed"
-        return "completed"
+            return {"status": "failed", "error": str(self._bg_task.exception())}
+        return {"status": "completed"}
 
     async def async_collect(self) -> dict:
         """Collect results from the completed workflow.
@@ -585,32 +619,34 @@ class Container:
         state = read_state(proj)
         if state.get("workflow", {}).get("status") == "completed":
             logger.info(f"[{self.label}] Already completed, no re-run.")
-            self.status = "success"
+            self.status = WorkflowStatus.COMPLETED
             self._collect_outputs()
             return self.status, self.output_files, self.output_values
 
         # Run the workflow — pass project_dir explicitly instead of
         # relying on os.chdir().
-        update_status(proj, "running")
+        update_status(proj, WorkflowStatus.RUNNING)
         self.workflow.project_dir = proj
 
         try:
             self.status, self.output_files, self.output_values = await self.workflow.async_launch()
         except Exception as e:
-            update_status(proj, "failed", error=str(e))
+            set_error(proj, str(e))
+            update_status(proj, WorkflowStatus.FAILED)
             raise
 
         # Write completion — but only if the workflow actually succeeded.
         # Workflows that return a non-success status (e.g. "failed") must
         # NOT be marked "completed" in the state file.
-        if self.status in ("success", "completed"):
+        if self.status in ("success", "completed", WorkflowStatus.COMPLETED):
             result_fields = {}
             for k, v in self.output_values.items():
                 result_fields[f"result_{k}"] = v
-            update_status(proj, "completed", **result_fields)
+            update_status(proj, WorkflowStatus.COMPLETED, **result_fields)
         else:
             error_msg = self.output_values.get("error", f"workflow returned status={self.status}")
-            update_status(proj, "failed", error=error_msg)
+            set_error(proj, error_msg)
+            update_status(proj, WorkflowStatus.FAILED)
             logger.warning(f"[{self.label}] {error_msg}")
 
         return self.status, self.output_files, self.output_values
@@ -632,13 +668,18 @@ class Container:
 
     # ── Phased execution (delegates to inner Workflow) ────────────
 
-    async def async_submit(self) -> dict:
+    async def async_submit(self, action: str = "run") -> dict:
         """Start the container's workflow in the background.
 
         Prepares the project directory, copies input files, then
         starts the inner workflow via ``asyncio.Task``.  Use
         :meth:`async_poll` and :meth:`async_collect` to monitor
         and retrieve results.
+
+        Parameters
+        ----------
+        action : str
+            MCP tool name for action validation.
 
         Returns
         -------
@@ -654,22 +695,22 @@ class Container:
             "project_dir": self.project_dir,
         }
 
-    async def async_poll(self) -> str:
+    async def async_poll(self) -> dict:
         """Check whether the container's workflow has completed.
 
         Returns
         -------
-        str
-            ``"running"``, ``"completed"``, ``"failed"``, or
-            ``"not_submitted"``.
+        dict
+            Status dict with ``get_workflow_summary()`` when running.
         """
         if self._bg_task is None:
-            return "not_submitted"
+            return {"status": "not_submitted"}
         if not self._bg_task.done():
-            return "running"
+            summary = get_workflow_summary(self.project_dir) if self.project_dir else {}
+            return {"status": "running", **summary}
         if self._bg_task.exception() is not None:
-            return "failed"
-        return "completed"
+            return {"status": "failed", "error": str(self._bg_task.exception())}
+        return {"status": "completed"}
 
     async def async_collect(self) -> dict:
         """Collect results from the completed container workflow.

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -37,6 +37,7 @@ Dependencies between workflows are declared with FileFrom / ValueFrom.
 # POSSIBILITY OF SUCH DAMAGE.
 
 import asyncio
+import hashlib
 import os
 import shutil
 import uuid
@@ -684,7 +685,7 @@ class Container:
                 raise FileNotFoundError(f"[{self.label}] Required input not found: {src}")
 
     def _compute_input_fingerprints(self) -> dict[str, dict]:
-        """Return ``{basename: {size, mtime}}`` for each resolved input file."""
+        """Return ``{basename: {sha256: hex_digest}}`` for each resolved input file."""
         fingerprints: dict[str, dict] = {}
         rename = len(self.rename_input_files) > 0 and len(self.rename_input_files) == len(self.input_files)
         for i, src in enumerate(self.input_files):
@@ -696,8 +697,11 @@ class Container:
             else:
                 key = os.path.basename(src)
             if os.path.exists(src):
-                st = os.stat(src)
-                fingerprints[key] = {"size": st.st_size, "mtime": st.st_mtime}
+                h = hashlib.sha256()
+                with open(src, "rb") as f:
+                    for chunk in iter(lambda: f.read(1 << 20), b""):
+                        h.update(chunk)
+                fingerprints[key] = {"sha256": h.hexdigest()}
         return fingerprints
 
     def _check_input_staleness(self, proj: str) -> bool:
@@ -715,11 +719,10 @@ class Container:
             if rec_fp is None:
                 # New input file not in original — treat as stale
                 return True
-            if cur_fp["size"] != rec_fp["size"] or cur_fp["mtime"] != rec_fp["mtime"]:
+            if cur_fp.get("sha256") != rec_fp.get("sha256"):
                 logger.warning(
                     f"[{self.label}] Input '{name}' has changed since last run "
-                    f"(size: {rec_fp['size']}→{cur_fp['size']}, "
-                    f"mtime: {rec_fp['mtime']:.1f}→{cur_fp['mtime']:.1f})."
+                    f"(sha256: {rec_fp.get('sha256', '?')[:12]}… → {cur_fp.get('sha256', '?')[:12]}…)."
                 )
                 return True
         return False
@@ -731,15 +734,23 @@ class Container:
 
         self._prepare()
 
-        # Check if already completed
+        # Check if already completed or running (resume)
         state = read_state(proj)
-        if state.get("workflow", {}).get("status") == "completed":
+        prev_status = state.get("workflow", {}).get("status")
+
+        if prev_status in ("completed", "running"):
             if self._check_input_staleness(proj):
                 logger.warning(
-                    f"[{self.label}] Inputs have changed but previous results "
-                    f"are still present. Delete '{self.dirname}/' to re-run "
-                    f"with the updated inputs."
+                    f"[{self.label}] Inputs have changed since the previous run. "
+                    f"Delete '{self.dirname}/' to re-run with the updated inputs."
                 )
+
+        # Record input-file fingerprints after staleness check but
+        # before any execution, so that even interrupted runs have a
+        # baseline for the next invocation.
+        set_input_fingerprints(proj, self._compute_input_fingerprints())
+
+        if prev_status == "completed":
             logger.info(f"[{self.label}] Already completed, no re-run.")
             self.status = WorkflowStatus.COMPLETED
             self._collect_outputs()
@@ -763,8 +774,6 @@ class Container:
             for k, v in self.output_values.items():
                 result_fields[f"result_{k}"] = v
             update_status(proj, WorkflowStatus.COMPLETED, **result_fields)
-            # Record input-file fingerprints for downstream staleness detection
-            set_input_fingerprints(proj, self._compute_input_fingerprints())
         else:
             error_msg = self.output_values.get("error", f"workflow returned status={self.status}")
             set_error(proj, error_msg)

--- a/tests/test_ao_basis_optimization.py
+++ b/tests/test_ao_basis_optimization.py
@@ -523,21 +523,39 @@ def test_full_wavefunction_exponent_gradient():
 # ============================================================
 
 
-def test_opt_with_projected_MOs_basis_conflict():
-    """opt_with_projected_MOs should raise ValueError when combined with basis optimization."""
+def test_opt_with_projected_MOs_lambda_basis_conflict():
+    """opt_with_projected_MOs should raise ValueError when combined with lambda basis optimization."""
     from jqmc.jqmc_mcmc import MCMC
 
-    # We just test that the validation logic raises the error
-    # by checking the error directly at the run_optimize level.
-    # Since MCMC initialization is heavy, we test the conflict check directly.
-    any_basis_flag = True
+    # Only opt_lambda_basis_exp/coeff conflict with opt_with_projected_MOs.
+    # opt_J3_basis_exp/coeff are allowed because J3 basis does not affect
+    # the overlap matrix used by MO projection.
     opt_with_projected_MOs = True
-    flags = [any_basis_flag, False, False, False]  # opt_J3_basis_exp=True
+
+    # lambda_basis_exp=True should conflict
+    flags_lambda_exp = [False, False, True, False]  # opt_lambda_basis_exp=True
     with pytest.raises(ValueError, match="cannot be combined with opt_with_projected_MOs"):
-        if opt_with_projected_MOs and any(flags):
+        if opt_with_projected_MOs and any(flags_lambda_exp[2:]):
             raise ValueError(
-                "AO basis optimization (opt_J3_basis_exp/coeff, opt_lambda_basis_exp/coeff) "
+                "Geminal AO basis optimization (opt_lambda_basis_exp/coeff) "
                 "cannot be combined with opt_with_projected_MOs. "
-                "Changing AO exponents/coefficients invalidates the overlap matrix "
+                "Changing Geminal AO exponents/coefficients invalidates the overlap matrix "
                 "used by the MO projection operators."
             )
+
+    # lambda_basis_coeff=True should conflict
+    flags_lambda_coeff = [False, False, False, True]  # opt_lambda_basis_coeff=True
+    with pytest.raises(ValueError, match="cannot be combined with opt_with_projected_MOs"):
+        if opt_with_projected_MOs and any(flags_lambda_coeff[2:]):
+            raise ValueError(
+                "Geminal AO basis optimization (opt_lambda_basis_exp/coeff) "
+                "cannot be combined with opt_with_projected_MOs. "
+                "Changing Geminal AO exponents/coefficients invalidates the overlap matrix "
+                "used by the MO projection operators."
+            )
+
+    # J3_basis_exp=True should NOT conflict with opt_with_projected_MOs
+    flags_j3 = [True, False, False, False]  # opt_J3_basis_exp=True
+    # This should not raise — J3 basis does not affect MO projection overlap
+    if opt_with_projected_MOs and any(flags_j3[2:]):
+        raise ValueError("Should not reach here")

--- a/tests/test_jqmc_tool.py
+++ b/tests/test_jqmc_tool.py
@@ -61,6 +61,10 @@ from jqmc.jqmc_tool import (  # noqa: E402
     vmc_analyze_output,
     vmc_generate_input,
 )
+from jqmc._setting import (  # noqa: E402
+    atol_consistency,
+    rtol_consistency,
+)
 from jqmc.trexio_wrapper import read_trexio_file  # noqa: E402
 
 trexio_files = [
@@ -508,105 +512,226 @@ class TestGenerateInput:
         assert "#" in text, "Expected comments in the generated TOML file"
 
 
+def _reference_mcmc_jackknife(rank_data, num_warmup, num_bin_blocks):
+    """Reference jackknife using np.sum (matches runtime get_E)."""
+    w_all = []
+    we_all = []
+    for obs in rank_data:
+        e_L = obs["e_L"][num_warmup:]
+        w_L = obs["w_L"][num_warmup:]
+        for arr in np.array_split(w_L, num_bin_blocks, axis=0):
+            w_all.extend(np.ravel(np.sum(arr, axis=0)).tolist())
+        for arr in np.array_split(w_L * e_L, num_bin_blocks, axis=0):
+            we_all.extend(np.ravel(np.sum(arr, axis=0)).tolist())
+    w = np.array(w_all)
+    we = np.array(we_all)
+    M = w.size
+    S_w, S_we = np.sum(w), np.sum(we)
+    E_jk = np.array([(S_we - we[m]) / (S_w - w[m]) for m in range(M)])
+    E_mean = np.mean(E_jk)
+    E_std = np.sqrt(M - 1) * np.std(E_jk)
+    return E_mean, E_std
+
+
+def _reference_lrdmc_jackknife(rank_data, num_warmup, num_bin_blocks, k):
+    """Reference jackknife for LRDMC using np.sum (matches runtime get_E)."""
+
+    def _compute_accumulated_weights(w_L, k):
+        """Pure-numpy equivalent of jqmc._checkpoint.compute_accumulated_weights."""
+        A, x = w_L.shape
+        G_L = np.ones((A - k, x))
+        for i in range(A - k):
+            G_L[i] = np.prod(w_L[i : i + k], axis=0)
+        return G_L
+
+    w_all = []
+    we_all = []
+    for obs in rank_data:
+        raw_e_L = obs["e_L"]
+        raw_w_L = obs["w_L"]
+        e_L = raw_e_L[k:][num_warmup:]
+        w_L = _compute_accumulated_weights(raw_w_L, k)[num_warmup:]
+        for arr in np.array_split(w_L, num_bin_blocks, axis=0):
+            w_all.extend(np.ravel(np.sum(arr, axis=0)).tolist())
+        for arr in np.array_split(w_L * e_L, num_bin_blocks, axis=0):
+            we_all.extend(np.ravel(np.sum(arr, axis=0)).tolist())
+    w = np.array(w_all)
+    we = np.array(we_all)
+    M = w.size
+    S_w, S_we = np.sum(w), np.sum(we)
+    E_jk = np.array([(S_we - we[m]) / (S_w - w[m]) for m in range(M)])
+    E_mean = np.mean(E_jk)
+    E_std = np.sqrt(M - 1) * np.std(E_jk)
+    return E_mean, E_std
+
+
 class TestComputeEnergy:
     """Tests for mcmc and lrdmc compute-energy commands."""
 
-    def test_mcmc_constant_energy_jackknife(self, tmp_path):
-        """With constant e_L and w_L=1 the jackknife mean must equal that constant."""
-        E_const = -5.0
+    def test_mcmc_random_energy_jackknife(self, tmp_path):
+        """jqmc-tool must match the np.sum-based reference jackknife for random data."""
+        rng = np.random.default_rng(42)
+        num_steps, num_walkers, num_bins, warmup = 103, 4, 7, 0
         chk_path = str(tmp_path / "mcmc.h5")
-        obj = _make_mcmc_obj(num_steps=100, num_walkers=4, e_L_value=E_const, with_force=False)
+        obj = _make_mcmc_obj(num_steps=num_steps, num_walkers=num_walkers, with_force=False)
+        obj.e_L = rng.standard_normal((num_steps, num_walkers)) - 5.0
+        obj.w_L = rng.uniform(0.8, 1.2, (num_steps, num_walkers))
         _write_chk(chk_path, [obj])
 
+        E_ref, std_ref = _reference_mcmc_jackknife(
+            [{"e_L": obj.e_L, "w_L": obj.w_L}],
+            warmup,
+            num_bins,
+        )
+
         from typer.testing import CliRunner
 
         from jqmc.jqmc_tool import mcmc_app
 
         runner = CliRunner()
-        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", "2", "-w", "0"])
+        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", str(num_bins), "-w", str(warmup)])
         assert result.exit_code == 0
-        assert f"E = {E_const}" in result.output
+        m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
+        assert m is not None
+        E_cli, std_cli = float(m.group(1)), float(m.group(2))
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
 
-    def test_mcmc_multi_rank(self, tmp_path):
-        """Multiple MPI ranks with same constant energy should give same result."""
-        E_const = -3.0
+    def test_mcmc_multi_rank_random(self, tmp_path):
+        """Multiple MPI ranks with random data should match np.sum reference."""
+        num_steps, num_walkers, num_bins, warmup = 97, 3, 5, 0
         chk_path = str(tmp_path / "mcmc.h5")
-        objs = [
-            _make_mcmc_obj(num_steps=100, num_walkers=2, e_L_value=E_const, with_force=False, rng=np.random.default_rng(i))
-            for i in range(3)
-        ]
+        objs = []
+        rank_data = []
+        for i in range(3):
+            rng = np.random.default_rng(i + 100)
+            obj = _make_mcmc_obj(num_steps=num_steps, num_walkers=num_walkers, with_force=False)
+            obj.e_L = rng.standard_normal((num_steps, num_walkers)) - 3.0
+            obj.w_L = rng.uniform(0.9, 1.1, (num_steps, num_walkers))
+            objs.append(obj)
+            rank_data.append({"e_L": obj.e_L, "w_L": obj.w_L})
         _write_chk(chk_path, objs)
 
+        E_ref, std_ref = _reference_mcmc_jackknife(rank_data, warmup, num_bins)
+
         from typer.testing import CliRunner
 
         from jqmc.jqmc_tool import mcmc_app
 
         runner = CliRunner()
-        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", "1", "-w", "0"])
+        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", str(num_bins), "-w", str(warmup)])
         assert result.exit_code == 0
         assert "Found 3 MPI ranks" in result.output
-        assert f"E = {E_const}" in result.output
+        m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
+        assert m is not None
+        E_cli, std_cli = float(m.group(1)), float(m.group(2))
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
 
     def test_mcmc_warmup_discards_steps(self, tmp_path):
-        """First num_mcmc_warmup_steps should be discarded."""
+        """Warmup discard + random data post-warmup must match reference."""
+        rng = np.random.default_rng(99)
+        num_steps, num_walkers, num_bins, warmup = 100, 2, 3, 10
         chk_path = str(tmp_path / "mcmc.h5")
-        # First 10 steps have e_L=100 (bad), remaining 90 have e_L=-5 (good)
-        obj = _make_mcmc_obj(num_steps=100, num_walkers=2, e_L_value=-5.0, with_force=False)
-        obj.e_L[:10, :] = 100.0
+        obj = _make_mcmc_obj(num_steps=num_steps, num_walkers=num_walkers, with_force=False)
+        obj.e_L = rng.standard_normal((num_steps, num_walkers)) - 5.0
+        obj.w_L = rng.uniform(0.8, 1.2, (num_steps, num_walkers))
+        # Poison first warmup steps to make warmup discard meaningful
+        obj.e_L[:warmup, :] = 100.0
         _write_chk(chk_path, [obj])
+
+        E_ref, std_ref = _reference_mcmc_jackknife(
+            [{"e_L": obj.e_L, "w_L": obj.w_L}],
+            warmup,
+            num_bins,
+        )
 
         from typer.testing import CliRunner
 
         from jqmc.jqmc_tool import mcmc_app
 
         runner = CliRunner()
-        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", "1", "-w", "10"])
+        result = runner.invoke(mcmc_app, ["compute-energy", chk_path, "-b", str(num_bins), "-w", str(warmup)])
         assert result.exit_code == 0
-        # After discarding first 10 steps, E should be -5.0
-        assert "E = -5.0" in result.output
+        m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
+        assert m is not None
+        E_cli, std_cli = float(m.group(1)), float(m.group(2))
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
 
-    def test_lrdmc_constant_energy_jackknife(self, tmp_path):
-        """LRDMC version of jackknife test with constant energy."""
-        E_const = -7.0
+    def test_lrdmc_random_energy_jackknife(self, tmp_path):
+        """LRDMC jqmc-tool must match the np.sum-based reference jackknife for random data."""
+        rng = np.random.default_rng(77)
+        num_steps, num_walkers, num_bins, warmup, k = 203, 4, 10, 30, 5
         chk_path = str(tmp_path / "lrdmc.h5")
-        obj = _make_lrdmc_obj(num_steps=100, num_walkers=4, e_L_value=E_const, with_force=False)
+        obj = _make_lrdmc_obj(num_steps=num_steps, num_walkers=num_walkers, with_force=False)
+        obj.e_L = rng.standard_normal((num_steps, num_walkers)) - 7.0
+        obj.w_L = rng.uniform(0.9, 1.1, (num_steps, num_walkers))
         _write_chk(chk_path, [obj])
 
+        E_ref, std_ref = _reference_lrdmc_jackknife(
+            [{"e_L": obj.e_L, "w_L": obj.w_L}],
+            warmup,
+            num_bins,
+            k,
+        )
+
         from typer.testing import CliRunner
 
         from jqmc.jqmc_tool import lrdmc_app
 
         runner = CliRunner()
-        result = runner.invoke(lrdmc_app, ["compute-energy", chk_path, "-b", "10", "-w", "30", "-c", "5"])
+        result = runner.invoke(lrdmc_app, ["compute-energy", chk_path, "-b", str(num_bins), "-w", str(warmup), "-c", str(k)])
         assert result.exit_code == 0
-        assert f"E = {E_const}" in result.output
+        m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
+        assert m is not None
+        E_cli, std_cli = float(m.group(1)), float(m.group(2))
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
 
-    def test_lrdmc_multi_rank(self, tmp_path):
-        """Multiple MPI ranks for LRDMC."""
-        E_const = -2.0
+    def test_lrdmc_multi_rank_random(self, tmp_path):
+        """Multiple LRDMC ranks with random data must match np.sum reference."""
+        num_steps, num_walkers, num_bins, warmup, k = 203, 2, 10, 30, 5
         chk_path = str(tmp_path / "lrdmc.h5")
-        objs = [
-            _make_lrdmc_obj(num_steps=80, num_walkers=2, e_L_value=E_const, with_force=False, rng=np.random.default_rng(i))
-            for i in range(2)
-        ]
+        objs = []
+        rank_data = []
+        for i in range(2):
+            rng = np.random.default_rng(i + 200)
+            obj = _make_lrdmc_obj(num_steps=num_steps, num_walkers=num_walkers, with_force=False)
+            obj.e_L = rng.standard_normal((num_steps, num_walkers)) - 2.0
+            obj.w_L = rng.uniform(0.9, 1.1, (num_steps, num_walkers))
+            objs.append(obj)
+            rank_data.append({"e_L": obj.e_L, "w_L": obj.w_L})
         _write_chk(chk_path, objs)
 
+        E_ref, std_ref = _reference_lrdmc_jackknife(rank_data, warmup, num_bins, k)
+
         from typer.testing import CliRunner
 
         from jqmc.jqmc_tool import lrdmc_app
 
         runner = CliRunner()
-        result = runner.invoke(lrdmc_app, ["compute-energy", chk_path, "-b", "10", "-w", "30", "-c", "5"])
+        result = runner.invoke(lrdmc_app, ["compute-energy", chk_path, "-b", str(num_bins), "-w", str(warmup), "-c", str(k)])
         assert result.exit_code == 0
         assert "Found 2 MPI ranks" in result.output
+        m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
+        assert m is not None
+        E_cli, std_cli = float(m.group(1)), float(m.group(2))
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
 
     def test_lrdmc_extrapolate_energy(self, tmp_path):
         """extrapolate-energy with two LRDMC checkpoints should report a->0 result."""
+        rng1, rng2 = np.random.default_rng(300), np.random.default_rng(301)
         chk1 = str(tmp_path / "lrdmc1.h5")
         chk2 = str(tmp_path / "lrdmc2.h5")
 
-        obj1 = _make_lrdmc_obj(num_steps=100, num_walkers=4, e_L_value=-5.0, alat=0.5, with_force=False)
-        obj2 = _make_lrdmc_obj(num_steps=100, num_walkers=4, e_L_value=-5.2, alat=0.3, with_force=False)
+        obj1 = _make_lrdmc_obj(num_steps=100, num_walkers=4, alat=0.5, with_force=False)
+        obj1.e_L = rng1.standard_normal((100, 4)) - 5.0
+        obj1.w_L = rng1.uniform(0.9, 1.1, (100, 4))
+        obj2 = _make_lrdmc_obj(num_steps=100, num_walkers=4, alat=0.3, with_force=False)
+        obj2.e_L = rng2.standard_normal((100, 4)) - 5.2
+        obj2.w_L = rng2.uniform(0.9, 1.1, (100, 4))
         _write_chk(chk1, [obj1])
         _write_chk(chk2, [obj2])
 


### PR DESCRIPTION
Major refactoring of `jqmc_workflow` with several bug fixes in the core QMC modules.

### Workflow refactoring (`jqmc_workflow`)

- **New `_phase.py` module**: Introduced `ScientificPhase` abstraction and `require_action` decorator for structuring workflow execution phases
- **Expanded `_state.py`**: Added `WorkflowStatus`, `get_job_by_step`, `get_input_fingerprints`, `set_input_fingerprints`, `get_workflow_summary`, `save_job_accounting`, and `set_error` for richer state management
- **`FileFrom` now accepts `ValueFrom`**: Dynamic filenames (e.g. optimized Hamiltonian whose step number depends on convergence) can be resolved at runtime instead of requiring a static string
- **Input fingerprinting with SHA256**: Use SHA256 hashes for `input_fingerprints` to detect changed inputs and avoid redundant re-runs
- **Improved continuation behavior**: Changed how continuation runs are managed across VMC, MCMC, and LRDMC workflows
- **Convergence-driven VMC production**: VMC workflow supports S/N ratio and energy-slope convergence criteria with early exit
- **Additional step estimation**: Accumulated-data error estimator (`σ ∝ 1/√N`) for MCMC and VMC workflows to compute the number of additional steps needed
- **Accumulated step count bug fix**: Corrected step counting in VMC and LRDMC workflows
- **File transfer and job management improvements**: Polished `FileFrom` resolution, fixed file-existence checks in `_transfer.py` and `_job.py`
- **New VMC workflow parameters**: Introduced additional configurable parameters (e.g. `target_snr`, `energy_slope_sigma_threshold`, `max_continuation`)
- **Fixed duplicate convergence log output**: VMC convergence check (`_check_convergence`) was called both in the production loop and in the final check, producing duplicate S/N and energy-slope log lines. Now reuses the loop result when available

### Core QMC bug fixes (`jqmc`)

- **MPI `Allreduce` → `allreduce` for scalars**: Replaced `mpi_comm.Allreduce(buf, ...)` with `mpi_comm.allreduce(val, ...)` for scalar `int`/`float` values in `jqmc_mcmc.py` and `jqmc_gfmc.py`. The buffer-based `Allreduce` shows undefined behavior for scalars with some MPI implementations; the lowercase `allreduce` (pickle-based, returns the result) is correct for scalar reductions
- **`jqmc_tool` compute-energy bug fix**: Fixed a bug in the `compute-energy` subcommand
- **Basis optimization filter bug fix**: Fixed incorrect filtering logic in `test_ao_basis_optimization.py`

### Output parser improvements

- Fixed various parser issues in `_output_parser.py` for more reliable extraction of energies, S/N ratios, and forces from jQMC output files

### Documentation

- Updated workflow documentation in `doc/notes/workflows.md` (detailed design notes)
- Updated `doc/examples.md`, `doc/overview.md`, `doc/api_reference_cli.md`