### PR TITLE
Fix optimizer fallback, restore post-update symmetrization, and improve step estimation

### DIFF
--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -263,7 +263,9 @@ class Geminal_data:
         """
         if block.name == "lambda_matrix":
             lambda_new = np.array(block.values)
-            # Post-update symmetrization removed — O_k symmetrized at source.
+
+            # Symmetrize unconditionally — the method is a no-op for non-symmetric matrices.
+            lambda_new = self.symmetrize_lambda(lambda_new)
 
             return Geminal_data(
                 num_electron_up=self.num_electron_up,
@@ -274,14 +276,14 @@ class Geminal_data:
             )
         elif block.name == "lambda_basis_exp":
             vals = np.asarray(block.values, dtype=np.float64)
-            # Post-update symmetrization removed — O_k symmetrized at source.
+            vals = self._symmetrize_ao_basis(vals)
             vals = jnp.asarray(vals, dtype=jnp.float64)
             n_up = len(self.ao_exponents_up)
             new_exp_up, new_exp_dn = vals[:n_up], vals[n_up:]
             return self.with_updated_ao_exponents(new_exp_up, new_exp_dn)
         elif block.name == "lambda_basis_coeff":
             vals = np.asarray(block.values, dtype=np.float64)
-            # Post-update symmetrization removed — O_k symmetrized at source.
+            vals = self._symmetrize_ao_basis(vals)
             vals = jnp.asarray(vals, dtype=jnp.float64)
             n_up = len(self.ao_coefficients_up)
             new_coeff_up, new_coeff_dn = vals[:n_up], vals[n_up:]

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -1870,17 +1870,19 @@ class Jastrow_data:
             j2 = Jastrow_two_body_data(jastrow_2b_param=new_param, jastrow_2b_type=j2.jastrow_2b_type)
         elif block.name == "j3_matrix" and j3 is not None:
             j3_new = np.array(block.values)
-            # Post-update symmetrization removed — O_k is symmetrized at source
-            # in get_dln_WF, so theta and parameter updates are already symmetric.
+
+            # Symmetrize unconditionally — the method is a no-op for non-symmetric matrices.
+            j3_new = self.symmetrize_j3(j3_new)
+
             j3 = Jastrow_three_body_data(orb_data=j3.orb_data, j_matrix=j3_new)
         elif block.name == "j3_basis_exp" and j3 is not None:
             new_exp = np.asarray(block.values, dtype=np.float64)
-            # Post-update symmetrization removed — O_k symmetrized at source.
-            j3 = j3.with_updated_ao_exponents(jnp.asarray(new_exp, dtype=jnp.float64))
+            new_exp = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_exp), dtype=jnp.float64)
+            j3 = j3.with_updated_ao_exponents(new_exp)
         elif block.name == "j3_basis_coeff" and j3 is not None:
             new_coeff = np.asarray(block.values, dtype=np.float64)
-            # Post-update symmetrization removed — O_k symmetrized at source.
-            j3 = j3.with_updated_ao_coefficients(jnp.asarray(new_coeff, dtype=jnp.float64))
+            new_coeff = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_coeff), dtype=jnp.float64)
+            j3 = j3.with_updated_ao_coefficients(new_coeff)
         elif block.name == "jastrow_nn_params" and nn3 is not None:
             # Update NN Jastrow parameters: block.values is the flattened parameter vector.
             flat = jnp.asarray(block.values).reshape(-1)

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -2109,18 +2109,17 @@ class MCMC:
 
         logger.info(f"aSR: gamma+ = {gamma_plus:.6f}, gamma- = {gamma_minus:.6f}")
 
-        # Collect positive roots.
-        positive_roots = [g for g in (gamma_plus, gamma_minus) if g > 0.0]
-
-        if positive_roots:
-            gamma = min(positive_roots)
-            logger.info(f"aSR: selected gamma = {gamma:.6f}")
+        # Choose the root with the smaller absolute value (conservative step).
+        if abs(gamma_plus) <= abs(gamma_minus):
+            gamma = gamma_plus
         else:
+            gamma = gamma_minus
+
+        if gamma > 0.0:
+            logger.info(f"aSR: selected gamma = {gamma:.6f} (steepest-descent direction).")
+        else:
+            logger.warning(f"aSR: anti-steepest-descent direction (gamma={gamma:.6f}); falling back to plain SR (gamma=0.1).")
             gamma = 0.1
-            logger.warning(
-                f"aSR: no positive root (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
-                f"falling back to plain SR (gamma=0.1)."
-            )
 
         return gamma
 
@@ -5895,18 +5894,17 @@ class _MCMC_debug:
 
         logger.info(f"aSR: gamma+ = {gamma_plus:.6f}, gamma- = {gamma_minus:.6f}")
 
-        # Collect positive roots; prefer the smaller one when both are positive.
-        positive_roots = [g for g in (gamma_plus, gamma_minus) if g > 0.0]
-
-        if positive_roots:
-            gamma = min(positive_roots)
-            logger.info(f"aSR: selected gamma = {gamma:.6f}")
+        # Choose the root with the smaller absolute value (conservative step).
+        if abs(gamma_plus) <= abs(gamma_minus):
+            gamma = gamma_plus
         else:
+            gamma = gamma_minus
+
+        if gamma > 0.0:
+            logger.info(f"aSR: selected gamma = {gamma:.6f} (steepest-descent direction).")
+        else:
+            logger.warning(f"aSR: anti-steepest-descent direction (gamma={gamma:.6f}); falling back to plain SR (gamma=0.1).")
             gamma = 0.1
-            logger.warning(
-                f"aSR: no positive root (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
-                f"falling back to plain SR (gamma=0.1)."
-            )
 
         return float(gamma)
 

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -2109,18 +2109,19 @@ class MCMC:
 
         logger.info(f"aSR: gamma+ = {gamma_plus:.6f}, gamma- = {gamma_minus:.6f}")
 
-        # Choose the root with the smaller absolute value (conservative step).
-        if abs(gamma_plus) <= abs(gamma_minus):
-            gamma = gamma_plus
-        else:
-            gamma = gamma_minus
+        # Collect positive roots.
+        positive_roots = [g for g in (gamma_plus, gamma_minus) if g > 0.0]
 
-        if gamma > 0.0:
-            logger.debug("aSR: steepest-descent direction (gamma > 0).")
+        if positive_roots:
+            gamma = min(positive_roots)
+            logger.info(f"aSR: selected gamma = {gamma:.6f}")
         else:
-            logger.debug("aSR: anti-steepest-descent direction (gamma < 0).")
+            gamma = 0.1
+            logger.warning(
+                f"aSR: no positive root (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
+                f"falling back to plain SR (gamma=0.1)."
+            )
 
-        logger.info(f"aSR: selected gamma = {gamma:.6f}")
         return gamma
 
     @staticmethod
@@ -3456,30 +3457,37 @@ class MCMC:
                 # Solve LM eigenvalue problem
                 c_vec, E_lm = self.solve_linear_method(H_0_lm, f_vec_lm, S_mat, K_mat, B_mat, epsilon=lm_cond)
 
-                # Back-transform: c_vec[0] = c₀ (SR direction), c_vec[1:] = c_k (individual params)
-                theta = np.zeros(total_num_params, dtype=np.float64)
-                theta[:] += c_vec[0] * g_sr  # SR collective variable (affects all params)
-                if lm_subspace_dim == -1 or lm_subspace_dim >= total_num_params:
-                    theta[:] += c_vec[1:]
-                else:
-                    theta[subspace_indices] += c_vec[1:]
-
-                # DEBUG: trace theta after LM replacement
-                for _ti in _trace_idx:
-                    _c0_g = c_vec[0] * g_sr[_ti]
-                    _c_ind = 0.0
-                    if _ti in subspace_indices:
-                        _sub_pos = int(np.searchsorted(subspace_indices, _ti))
-                        if _sub_pos < len(subspace_indices) and subspace_indices[_sub_pos] == _ti:
-                            _c_ind = c_vec[1 + _sub_pos]
-                    logger.debug(
-                        "  [LM trace] flat=%d  theta_LM=%.6e  (c0*g=%.6e  c_ind=%.6e)  c0=%.6e",
-                        int(_ti),
-                        float(theta[_ti]),
-                        float(_c0_g),
-                        float(_c_ind),
-                        float(c_vec[0]),
+                if E_lm > H_0_lm + 3.0 * E_std:
+                    logger.warning(
+                        f"LM: E_LM={E_lm:.6f} > E_0 + 3*sigma = {H_0_lm:.6f} + 3*{E_std:.6f} = {H_0_lm + 3.0 * E_std:.6f}; "
+                        f"LM does not predict improvement. Falling back to plain SR."
                     )
+                    theta = 0.1 * g_sr
+                else:
+                    # Back-transform: c_vec[0] = c₀ (SR direction), c_vec[1:] = c_k (individual params)
+                    theta = np.zeros(total_num_params, dtype=np.float64)
+                    theta[:] += c_vec[0] * g_sr  # SR collective variable (affects all params)
+                    if lm_subspace_dim == -1 or lm_subspace_dim >= total_num_params:
+                        theta[:] += c_vec[1:]
+                    else:
+                        theta[subspace_indices] += c_vec[1:]
+
+                    # DEBUG: trace theta after LM replacement
+                    for _ti in _trace_idx:
+                        _c0_g = c_vec[0] * g_sr[_ti]
+                        _c_ind = 0.0
+                        if _ti in subspace_indices:
+                            _sub_pos = int(np.searchsorted(subspace_indices, _ti))
+                            if _sub_pos < len(subspace_indices) and subspace_indices[_sub_pos] == _ti:
+                                _c_ind = c_vec[1 + _sub_pos]
+                        logger.debug(
+                            "  [LM trace] flat=%d  theta_LM=%.6e  (c0*g=%.6e  c_ind=%.6e)  c0=%.6e",
+                            int(_ti),
+                            float(theta[_ti]),
+                            float(_c0_g),
+                            float(_c_ind),
+                            float(c_vec[0]),
+                        )
 
             elif use_lm:
                 # ---- aSR (lm_subspace_dim = 0) ----
@@ -5887,22 +5895,17 @@ class _MCMC_debug:
 
         logger.info(f"aSR: gamma+ = {gamma_plus:.6f}, gamma- = {gamma_minus:.6f}")
 
-        # Return the positive root; prefer the smaller one when both are positive.
-        if gamma_plus > 0.0 and gamma_minus <= 0.0:
-            gamma = gamma_plus
-        elif gamma_minus > 0.0 and gamma_plus <= 0.0:
-            gamma = gamma_minus
-        elif gamma_plus > 0.0 and gamma_minus > 0.0:
-            gamma = min(gamma_plus, gamma_minus)
-            logger.warning(
-                f"aSR: both roots positive (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
-                f"using smaller root gamma={gamma:.6f}."
-            )
+        # Collect positive roots; prefer the smaller one when both are positive.
+        positive_roots = [g for g in (gamma_plus, gamma_minus) if g > 0.0]
+
+        if positive_roots:
+            gamma = min(positive_roots)
+            logger.info(f"aSR: selected gamma = {gamma:.6f}")
         else:
-            gamma = gamma_plus if abs(gamma_plus) >= abs(gamma_minus) else gamma_minus
+            gamma = 0.1
             logger.warning(
-                f"aSR: neither root is positive (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
-                f"using root with larger absolute value gamma={gamma:.6f}."
+                f"aSR: no positive root (gamma+={gamma_plus:.6f}, gamma-={gamma_minus:.6f}); "
+                f"falling back to plain SR (gamma=0.1)."
             )
 
         return float(gamma)

--- a/jqmc/jqmc_tool.py
+++ b/jqmc/jqmc_tool.py
@@ -373,9 +373,11 @@ def trexio_convert_to(
                         # the median of the log-exponent distribution.
                         # The window width scales with n_shells/len: small
                         # selections stay near the middle, larger ones spread out.
+                        # Using /2.5 for a wider window that covers more of the
+                        # exponent range (e.g. 2/10 -> [32%,68%] of CDF).
                         log_exps = np.log(basis_exps)
                         frac = n_shells / len(basis_exps)
-                        margin = (1.0 - frac) / 2.0
+                        margin = (1.0 - frac) / 2.5
                         cdf = np.linspace(0, 1, len(log_exps))
                         lo = np.interp(margin, cdf, log_exps)
                         hi = np.interp(1.0 - margin, cdf, log_exps)

--- a/jqmc_workflow/_error_estimator.py
+++ b/jqmc_workflow/_error_estimator.py
@@ -53,6 +53,7 @@ def estimate_required_steps(
     pilot_error: float,
     target_error: float,
     walker_ratio: float = 1.0,
+    min_steps: int = 0,
 ) -> int:
     """Estimate total measurement steps to achieve *target_error*.
 
@@ -65,9 +66,9 @@ def estimate_required_steps(
 
     .. math::
 
-        N_{\\text{prod}} = \\lceil N_{\\text{pilot}}
+        N_{\\text{prod}} = N_{\\text{pilot}}
             \\times (\\sigma_{\\text{pilot}} / \\sigma_{\\text{target}})^2
-            \\times W_{\\text{pilot}} / W_{\\text{prod}} \\rceil
+            \\times W_{\\text{pilot}} / W_{\\text{prod}}
 
     Parameters
     ----------
@@ -82,21 +83,23 @@ def estimate_required_steps(
         When walkers-per-MPI is constant this equals
         ``pilot_num_mpi / prod_num_mpi``.
         Default 1.0 (same queue for pilot and production).
+    min_steps : int
+        Minimum number of steps to return (e.g. warmup + bin_blocks).
+        Default 0 (no minimum).
 
     Returns
     -------
     int
-        Estimated number of steps (never less than *pilot_steps*).
+        Estimated number of steps for the production run.
     """
     if target_error <= 0:
         raise ValueError(f"target_error must be positive, got {target_error}")
     if pilot_error <= 0:
         logger.warning(f"pilot_error={pilot_error} is non-positive; returning pilot_steps={pilot_steps} as fallback.")
-        return pilot_steps
+        return max(pilot_steps, min_steps)
 
     ratio_sq = (pilot_error / target_error) ** 2
-    n_required = math.ceil(pilot_steps * ratio_sq * walker_ratio)
-    n_required = max(n_required, pilot_steps)
+    n_required = max(int(pilot_steps * ratio_sq * walker_ratio), min_steps)
 
     logger.info(
         f"Step estimation (sigma ~ 1/sqrt(N*W)):\n"
@@ -105,7 +108,8 @@ def estimate_required_steps(
         f"  target_error   = {target_error:.6g} Ha\n"
         f"  (sig_p/sig_t)^2 = ({pilot_error:.6g}/{target_error:.6g})^2 = {ratio_sq:.2f}\n"
         f"  walker_ratio   = {walker_ratio:.4g}\n"
-        f"  N_required     = ceil({pilot_steps} * {ratio_sq:.2f} * {walker_ratio:.4g}) = {n_required}"
+        f"  min_steps      = {min_steps}\n"
+        f"  N_required     = max(int({pilot_steps} * {ratio_sq:.2f} * {walker_ratio:.4g}), {min_steps}) = {n_required}"
     )
     return n_required
 

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -802,6 +802,7 @@ class LRDMC_Workflow(Workflow):
                 pilot_error,
                 self.target_error,
                 walker_ratio=walker_ratio,
+                min_steps=self.num_gfmc_bin_blocks,
             )
             # Add warmup back: production also discards warmup steps
             estimated_steps += self.num_gfmc_warmup_steps

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -523,6 +523,7 @@ class MCMC_Workflow(Workflow):
                 pilot_error,
                 self.target_error,
                 walker_ratio=walker_ratio,
+                min_steps=self.num_mcmc_bin_blocks,
             )
             # Add warmup back: production also discards warmup steps
             estimated_steps += self.num_mcmc_warmup_steps

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -540,7 +540,11 @@ class VMC_Workflow(Workflow):
         output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = h5_files + output_logs
 
-        opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")))
+        def _h5_step_num(path: str) -> int:
+            m = re.search(r"hamiltonian_data_opt_step_(\d+)\.h5$", path)
+            return int(m.group(1)) if m else -1
+
+        opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")), key=_h5_step_num)
         if opt_files:
             self.output_values["optimized_hamiltonian"] = os.path.basename(opt_files[-1])
         restart_chk = self._find_restart_chk(_wd)
@@ -795,7 +799,11 @@ class VMC_Workflow(Workflow):
         output_logs = sorted(os.path.basename(f) for f in glob.glob(os.path.join(_wd, "*.out")))
         self.output_files = h5_files + output_logs
 
-        opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")))
+        def _h5_step_num(path: str) -> int:
+            m = re.search(r"hamiltonian_data_opt_step_(\d+)\.h5$", path)
+            return int(m.group(1)) if m else -1
+
+        opt_files = sorted(glob.glob(os.path.join(_wd, "hamiltonian_data_opt_step_*.h5")), key=_h5_step_num)
         if opt_files:
             self.output_values["optimized_hamiltonian"] = os.path.basename(opt_files[-1])
         restart_chk = self._find_restart_chk(_wd)

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -634,6 +634,7 @@ class VMC_Workflow(Workflow):
                 pilot_error,
                 self.target_error,
                 walker_ratio=walker_ratio,
+                min_steps=self.num_mcmc_bin_blocks or 0,
             )
             # Add warmup back: production also discards warmup steps
             estimated_mcmc_steps += warmup

--- a/tests/test_ao_basis_optimization.py
+++ b/tests/test_ao_basis_optimization.py
@@ -14,7 +14,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc.atomic_orbital import AOs_cart_data, AOs_sphe_data  # noqa: E402
+from jqmc.atomic_orbital import AOs_cart_data, AOs_sphe_data, ShellPrimMap  # noqa: E402
 from jqmc.determinant import Geminal_data, compute_det_geminal_all_elements  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -528,10 +528,10 @@ def test_full_wavefunction_exponent_gradient():
 
 
 def test_shell_symmetrize_j3_basis():
-    """apply_block_update passes exponents through without shell averaging.
+    """apply_block_update shell-averages exponents within each shell group.
 
-    Post-update symmetrization was removed; O_k is now symmetrized at source
-    in get_dln_WF, so apply_block_update stores the raw values as-is.
+    Post-update symmetrization is applied in apply_block_update so that
+    shell-mates always share identical radial parameters.
     """
     _, aos_data, _, _, _, _ = _load_trexio("H2_ae_ccpvdz_cart.h5")
 
@@ -557,15 +557,17 @@ def test_shell_symmetrize_j3_basis():
     jastrow_new = jastrow_data.apply_block_update(block)
     result = np.array(jastrow_new.jastrow_three_body_data.ao_exponents)
 
-    # apply_block_update stores the raw perturbed values (no shell averaging)
-    npt.assert_allclose(result, perturbed, rtol=1e-14)
+    # apply_block_update shell-averages the perturbed values
+    spm = ShellPrimMap.from_aos_data(aos_data)
+    expected = spm.symmetrize(perturbed)
+    npt.assert_allclose(result, expected, rtol=1e-14)
 
 
 def test_shell_symmetrize_geminal_basis():
-    """apply_block_update passes exponents through without shell averaging (Geminal).
+    """apply_block_update shell-averages exponents within each shell group (Geminal).
 
-    Post-update symmetrization was removed; O_k is now symmetrized at source
-    in get_dln_WF, so apply_block_update stores the raw values as-is.
+    Post-update symmetrization is applied in apply_block_update so that
+    shell-mates always share identical radial parameters.
     """
     _, _, _, _, geminal_mo_data, _ = _load_trexio("H2_ae_ccpvdz_cart.h5")
 
@@ -593,8 +595,15 @@ def test_shell_symmetrize_geminal_basis():
             np.array(geminal_new.ao_exponents_dn),
         ]
     )
-    # apply_block_update stores the raw perturbed values (no shell averaging)
-    npt.assert_allclose(result, perturbed, rtol=1e-14)
+    # apply_block_update shell-averages the perturbed values
+    from jqmc.wavefunction import _get_aos_data
+
+    spm = ShellPrimMap.concat(
+        ShellPrimMap.from_aos_data(_get_aos_data(geminal_ao.orb_data_up_spin)),
+        ShellPrimMap.from_aos_data(_get_aos_data(geminal_ao.orb_data_dn_spin)),
+    )
+    expected = spm.symmetrize(perturbed)
+    npt.assert_allclose(result, expected, rtol=1e-14)
 
 
 def test_shell_symmetrize_metric_averages_sn():

--- a/tests/test_determinant.py
+++ b/tests/test_determinant.py
@@ -1593,20 +1593,14 @@ def test_symmetrize_lambda_1d():
 
 
 def test_apply_block_update_square_symmetric_preserved():
-    """L2-1: symmetric square lambda stays symmetric when delta is symmetric.
-
-    Symmetry is enforced at the O_k level (get_dln_WF), so theta and
-    parameter updates are always symmetric.  apply_block_update no longer
-    symmetrizes post-hoc.
-    """
+    """L2-1: symmetric square lambda stays symmetric after non-symmetric delta."""
     rng = np.random.RandomState(10)
     n = 5
     lam_sym = rng.randn(n, n)
     lam_sym = 0.5 * (lam_sym + lam_sym.T)
     gd = _make_geminal_with_lambda(lam_sym)
 
-    delta = rng.randn(n, n)
-    delta = 0.5 * (delta + delta.T)  # symmetric delta (as produced by O_k symmetrization)
+    delta = rng.randn(n, n)  # intentionally non-symmetric
     lr = 0.1
     updated_values = lam_sym + lr * delta
     block = VariationalParameterBlock(
@@ -1636,12 +1630,7 @@ def test_apply_block_update_square_nonsymmetric_free():
 
 
 def test_apply_block_update_rect_paired_symmetric_preserved():
-    """L2-3: rectangular lambda, paired part stays symmetric when delta paired part is symmetric.
-
-    Symmetry is enforced at the O_k level, so the paired sub-block of
-    theta is always symmetric.  apply_block_update no longer symmetrizes
-    post-hoc.
-    """
+    """L2-3: rectangular lambda, paired part stays symmetric after non-symmetric delta."""
     rng = np.random.RandomState(12)
     n_up = 4
     n_extra = 2
@@ -1651,10 +1640,7 @@ def test_apply_block_update_rect_paired_symmetric_preserved():
     lam_rect = np.column_stack([paired, unpaired])
     gd = _make_geminal_with_lambda(lam_rect, num_up=n_up + n_extra, num_dn=n_up)
 
-    delta_paired = rng.randn(n_up, n_up)
-    delta_paired = 0.5 * (delta_paired + delta_paired.T)  # symmetric paired delta
-    delta_unpaired = rng.randn(n_up, n_extra)
-    delta = np.column_stack([delta_paired, delta_unpaired])
+    delta = rng.randn(n_up, n_up + n_extra)
     lr = 0.1
     updated_values = lam_rect + lr * delta
     block = VariationalParameterBlock(

--- a/tests/test_jastrow.py
+++ b/tests/test_jastrow.py
@@ -1573,12 +1573,7 @@ def test_symmetrize_j3_too_few_columns():
 
 
 def test_apply_block_update_symmetric_j3_preserved():
-    """L2-4: symmetric j3 stays symmetric when delta square sub-block is symmetric.
-
-    Symmetry is enforced at the O_k level (get_dln_WF), so the square
-    sub-block of theta is always symmetric.  apply_block_update no longer
-    symmetrizes post-hoc.
-    """
+    """L2-4: symmetric j3 stays symmetric after non-symmetric delta."""
     rng = np.random.RandomState(20)
     n = 4
     sq_sym = rng.randn(n, n)
@@ -1587,10 +1582,7 @@ def test_apply_block_update_symmetric_j3_preserved():
     j_matrix = np.column_stack([sq_sym, last_col])
     jd = _make_jastrow_with_j3(j_matrix)
 
-    delta_sq = rng.randn(n, n)
-    delta_sq = 0.5 * (delta_sq + delta_sq.T)  # symmetric square sub-block
-    delta_last = rng.randn(n)
-    delta = np.column_stack([delta_sq, delta_last])
+    delta = rng.randn(n, n + 1)
     lr = 0.1
     updated_values = j_matrix + lr * delta
     block = VariationalParameterBlock(

--- a/tests/test_jqmc_tool.py
+++ b/tests/test_jqmc_tool.py
@@ -228,7 +228,7 @@ class TestTrexioConvertTo:
                     else:
                         log_exps = np.log(basis_exps)
                         frac = n_shells / len(basis_exps)
-                        margin = (1.0 - frac) / 2.0
+                        margin = (1.0 - frac) / 2.5
                         cdf = np.linspace(0, 1, len(log_exps))
                         lo = np.interp(margin, cdf, log_exps)
                         hi = np.interp(1.0 - margin, cdf, log_exps)


### PR DESCRIPTION
Fix optimizer fallback, restore post-update symmetrization, and improve step estimation

  - **aSR optimizer fallback**: Both `MCMC` and `_MCMC_debug` now select the smallest positive root for gamma; when no positive root exists, fall back to plain SR (`gamma=0.1`) instead  of using a negative root
  - **LM energy guard**: When `E_LM > E_0 + 3 \sigma`, the Linear Method is skipped and falls back to plain SR to avoid uphill steps
  - **Restore post-update symmetrization**: Re-enable `symmetrize_lambda`, `_symmetrize_ao_basis`, and `symmetrize_j3` in `apply_block_update` for `determinant.py` and  `jastrow_factor.py` — symmetrizing only at the O_k source was insufficient
  - **Step estimation fix**: `estimate_required_steps` now accepts `min_steps` parameter and removes the `ceil` / `max(n, pilot_steps)` floor, giving more accurate production step counts; all workflows pass `min_steps=num_bin_blocks`
  - **Wider AO basis exponent window**: Change margin divisor from 2.0 to 2.5 in `trexio_convert_to` for broader exponent coverage