### PR TITLE
Fix SSH connection hangs, leaks, and consolidate Machine objects

### DIFF
--- a/examples/jqmc-example01/README.md
+++ b/examples/jqmc-example01/README.md
@@ -351,7 +351,7 @@ max_time = 86400 # Maximum time in sec.
 restart = false
 restart_chk = "restart.h5" # Restart checkpoint file. If restart is True, this file is used.
 hamiltonian_h5 = "hamiltonian_data.h5" # Hamiltonian checkpoint file. If restart is False, this file is used.
-verbosity = "low" # Verbosity level. "low" or "high"
+verbosity = "high" # Verbosity level. "low" or "high"
 
 [vmc]
 num_mcmc_steps = 500 # Number of observable measurement steps per MPI and Walker. Every local energy and other observeables are measured num_mcmc_steps times in total. The total number of measurements is num_mcmc_steps * mpi_size * number_of_walkers.
@@ -362,14 +362,17 @@ Dt = 2.0 # Step size for the MCMC update (bohr).
 epsilon_AS = 0.0 # the epsilon parameter used in the Attacalite-Sandro regulatization method.
 num_opt_steps = 300 # Number of optimization steps.
 wf_dump_freq = 1 # Frequency of wavefunction (i.e. hamiltonian_data) dump.
-optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, adaptive_learning_rate = true } # SR optimizer configuration (method plus step/regularization).
+optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, use_lm = true } # SR optimizer configuration (method plus step/regularization).
 opt_J1_param = false
 opt_J2_param = true
 opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = false
 opt_with_projected_MOs = false
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
+opt_J3_basis_exp = true
+opt_J3_basis_coeff = true
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 Please lunch the job.
@@ -414,7 +417,7 @@ The important criteria are `Max f` and `Max of signal to noise of f`. `Max f` sh
 > [!TIP]
 > If the optimization does not converge well, try the following:
 > - Adjust the `delta` parameter in `optimizer_kwargs`. A smaller `delta` (e.g., `0.05`) makes the optimization more conservative but stable, while a larger one (e.g., `0.30`) is more aggressive but may cause instabilities.
-> - Set `adaptive_learning_rate = false` in `optimizer_kwargs` to disable the adaptive learning rate and use a fixed step size instead. This can sometimes improve convergence for difficult cases.
+> - Set `use_lm = false` in `optimizer_kwargs` to disable the Linear Method (LM) and use a fixed step size instead. This can sometimes improve convergence for difficult cases.
 
 You can also plot them and make a figure.
 

--- a/examples/jqmc-example02/README.md
+++ b/examples/jqmc-example02/README.md
@@ -118,7 +118,10 @@ opt_J3_param = false
 opt_JNN_param = true
 opt_lambda_param = false
 opt_with_projected_MOs = false
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 optimizer_kwargs = { method = "adam" }
 ```
 

--- a/examples/jqmc-example03/README.md
+++ b/examples/jqmc-example03/README.md
@@ -103,14 +103,17 @@ Dt = 2.0 # Step size for the MCMC update (bohr).
 epsilon_AS = 0.0 # the epsilon parameter used in the Attacalite-Sandro regulatization method.
 num_opt_steps = 300 # Number of optimization steps.
 wf_dump_freq = 1 # Frequency of wavefunction (i.e. hamiltonian_data) dump.
-optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, adaptive_learning_rate = true } # SR optimizer configuration (method plus step/regularization).
+optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, use_lm = true } # SR optimizer configuration (method plus step/regularization).
 opt_J1_param = false
 opt_J2_param = true
 opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = true
 opt_with_projected_MOs = true
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 The key differences from `example01` are:
@@ -137,7 +140,7 @@ The important criteria are `Max f` and `Max of signal to noise of f`. `Max f` sh
 > [!TIP]
 > If the optimization does not converge well, try the following:
 > - Adjust the `delta` parameter in `optimizer_kwargs`. A smaller `delta` (e.g., `0.05`) makes the optimization more conservative but stable, while a larger one (e.g., `0.30`) is more aggressive but may cause instabilities.
-> - Set `adaptive_learning_rate = false` in `optimizer_kwargs` to disable the adaptive learning rate and use a fixed step size instead. This can sometimes improve convergence for difficult cases.
+> - Set `use_lm = false` in `optimizer_kwargs` to disable the Linear Method (LM) and use a fixed step size instead. This can sometimes improve convergence for difficult cases.
 
 You can also plot them and make a figure.
 

--- a/examples/jqmc-example04/README.md
+++ b/examples/jqmc-example04/README.md
@@ -215,14 +215,17 @@ Dt = 2.0 # Step size for the MCMC update (bohr).
 epsilon_AS = 0.0 # the epsilon parameter used in the Attacalite-Sandro regulatization method.
 num_opt_steps = 200 # Number of optimization steps.
 wf_dump_freq = 20 # Frequency of wavefunction (i.e. hamiltonian_data) dump.
-optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, adaptive_learning_rate = true } # SR optimizer configuration (method plus step/regularization).
+optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, use_lm = true } # SR optimizer configuration (method plus step/regularization).
 opt_J1_param = false
 opt_J2_param = true
 opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = false
 opt_with_projected_MOs = false
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 Please lunch the job.
@@ -436,14 +439,17 @@ Dt = 2.0 # Step size for the MCMC update (bohr).
 epsilon_AS = 0.05 # the epsilon parameter used in the Attacalite-Sandro regulatization method.
 num_opt_steps = 200 # Number of optimization steps.
 wf_dump_freq = 20 # Frequency of wavefunction (i.e. hamiltonian_data) dump.
-optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, adaptive_learning_rate = true } # SR optimizer configuration (method plus step/regularization).
+optimizer_kwargs = { method = "sr", delta = 0.15, epsilon = 0.001, cg_flag = true, cg_max_iter = 10000, cg_tol = 1e-6, use_lm = true } # SR optimizer configuration (method plus step/regularization).
 opt_J1_param = false
 opt_J2_param = true
 opt_J3_param = true
 opt_JNN_param = false
 opt_lambda_param = true
 opt_with_projected_MOs = false
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If it is set 0, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 > [!IMPORTANT]

--- a/examples/jqmc-example05/README.md
+++ b/examples/jqmc-example05/README.md
@@ -95,7 +95,10 @@ opt_J1_param = true
 opt_J2_param = true
 opt_J3_param = true
 opt_lambda_param = false
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If None, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 Please launch the job.
@@ -309,7 +312,10 @@ opt_J1_param = true
 opt_J2_param = true
 opt_J3_param = true
 opt_lambda_param = true
-num_param_opt = 0 # the number of parameters to optimize in the descending order of |f|/|std f|. If None, all parameters are optimized.
+opt_J3_basis_exp = false
+opt_J3_basis_coeff = false
+opt_lambda_basis_exp = false
+opt_lambda_basis_coeff = false
 ```
 
 Please launch the job.

--- a/examples/jqmc-workflow-example01/run_pes_pipeline.py
+++ b/examples/jqmc-workflow-example01/run_pes_pipeline.py
@@ -277,7 +277,7 @@ def build_pipeline() -> tuple[list[Container], dict[float, Container], dict[floa
                 target_error=TARGET_VMC_ERROR,
                 target_snr=TARGET_SNR,
                 energy_slope_sigma_threshold=ENERGY_SLOPE_THRESHOLD,
-                optimizer_kwargs={"method": "sr", "delta": 0.300, "epsilon": 0.010, "adaptive_learning_rate": True},
+                optimizer_kwargs={"method": "sr", "delta": 0.300, "epsilon": 0.010, "use_lm": True},
                 max_time=3000,
                 poll_interval=120,
                 max_continuation=1,

--- a/examples/jqmc-workflow-example02/run_pipelines.py
+++ b/examples/jqmc-workflow-example02/run_pipelines.py
@@ -229,7 +229,7 @@ def build_pipeline() -> tuple[
                 "method": "sr",
                 "delta": 0.350,
                 "epsilon": 0.001,
-                "adaptive_learning_rate": True,
+                "use_lm": True,
             },
             max_time=3000,
             poll_interval=300,

--- a/examples/jqmc-workflow-example03/run_pipelines.py
+++ b/examples/jqmc-workflow-example03/run_pipelines.py
@@ -9,7 +9,7 @@ For a water molecule (ccECP, cc-pVTZ, Cartesian), this script:
 
 Patterns
 --------
-  A) J3 + MCMC   — SR adaptive_learning_rate=True, delta=0.35
+  A) J3 + MCMC   — SR use_lm=True, delta=0.35
   B) J3 + LRDMC  — same VMC; LRDMC a=0.30
 """
 
@@ -187,7 +187,7 @@ def build_pipeline() -> tuple[
         ),
     )
 
-    # VMC: SR with adaptive_learning_rate=True, delta=0.35
+    # VMC: SR with use_lm=True, delta=0.35
     vmc = Container(
         label="vmc",
         dirname="02_vmc",
@@ -215,7 +215,7 @@ def build_pipeline() -> tuple[
                 "method": "sr",
                 "delta": 0.350,
                 "epsilon": 0.001,
-                "adaptive_learning_rate": True,
+                "use_lm": True,
             },
             max_time=MAX_TIME,
             poll_interval=POLL_INTERVAL,

--- a/examples/jqmc-workflow-example99/run_test_on_local.py
+++ b/examples/jqmc-workflow-example99/run_test_on_local.py
@@ -174,7 +174,7 @@ def build_pipeline() -> list[Container]:
                     "method": "sr",
                     "delta": 0.100,
                     "epsilon": 0.100,
-                    "adaptive_learning_rate": True,
+                    "use_lm": True,
                 },
                 max_time=600,
                 poll_interval=120,

--- a/examples/jqmc-workflow-example99/run_test_on_local.py
+++ b/examples/jqmc-workflow-example99/run_test_on_local.py
@@ -41,7 +41,7 @@ from jqmc_workflow import (
 )
 
 # ── Configuration ─────────────────────────────────────────────────
-SERVER = "localhost"
+SERVER = "cluster"
 QUEUE_LABEL = "qM"
 
 # Tiny parameters for fast local testing

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -2360,12 +2360,9 @@ class MCMC:
             opt_lambda_basis_coeff (bool, optional): Optimize Geminal AO contraction coefficients (up and down). Defaults to False.
                 Cannot be combined with ``opt_with_projected_MOs``.
             optimizer_kwargs (dict | None, optional): Optimizer configuration.
-                ``method='sr'`` uses SR keys (``sr_delta``, ``sr_epsilon``, ``cg_flag``,
-                ``cg_max_iter``, ``cg_tol``, ``adaptive_learning_rate``);
-                ``use_lm=True`` enables LM with keys (``lm_subspace_dim``, ``lm_cond``,
-                ``lm_subspace_dim``, ``lm_cond``); ``adaptive_learning_rate=True`` (SR only) enables
-                accelerated SR (aSR) gamma scaling and requires
-                ``compute_log_WF_param_deriv=True`` and ``comput_e_L_param_deriv=True``;
+                ``method='sr'`` uses SR keys (``delta``, ``epsilon``, ``cg_flag``,
+                ``cg_max_iter``, ``cg_tol``);
+                ``use_lm=True`` enables LM with keys (``lm_subspace_dim``, ``lm_cond``);
                 other ``method`` names are optax constructors (e.g., ``"adam"``) and
                 receive remaining keys.
 

--- a/jqmc_workflow/_cli.py
+++ b/jqmc_workflow/_cli.py
@@ -274,17 +274,19 @@ class Monitor:
             from ._machine import Machine
 
             machine = Machine(server)
-            job_list_text = machine.get_job_list_as_text()
+            try:
+                job_list_text = machine.get_job_list_as_text()
 
-            # PBS may store "1428989.opbs" but qstat shows "1428989".
-            jid_short = stored_job_id.split(".")[0]
-            found = any(stored_job_id in line or jid_short in line for line in job_list_text)
-            if found:
-                logger.info(f"  Job {stored_job_id} is RUNNING on {server}.")
-            else:
-                logger.info(f"  Job {stored_job_id} is NOT in the queue on {server}.")
-                logger.info(f"  (it may have finished or been cancelled)")
-            machine.ssh_close()
+                # PBS may store "1428989.opbs" but qstat shows "1428989".
+                jid_short = stored_job_id.split(".")[0]
+                found = any(stored_job_id in line or jid_short in line for line in job_list_text)
+                if found:
+                    logger.info(f"  Job {stored_job_id} is RUNNING on {server}.")
+                else:
+                    logger.info(f"  Job {stored_job_id} is NOT in the queue on {server}.")
+                    logger.info(f"  (it may have finished or been cancelled)")
+            finally:
+                machine.ssh_close()
         except Exception as ex:
             logger.error(f"  Failed to check job on {server}: {ex}")
 
@@ -310,9 +312,11 @@ class Monitor:
                 from ._machine import Machine
 
                 machine = Machine(server)
-                result = machine.delete_job(stored_job_id)
-                logger.info(f"  Queue response: {' '.join(result)}")
-                machine.ssh_close()
+                try:
+                    result = machine.delete_job(stored_job_id)
+                    logger.info(f"  Queue response: {' '.join(result)}")
+                finally:
+                    machine.ssh_close()
             except Exception as ex:
                 logger.error(f"  Failed to delete job on {server}: {ex}")
 

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -106,10 +106,10 @@ class JobSubmission:
         run_id: str = "",
         safe_mode: bool = False,
     ):
-        self.server_machine = Machine(server_machine_name)
         self.data_transfer = Data_transfer(
             server_machine_name=server_machine_name,
         )
+        self.server_machine = self.data_transfer.server_machine
 
         # Bootstrap config directory if needed
         cfg = get_config_dir()
@@ -262,7 +262,6 @@ class JobSubmission:
             self.job_submit_date = datetime.today()
             logger.info(f"  Job submitted (number={self.job_number}).")
 
-            self._close_ssh()
             return True, self.job_number
 
         except Exception as e:
@@ -270,6 +269,8 @@ class JobSubmission:
             self.job_running = False
             logger.error(f"Job submission failed: {e}")
             raise
+        finally:
+            self._close_ssh()
 
     # ── Job checking ──────────────────────────────────────────────
 

--- a/jqmc_workflow/_machine.py
+++ b/jqmc_workflow/_machine.py
@@ -158,6 +158,9 @@ class Machine:
                 if proxy_flag:
                     kwargs["sock"] = paramiko.ProxyCommand(proxy_command)
                 self.ssh.connect(**kwargs)
+                # Enable SSH keepalive so the client detects dead connections
+                # early instead of discovering them at close() time.
+                self.ssh.get_transport().set_keepalive(30)
                 logger.info(f"  SSH connected (attempt {tt + 1})")
                 break
             except paramiko.ssh_exception.SSHException:
@@ -173,25 +176,21 @@ class Machine:
     def ssh_close(self):
         if self.machine_type != "remote" or not self.ssh_status:
             return
-        max_retries = 3
         timeout_sec = 5.0
 
         for obj_name, obj in [("sftp", self.sftp), ("ssh", self.ssh)]:
-            for attempt in range(1, max_retries + 1):
-                executor = ThreadPoolExecutor(max_workers=1)
-                future = executor.submit(obj.close)
-                try:
-                    future.result(timeout=timeout_sec)
-                    logger.debug(f"{obj_name}.close() ok (attempt {attempt})")
-                    break
-                except Exception as e:
-                    logger.warning(f"{obj_name}.close() attempt {attempt}: {e.__class__.__name__}: {e}")
-                    if attempt == max_retries:
-                        logger.error(f"{obj_name}.close() failed after {max_retries} attempts")
-                        raise ValueError(f"Cannot close {obj_name}")
-                    time.sleep(1)
-                finally:
-                    executor.shutdown(wait=True)
+            executor = ThreadPoolExecutor(max_workers=1)
+            future = executor.submit(obj.close)
+            try:
+                future.result(timeout=timeout_sec)
+                logger.debug(f"{obj_name}.close() ok")
+            except Exception as e:
+                logger.warning(f"{obj_name}.close() failed ({e.__class__.__name__}: {e}) — abandoning")
+                future.cancel()
+            finally:
+                # wait=False: the close thread may be stuck on a dead connection;
+                # waiting would hang forever (the reason we timed out in the first place).
+                executor.shutdown(wait=False)
 
         del self.ssh
         del self.sftp
@@ -347,7 +346,9 @@ class Machine:
                     raise RuntimeError(f"SFTP lstat failed for '{path}'")
                 time.sleep(1)
             finally:
-                executor.shutdown(wait=True)
+                # wait=False: the lstat thread may be stuck on a dead connection;
+                # waiting would hang forever.
+                executor.shutdown(wait=False)
 
     def is_file(self, file_name: str) -> bool:
         if self.machine_type == "local":
@@ -390,8 +391,8 @@ class Machines_handler:
     The client is always localhost — only one Machine (server) is needed.
     """
 
-    def __init__(self, server_machine_name: str):
-        self.server_machine = Machine(server_machine_name)
+    def __init__(self, machine: Machine):
+        self.server_machine = machine
 
     def ssh_close(self):
         self.server_machine.ssh_close()

--- a/jqmc_workflow/_machine.py
+++ b/jqmc_workflow/_machine.py
@@ -112,7 +112,8 @@ class Machine:
         ssh_config = paramiko.SSHConfig()
         config_file = os.path.join(os.getenv("HOME"), ".ssh/config")
         try:
-            ssh_config.parse(open(config_file, "r"))
+            with open(config_file, "r") as fh:
+                ssh_config.parse(fh)
         except FileNotFoundError:
             logger.error(f"SSH config file ({config_file}) is required.")
             raise
@@ -175,7 +176,7 @@ class Machine:
         max_retries = 3
         timeout_sec = 5.0
 
-        for obj_name, obj in [("ssh", self.ssh), ("sftp", self.sftp)]:
+        for obj_name, obj in [("sftp", self.sftp), ("ssh", self.ssh)]:
             for attempt in range(1, max_retries + 1):
                 executor = ThreadPoolExecutor(max_workers=1)
                 future = executor.submit(obj.close)
@@ -190,7 +191,7 @@ class Machine:
                         raise ValueError(f"Cannot close {obj_name}")
                     time.sleep(1)
                 finally:
-                    executor.shutdown(wait=False, cancel_futures=True)
+                    executor.shutdown(wait=True)
 
         del self.ssh
         del self.sftp
@@ -317,9 +318,13 @@ class Machine:
     def _run_remote(self, command_r: str):
         self.ssh_open()
         _, pstdout, pstderr = self.ssh.exec_command(command=command_r)
-        exit_status = pstdout.channel.recv_exit_status()
-        stdout = pstdout.read().decode("utf-8").strip()
-        stderr = pstderr.read().decode("utf-8").strip()
+        try:
+            exit_status = pstdout.channel.recv_exit_status()
+            stdout = pstdout.read().decode("utf-8").strip()
+            stderr = pstderr.read().decode("utf-8").strip()
+        finally:
+            pstdout.close()
+            pstderr.close()
         if exit_status != 0:
             logger.error(f"Remote command failed: {command_r}")
             logger.error(f"stdout={stdout}")
@@ -342,7 +347,7 @@ class Machine:
                     raise RuntimeError(f"SFTP lstat failed for '{path}'")
                 time.sleep(1)
             finally:
-                executor.shutdown(wait=False, cancel_futures=True)
+                executor.shutdown(wait=True)
 
     def is_file(self, file_name: str) -> bool:
         if self.machine_type == "local":

--- a/jqmc_workflow/_state.py
+++ b/jqmc_workflow/_state.py
@@ -182,6 +182,46 @@ def _check_normal_termination(directory: str, jobs: list) -> list[str]:
     return abnormal
 
 
+def validate_completion(directory: str, output_values: dict | None = None) -> tuple[bool, str]:
+    """Run all post-completion checks and return ``(ok, error_msg)``.
+
+    Called once from :class:`Container` after a workflow reports
+    ``COMPLETED``.  All "is this really completed?" checks live here.
+
+    Parameters
+    ----------
+    directory : str
+        Working directory containing ``workflow_state.toml`` and
+        fetched output files.
+    output_values : dict, optional
+        Scalar results from the workflow (energy, error, etc.).
+
+    Returns
+    -------
+    ok : bool
+        ``True`` if all checks pass.
+    error_msg : str
+        Empty when *ok* is ``True``; describes the failure otherwise.
+    """
+    output_values = output_values or {}
+    state = read_state(directory)
+
+    # ── Check 1: "Program ends" marker in output files ────────────
+    abnormal = _check_normal_termination(directory, state.get("jobs", []))
+    if abnormal:
+        files_str = ", ".join(abnormal)
+        return False, f"Abnormal termination: 'Program ends' marker missing in output file(s): {files_str}"
+
+    # ── Check 2: Non-finite energy ────────────────────────────────
+    import math
+
+    energy = output_values.get("energy")
+    if energy is not None and not math.isfinite(energy):
+        return False, f"Non-finite energy detected (E={energy})"
+
+    return True, ""
+
+
 def update_status(
     directory: str,
     status: str | WorkflowStatus,
@@ -202,13 +242,6 @@ def update_status(
     **extra_fields
         Additional fields.  Keys starting with ``result_`` go into
         ``[result]``; everything else goes into ``[workflow]``.
-
-    When *status* is ``"completed"``, every fetched output file listed in
-    the ``[[jobs]]`` table is checked for the ``Program ends`` footer.  If
-    any output file exists on disk but lacks this marker the status is
-    automatically downgraded to ``"failed"`` and an ``error`` field is
-    recorded, because the absence almost certainly indicates abnormal
-    termination (e.g. wall-time expiration on a supercomputer).
     """
     # Ensure we work with raw string for VALID_STATUSES check
     status_str = status.value if isinstance(status, WorkflowStatus) else status
@@ -218,16 +251,6 @@ def update_status(
     if not state:
         logger.warning(f"No workflow_state.toml in {directory}; creating minimal one.")
         state = {"workflow": {}, "jobs": [], "result": {}}
-
-    # ── Abnormal-termination guard ────────────────────────────────
-    if status_str == "completed":
-        abnormal = _check_normal_termination(directory, state.get("jobs", []))
-        if abnormal:
-            files_str = ", ".join(abnormal)
-            error_msg = f"Abnormal termination detected: 'Program ends' marker missing in output file(s): {files_str}"
-            logger.error(error_msg)
-            status_str = "failed"
-            extra_fields.setdefault("error", error_msg)
 
     state.setdefault("workflow", {})
     state["workflow"]["status"] = status_str

--- a/jqmc_workflow/_transfer.py
+++ b/jqmc_workflow/_transfer.py
@@ -70,7 +70,10 @@ class Data_transfer:
         """Determine the local workspace_root from localhost entry."""
         try:
             local_m = Machine("localhost")
-            return local_m.workspace_root or os.path.expanduser("~")
+            try:
+                return local_m.workspace_root or os.path.expanduser("~")
+            finally:
+                local_m.ssh_close()
         except (KeyError, FileNotFoundError):
             return os.path.expanduser("~")
 

--- a/jqmc_workflow/_transfer.py
+++ b/jqmc_workflow/_transfer.py
@@ -58,9 +58,7 @@ class Data_transfer:
 
     def __init__(self, server_machine_name: str, safe_mode: bool = False):
         self.server_machine = Machine(server_machine_name)
-        self.machine_handler = Machines_handler(
-            server_machine_name=server_machine_name,
-        )
+        self.machine_handler = Machines_handler(self.server_machine)
         self.safe_mode = safe_mode
 
         # Local root from machine_data.yaml (for path mapping)

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -61,6 +61,7 @@ from ._state import (
     set_input_fingerprints,
     update_job,
     update_status,
+    validate_completion,
 )
 
 logger = getLogger("jqmc-workflow").getChild(__name__)
@@ -554,7 +555,9 @@ class Workflow:
             # Collect scheduler accounting before fetch
             self._collect_job_acct(job, work_dir, input_file)
 
-            job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch)
+            job.fetch_job(
+                from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
+            )
         finally:
             job._close_ssh()
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
@@ -876,10 +879,18 @@ class Container:
 
         # Write completion — but only if the workflow did not fail.
         if self.status != WorkflowStatus.FAILED:
-            result_fields = {}
-            for k, v in self.output_values.items():
-                result_fields[f"result_{k}"] = v
-            update_status(proj, WorkflowStatus.COMPLETED, **result_fields)
+            # Run all post-completion validation checks in one place.
+            ok, error_msg = validate_completion(proj, self.output_values)
+            if ok:
+                result_fields = {}
+                for k, v in self.output_values.items():
+                    result_fields[f"result_{k}"] = v
+                update_status(proj, WorkflowStatus.COMPLETED, **result_fields)
+            else:
+                logger.error(error_msg)
+                self.status = WorkflowStatus.FAILED
+                set_error(proj, error_msg)
+                update_status(proj, WorkflowStatus.FAILED)
         else:
             error_msg = self.output_values.get("error", f"workflow returned status={self.status}")
             set_error(proj, error_msg)

--- a/jqmc_workflow/workflow.py
+++ b/jqmc_workflow/workflow.py
@@ -467,11 +467,14 @@ class Workflow:
         # These are non-essential: warn (not error) if missing on server.
         optional_fetch = []
         job_tmp = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
-        if job_tmp.server_machine.queuing:
-            for jf in (job_tmp.job_stdout, job_tmp.job_stderr):
-                if jf and jf not in fetch_from_objects:
-                    fetch_from_objects.append(jf)
-                    optional_fetch.append(jf)
+        try:
+            if job_tmp.server_machine.queuing:
+                for jf in (job_tmp.job_stdout, job_tmp.job_stderr):
+                    if jf and jf not in fetch_from_objects:
+                        fetch_from_objects.append(jf)
+                        optional_fetch.append(jf)
+        finally:
+            job_tmp._close_ssh()
 
         # ── Restart detection via job history ─────────────────────
         if step is not None:
@@ -486,9 +489,12 @@ class Workflow:
         if recorded.get("status") == "completed":
             logger.info(f"  {input_file}: completed but not fetched. Fetching...")
             job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
-            job.fetch_job(
-                from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
-            )
+            try:
+                job.fetch_job(
+                    from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
+                )
+            finally:
+                job._close_ssh()
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
 
@@ -496,55 +502,61 @@ class Workflow:
             stored_job_id = recorded.get("job_id")
             logger.info(f"  Resuming previously submitted job {stored_job_id}")
             job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
-            job.job_number = stored_job_id
-            while job.jobcheck():
-                logger.info(f"  Job {stored_job_id} still running, waiting {self.poll_interval}s...")
-                await asyncio.sleep(self.poll_interval)
-            logger.info("  Job completed.")
-            update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
-            self._collect_job_acct(job, work_dir, input_file)
-            job.fetch_job(
-                from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
-            )
+            try:
+                job.job_number = stored_job_id
+                while job.jobcheck():
+                    logger.info(f"  Job {stored_job_id} still running, waiting {self.poll_interval}s...")
+                    await asyncio.sleep(self.poll_interval)
+                logger.info("  Job completed.")
+                update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
+                self._collect_job_acct(job, work_dir, input_file)
+                job.fetch_job(
+                    from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch
+                )
+            finally:
+                job._close_ssh()
             update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
             return
 
         # ── New submission ────────────────────────────────────────
         job = self._make_job(input_file, output_file, queue_label=queue_label, run_id=run_id)
-        submit_sh = self._submit_script_name(run_id)
-        job.generate_script(submission_script=submit_sh, work_dir=work_dir)
+        try:
+            submit_sh = self._submit_script_name(run_id)
+            job.generate_script(submission_script=submit_sh, work_dir=work_dir)
 
-        from_objects = [input_file, self.hamiltonian_file, submit_sh]
-        if extra_from_objects:
-            from_objects.extend(extra_from_objects)
-        submitted, job_number = job.job_submit(submission_script=submit_sh, from_objects=from_objects, work_dir=work_dir)
-        if not submitted:
-            raise RuntimeError("Job submission failed (queue limit or error).")
+            from_objects = [input_file, self.hamiltonian_file, submit_sh]
+            if extra_from_objects:
+                from_objects.extend(extra_from_objects)
+            submitted, job_number = job.job_submit(submission_script=submit_sh, from_objects=from_objects, work_dir=work_dir)
+            if not submitted:
+                raise RuntimeError("Job submission failed (queue limit or error).")
 
-        logger.info(f"  Job submitted: {job_number}")
-        add_job(
-            work_dir,
-            input_file=input_file,
-            output_file=output_file,
-            job_id=str(job_number) if job_number else "local",
-            server_machine=self.server_machine_name,
-            step=step,
-            run_id=run_id,
-            job_stdout=job.job_stdout if job.server_machine.queuing else "",
-            job_stderr=job.job_stderr if job.server_machine.queuing else "",
-        )
+            logger.info(f"  Job submitted: {job_number}")
+            add_job(
+                work_dir,
+                input_file=input_file,
+                output_file=output_file,
+                job_id=str(job_number) if job_number else "local",
+                server_machine=self.server_machine_name,
+                step=step,
+                run_id=run_id,
+                job_stdout=job.job_stdout if job.server_machine.queuing else "",
+                job_stderr=job.job_stderr if job.server_machine.queuing else "",
+            )
 
-        while job.jobcheck():
-            logger.info(f"  Job {job_number} still running, waiting {self.poll_interval}s...")
-            await asyncio.sleep(self.poll_interval)
+            while job.jobcheck():
+                logger.info(f"  Job {job_number} still running, waiting {self.poll_interval}s...")
+                await asyncio.sleep(self.poll_interval)
 
-        logger.info("  Job completed.")
-        update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
+            logger.info("  Job completed.")
+            update_job(work_dir, input_file, status="completed", completed_at=_now_iso())
 
-        # Collect scheduler accounting before fetch
-        self._collect_job_acct(job, work_dir, input_file)
+            # Collect scheduler accounting before fetch
+            self._collect_job_acct(job, work_dir, input_file)
 
-        job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch)
+            job.fetch_job(from_objects=fetch_from_objects, exclude_patterns=[], work_dir=work_dir, optional_patterns=optional_fetch)
+        finally:
+            job._close_ssh()
         update_job(work_dir, input_file, status="fetched", fetched_at=_now_iso())
 
     def _make_job(self, input_file, output_file, queue_label=None, run_id=""):

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -622,7 +622,7 @@ def test_jqmc_vmc(trexio_file, monkeypatch):
 
         jax.clear_caches()
 
-    # ── adaptive_learning_rate (aSR) smoke test ──────────────────────────────
+    # ── use_lm (LM/aSR) smoke test ──────────────────────────────────────────
     # A separate MCMC instance with comput_e_L_param_deriv=True.
     # get_aH is patched at instance level so that no real sampled data are
     # needed; the dummy return values have H_1 < 0 so compute_asr_gamma


### PR DESCRIPTION
Fixed SSH connection hangs, leaks, and consolidate Machine objects

- Fixed ssh_close() hanging indefinitely when the remote connection is dead (shutdown(wait=True) -> wait=False, remove raise on close failure)
- Added SSH keepalive (set_keepalive(30)) to detect dead connections early                                                       
- Fixed _sftp_lstat_with_retry() same hang issue with shutdown(wait=True)                                                        
- Fixed SSH leak in _cli.py check_job() / delete_job() (missing try-finally)                                                     
- Fixed SSH leak in job_submit() exception path (move _close_ssh() to finally)                                                   
- Consolidated 3 redundant Machine objects per JobSubmission into 1 shared instance    
- Updated docstrings and examples.