### PR TITLE
Clean up jqmc-workflow SSH handling and fix MPI deadlock

### DIFF
--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -1930,23 +1930,35 @@ class GFMC_t:
             timer_reconfiguration += end_reconfiguration - start_reconfiguration
 
             # check current time
+            # Use rank 0's decision and broadcast to all ranks to prevent
+            # MPI deadlock caused by different ranks disagreeing on whether
+            # to break (due to slight differences in gfmc_total_start).
             gmfc_current = time.perf_counter()
-            if max_time < gmfc_current - gfmc_total_start:
+            should_stop = bool(max_time < gmfc_current - gfmc_total_start) if mpi_rank == 0 else False
+            should_stop = mpi_comm.bcast(should_stop, root=0)
+            if should_stop:
                 logger.info(f"  Stopping... Max_time = {max_time} sec. exceeds.")
                 logger.info("  Break the branching loop.")
                 break
 
             # check toml file (stop flag)
-            if os.path.isfile(toml_filename):
-                dict_toml = toml.load(open(toml_filename))
-                try:
-                    stop_flag = dict_toml["external_control"]["stop"]
-                except KeyError:
+            # Only rank 0 reads the file to avoid filesystem cache inconsistencies.
+            if mpi_rank == 0:
+                if os.path.isfile(toml_filename):
+                    dict_toml = toml.load(open(toml_filename))
+                    try:
+                        stop_flag = dict_toml["external_control"]["stop"]
+                    except KeyError:
+                        stop_flag = False
+                else:
                     stop_flag = False
-                if stop_flag:
-                    logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
-                    logger.info("  Break the mcmc loop.")
-                    break
+            else:
+                stop_flag = False
+            stop_flag = mpi_comm.bcast(stop_flag, root=0)
+            if stop_flag:
+                logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
+                logger.info("  Break the mcmc loop.")
+                break
 
             # count up, here is the end of the branching step.
             num_mcmc_done += 1
@@ -5814,22 +5826,34 @@ class GFMC_n:
 
             gfmc_current = time.perf_counter()
 
-            if max_time < gfmc_current - gfmc_total_start:
+            # Use rank 0's decision and broadcast to all ranks to prevent
+            # MPI deadlock caused by different ranks disagreeing on whether
+            # to break (due to slight differences in gfmc_total_start).
+            should_stop = bool(max_time < gfmc_current - gfmc_total_start) if mpi_rank == 0 else False
+            should_stop = mpi_comm.bcast(should_stop, root=0)
+            if should_stop:
                 logger.info(f"  Stopping... Max_time = {max_time} sec. exceeds.")
                 logger.info("  Break the branching loop.")
                 break
 
             # check toml file (stop flag)
-            if os.path.isfile(toml_filename):
-                dict_toml = toml.load(open(toml_filename))
-                try:
-                    stop_flag = dict_toml["external_control"]["stop"]
-                except KeyError:
+            # Only rank 0 reads the file to avoid filesystem cache inconsistencies.
+            if mpi_rank == 0:
+                if os.path.isfile(toml_filename):
+                    dict_toml = toml.load(open(toml_filename))
+                    try:
+                        stop_flag = dict_toml["external_control"]["stop"]
+                    except KeyError:
+                        stop_flag = False
+                else:
                     stop_flag = False
-                if stop_flag:
-                    logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
-                    logger.info("  Break the mcmc loop.")
-                    break
+            else:
+                stop_flag = False
+            stop_flag = mpi_comm.bcast(stop_flag, root=0)
+            if stop_flag:
+                logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
+                logger.info("  Break the mcmc loop.")
+                break
 
             # count up, here is the end of the branching step.
             num_mcmc_done += 1

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -911,23 +911,35 @@ class MCMC:
             num_mcmc_done += 1
 
             # check max time
+            # Use rank 0's decision and broadcast to all ranks to prevent
+            # MPI deadlock caused by different ranks disagreeing on whether
+            # to break (due to slight differences in mcmc_total_start).
             mcmc_current = time.perf_counter()
-            if max_time < mcmc_current - mcmc_total_start:
+            should_stop = bool(max_time < mcmc_current - mcmc_total_start) if mpi_rank == 0 else False
+            should_stop = mpi_comm.bcast(should_stop, root=0)
+            if should_stop:
                 logger.info(f"  Stopping... max_time = {max_time} sec. exceeds.")
                 logger.info("  Break the mcmc loop.")
                 break
 
             # check toml file (stop flag)
-            if os.path.isfile(toml_filename):
-                dict_toml = toml.load(open(toml_filename))
-                try:
-                    stop_flag = dict_toml["external_control"]["stop"]
-                except KeyError:
+            # Only rank 0 reads the file to avoid filesystem cache inconsistencies.
+            if mpi_rank == 0:
+                if os.path.isfile(toml_filename):
+                    dict_toml = toml.load(open(toml_filename))
+                    try:
+                        stop_flag = dict_toml["external_control"]["stop"]
+                    except KeyError:
+                        stop_flag = False
+                else:
                     stop_flag = False
-                if stop_flag:
-                    logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
-                    logger.info("  Break the mcmc loop.")
-                    break
+            else:
+                stop_flag = False
+            stop_flag = mpi_comm.bcast(stop_flag, root=0)
+            if stop_flag:
+                logger.info(f"  Stopping... stop_flag in {toml_filename} is true.")
+                logger.info("  Break the mcmc loop.")
+                break
 
         # Barrier after MCMC operation
         start = time.perf_counter()

--- a/jqmc_workflow/_job.py
+++ b/jqmc_workflow/_job.py
@@ -223,14 +223,14 @@ class JobSubmission:
         """
         from_objects = from_objects or []
 
-        if not self.jobnum_check():
-            logger.info("Max job limit reached; not submitting.")
-            self.job_submit_date = None
-            self.job_number = None
-            self.job_running = False
-            return False, self.job_number
-
         try:
+            if not self.jobnum_check():
+                logger.info("Max job limit reached; not submitting.")
+                self.job_submit_date = None
+                self.job_number = None
+                self.job_running = False
+                return False, self.job_number
+
             local_cwd = os.path.abspath(work_dir) if work_dir else os.path.abspath(os.getcwd())
 
             # ── Submit via queuing system or remote submit script ──
@@ -275,11 +275,16 @@ class JobSubmission:
     # ── Job checking ──────────────────────────────────────────────
 
     def jobcheck(self) -> bool:
-        """Return True if the job is still running."""
+        """Return True if the job is still running.
+
+        The SSH connection is intentionally kept open so that the
+        polling loop in ``_submit_and_wait`` reuses a single
+        connection instead of opening and closing one per poll.
+        The caller's ``finally: _close_ssh()`` handles cleanup.
+        """
         self.job_check_last_time = datetime.today()
 
         if not self.server_machine.queuing:
-            self._close_ssh()
             return False
 
         trial_num = 10
@@ -309,11 +314,15 @@ class JobSubmission:
             self.job_running = False
             flag = False
 
-        self._close_ssh()
         return flag
 
     def jobnum_check(self) -> bool:
-        """Check if we are below the max_job_submit limit."""
+        """Check if we are below the max_job_submit limit.
+
+        The SSH connection is kept open so that the subsequent
+        ``job_submit`` call can reuse it.  The caller's ``finally``
+        block handles cleanup.
+        """
         if not self.server_machine.queuing:
             return True
 
@@ -331,9 +340,7 @@ class JobSubmission:
         )
         logger.info(f"  {count} jobs running on {self.server_machine.name}")
 
-        flag = count < self.max_job_submit
-        self._close_ssh()
-        return flag
+        return count < self.max_job_submit
 
     # ── Fetch results ─────────────────────────────────────────────
 

--- a/jqmc_workflow/_machine.py
+++ b/jqmc_workflow/_machine.py
@@ -87,6 +87,7 @@ class Machine:
 
         self.__name = machine
         self.ssh_status = False
+        self._proxy_cmd = None  # track ProxyCommand for cleanup
 
         # Validate ssh_host for remote machines
         if self.machine_type == "remote" and "ssh_host" not in self.data:
@@ -96,7 +97,46 @@ class Machine:
                 f"Please add 'ssh_host' (e.g. the Host alias in ~/.ssh/config)."
             )
 
+    def __del__(self):
+        """Safety net: clean up SSH resources if not explicitly closed."""
+        try:
+            if getattr(self, "ssh_status", False):
+                self.ssh_close()
+        except Exception:
+            pass
+
     # ── SSH management ──────────────────────────────────────────────
+
+    @staticmethod
+    def _kill_proxy_process(proxy_cmd):
+        """Force-kill a ProxyCommand subprocess and close its pipe FDs.
+
+        paramiko's ProxyCommand.close() only sends SIGTERM without
+        wait() or closing pipes, leaving zombie processes and leaked
+        file descriptors.  This method ensures full cleanup.
+        """
+        if proxy_cmd is None:
+            return
+        proc = getattr(proxy_cmd, "process", None)
+        if proc is None:
+            return
+        # Close pipe file descriptors first
+        for pipe in (proc.stdin, proc.stdout, proc.stderr):
+            if pipe is not None:
+                try:
+                    pipe.close()
+                except Exception:
+                    pass
+        # Kill the process (SIGKILL — SIGTERM may be ignored)
+        try:
+            proc.kill()
+        except OSError:
+            pass  # already dead
+        # Reap the zombie so the PID is released
+        try:
+            proc.wait(timeout=3)
+        except Exception:
+            pass
 
     def ssh_open(self):
         if self.machine_type != "remote":
@@ -149,6 +189,7 @@ class Machine:
         self.ssh.load_system_host_keys()
 
         for tt in range(self.ssh_retry_max_num):
+            proxy_cmd = None
             try:
                 kwargs = dict(
                     hostname=hostname,
@@ -156,14 +197,18 @@ class Machine:
                     key_filename=key_filename,
                 )
                 if proxy_flag:
-                    kwargs["sock"] = paramiko.ProxyCommand(proxy_command)
+                    proxy_cmd = paramiko.ProxyCommand(proxy_command)
+                    kwargs["sock"] = proxy_cmd
                 self.ssh.connect(**kwargs)
                 # Enable SSH keepalive so the client detects dead connections
                 # early instead of discovering them at close() time.
                 self.ssh.get_transport().set_keepalive(30)
+                self._proxy_cmd = proxy_cmd  # save reference for cleanup
                 logger.info(f"  SSH connected (attempt {tt + 1})")
                 break
             except paramiko.ssh_exception.SSHException:
+                # Clean up the ProxyCommand from this failed attempt
+                self._kill_proxy_process(proxy_cmd)
                 logger.warning(f"SSH connect failed (attempt {tt + 1}). Retrying in {self.ssh_retry_time}s.")
                 time.sleep(self.ssh_retry_time)
                 if tt == self.ssh_retry_max_num - 1:
@@ -176,8 +221,12 @@ class Machine:
     def ssh_close(self):
         if self.machine_type != "remote" or not self.ssh_status:
             return
-        timeout_sec = 5.0
 
+        # Save proxy reference before closing — ssh.close() may clear it
+        proxy_cmd = self._proxy_cmd
+        self._proxy_cmd = None
+
+        timeout_sec = 5.0
         for obj_name, obj in [("sftp", self.sftp), ("ssh", self.ssh)]:
             executor = ThreadPoolExecutor(max_workers=1)
             future = executor.submit(obj.close)
@@ -188,9 +237,15 @@ class Machine:
                 logger.warning(f"{obj_name}.close() failed ({e.__class__.__name__}: {e}) — abandoning")
                 future.cancel()
             finally:
-                # wait=False: the close thread may be stuck on a dead connection;
-                # waiting would hang forever (the reason we timed out in the first place).
                 executor.shutdown(wait=False)
+
+        # Force-kill the ProxyCommand subprocess and close its pipe FDs.
+        # This is essential because:
+        #  - paramiko's ProxyCommand.close() only sends SIGTERM, never
+        #    calls wait() or closes the subprocess pipes.
+        #  - If ssh.close() timed out above, the ProxyCommand process
+        #    is still alive with open file descriptors.
+        self._kill_proxy_process(proxy_cmd)
 
         del self.ssh
         del self.sftp
@@ -316,14 +371,25 @@ class Machine:
 
     def _run_remote(self, command_r: str):
         self.ssh_open()
-        _, pstdout, pstderr = self.ssh.exec_command(command=command_r)
+        try:
+            pstdin, pstdout, pstderr = self.ssh.exec_command(command=command_r)
+        except (paramiko.SSHException, OSError, EOFError):
+            # Connection may have died (e.g. keepalive timeout during
+            # a long asyncio.sleep between polls).  Reconnect once.
+            logger.warning("SSH connection lost during exec_command; reconnecting...")
+            self.ssh_close()
+            self.ssh_open()
+            pstdin, pstdout, pstderr = self.ssh.exec_command(command=command_r)
         try:
             exit_status = pstdout.channel.recv_exit_status()
             stdout = pstdout.read().decode("utf-8").strip()
             stderr = pstderr.read().decode("utf-8").strip()
         finally:
-            pstdout.close()
-            pstderr.close()
+            for ch in (pstdin, pstdout, pstderr):
+                try:
+                    ch.close()
+                except Exception:
+                    pass
         if exit_status != 0:
             logger.error(f"Remote command failed: {command_r}")
             logger.error(f"stdout={stdout}")

--- a/jqmc_workflow/_machine.py
+++ b/jqmc_workflow/_machine.py
@@ -114,6 +114,10 @@ class Machine:
         paramiko's ProxyCommand.close() only sends SIGTERM without
         wait() or closing pipes, leaving zombie processes and leaked
         file descriptors.  This method ensures full cleanup.
+
+        After cleanup, the ProxyCommand's close() is neutralised so
+        that paramiko's transport thread does not attempt to kill the
+        already-reaped process (which would log a ProcessLookupError).
         """
         if proxy_cmd is None:
             return
@@ -137,6 +141,9 @@ class Machine:
             proc.wait(timeout=3)
         except Exception:
             pass
+        # Neutralise the ProxyCommand so that paramiko's transport
+        # thread does not try os.kill() on the now-dead PID.
+        proxy_cmd.close = lambda: None
 
     def ssh_open(self):
         if self.machine_type != "remote":


### PR DESCRIPTION
- Fix MPI deadlock by making max_time and stop_flag checks follow rank 0's decision via `mpi_comm.bcast()`, ensuring all ranks exit consistently (GFMC_t, GFMC_n, MCMC)
- Clean up jqmc-workflow SSH lifecycle by removing redundant `_close_ssh()` calls from `jobcheck` and `jobnum_check`, and reusing connections within polling loops
- Fix ProxyCommand subprocess leaks by force-killing processes and reaping zombies on SSH close
- Add SSH reconnection on `exec_command` failure