### PR TITLE
Add mixed-precision (fp32/fp64) support with selectable per-zone dtype

### DIFF
--- a/.github/workflows/jqmc-run-full-pytest.yml
+++ b/.github/workflows/jqmc-run-full-pytest.yml
@@ -3,7 +3,7 @@
 name: jqmc full test
 
 on:
-  push:
+  pull_request:
     branches: [ "main" ]
     paths-ignore:
       - '.gitignore'
@@ -14,8 +14,6 @@ on:
       - 'README.md'
       - '.pre-commit-config.yaml'
       - 'jqmc_workflow/**'
-  pull_request:
-    branches: [ "main" ]
 
 jobs:
   run:
@@ -73,6 +71,7 @@ jobs:
         pytest -s -v tests/test_checkpoint_mcmc.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_checkpoint_gfmc.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_ao_basis_optimization.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
+        pytest -s -v tests/test_mixed_precision.py --precision-mode=mixed --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
 
     - name: Test jqmc (inter-software comparisons)
       run: |
@@ -85,12 +84,6 @@ jobs:
         pytest -s -v tests/test_jqmc_mcmc.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_jqmc_gfmc_tau.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_jqmc_gfmc_bra.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
-
-    #- name: Test jqmc (QMC kernels with 2MPIs)
-    #  run: |
-    #    mpirun -np 2 pytest -s -v tests/test_jqmc_mcmc.py
-    #    mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_tau.py
-    #    mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_bra.py
 
     - name: Test jqmc-tool (toolset for jqmc)
       run: |

--- a/.github/workflows/jqmc-run-rc-pytest.yml
+++ b/.github/workflows/jqmc-run-rc-pytest.yml
@@ -1,6 +1,6 @@
-# A full test of jqmc.
+# An rc test of jqmc.
 
-name: jqmc full test
+name: jqmc rc test
 
 on:
   push:
@@ -16,6 +16,15 @@ on:
       - 'jqmc_workflow/**'
   pull_request:
     branches: [ "rc" ]
+    paths-ignore:
+      - '.gitignore'
+      - '.github/**'
+      - 'doc/**'
+      - 'examples/**'
+      - 'benchmarks/**'
+      - 'README.md'
+      - '.pre-commit-config.yaml'
+      - 'jqmc_workflow/**'
 
 jobs:
   run:
@@ -49,18 +58,33 @@ jobs:
         python -m pip install flake8 pytest pytest-cov
         python -m pip install .
 
-    - name: Test jqmc (QMC kernels without MPI)
+    - name: Test jqmc command-line
       run: |
         pytest -s -v tests/test_jqmc_command_lines.py
+
+    - name: Test jqmc FP64 (QMC kernels without MPI, FP64)
+      run: |
         pytest -s -v tests/test_jqmc_mcmc.py
         pytest -s -v tests/test_jqmc_gfmc_tau.py
         pytest -s -v tests/test_jqmc_gfmc_bra.py
 
-    - name: Test jqmc (QMC kernels with 2MPIs)
+    - name: Test jqmc FP64 (QMC kernels with 2MPIs, FP64)
       run: |
         mpirun -np 2 pytest -s -v tests/test_jqmc_mcmc.py
         mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_tau.py
         mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_bra.py
+
+    - name: Test jqmc FP32+FP64 (QMC kernels without MPI, FP32+FP64)
+      run: |
+        pytest -s -v tests/test_jqmc_mcmc.py --precision-mode=mixed
+        pytest -s -v tests/test_jqmc_gfmc_tau.py --precision-mode=mixed
+        pytest -s -v tests/test_jqmc_gfmc_bra.py --precision-mode=mixed
+
+    - name: Test jqmc FP32+FP64 (QMC kernels with 2MPIs, FP32+FP64)
+      run: |
+        mpirun -np 2 pytest -s -v tests/test_jqmc_mcmc.py --precision-mode=mixed
+        mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_tau.py --precision-mode=mixed
+        mpirun -np 2 pytest -s -v tests/test_jqmc_gfmc_bra.py --precision-mode=mixed
 
     - name: Test jqmc-tool (toolset for jqmc)
       run: |

--- a/.github/workflows/jqmc-run-short-pytest.yml
+++ b/.github/workflows/jqmc-run-short-pytest.yml
@@ -14,6 +14,17 @@ on:
       - 'README.md'
       - '.pre-commit-config.yaml'
       - 'jqmc_workflow/**'
+  pull_request:
+    branches: [ "devel*" ]
+    paths-ignore:
+      - '.gitignore'
+      - '.github/**'
+      - 'doc/**'
+      - 'examples/**'
+      - 'benchmarks/**'
+      - 'README.md'
+      - '.pre-commit-config.yaml'
+      - 'jqmc_workflow/**'
 
 jobs:
   run:
@@ -67,6 +78,7 @@ jobs:
         pytest -s -v tests/test_swct.py --skip-heavy
         pytest -s -v tests/test_mcmc_force.py --skip-heavy
         pytest -s -v tests/test_lrdmc_force.py --skip-heavy
+        pytest -s -v tests/test_mixed_precision.py --precision-mode=mixed --skip-heavy
 
     - name: Test jqmc (pytest) with @jit decorator (inter-software comparisons)
       run: |

--- a/doc/index.md
+++ b/doc/index.md
@@ -21,6 +21,7 @@ install
 examples
 notes/technical_notes
 notes/workflows
+notes/mixed_precision
 api_reference_cli
 api_reference_cli_tool
 api_reference_mod/modules

--- a/doc/notes/mixed_precision.md
+++ b/doc/notes/mixed_precision.md
@@ -30,21 +30,44 @@ Or keep the default (all float64, backward compatible):
 
 ## Precision zones
 
-jQMC divides the computation into 10 **Precision Zones**.  The mapping
-from zone to dtype is determined entirely by the chosen mode:
+jQMC divides the computation into 16 **Precision Zones**.  Each zone is
+owned by exactly one module and is named for its *purpose* (not its
+dtype).  The mapping from zone to dtype is determined entirely by the
+chosen mode.
 
-| Zone           | Components                        | `full` | `mixed` | float32 risk |
-|----------------|-----------------------------------|--------|---------|--------------|
-| `orb_eval`     | AO/MO forward evaluation          | f64    | **f32** | low          |
-| `jastrow`      | Jastrow factor (J1/J2/J3)         | f64    | **f32** | low          |
-| `geminal`      | Geminal matrix elements            | f64    | f64     | high         |
-| `determinant`  | log-det, SVD, AS regularization    | f64    | f64     | high         |
-| `coulomb`      | Coulomb + ECP potential            | f64    | **f32** | low-medium   |
-| `kinetic`      | Kinetic energy + AO/MO derivatives | f64    | f64     | high         |
-| `mcmc`         | MCMC sampling                      | f64    | f64     | high         |
-| `gfmc`         | GFMC propagation                   | f64    | f64     | high         |
-| `optimization` | SR matrix, parameter updates       | f64    | f64     | high         |
-| `io`           | I/O, structure data                | f64    | f64     | low-medium   |
+| Zone               | Owning module          | `full` | `mixed`  | risk     | E_L path   |
+|--------------------|------------------------|--------|----------|----------|------------|
+| `ao_eval`          | `atomic_orbital`       | f64    | **f32**  | low      | core       |
+| `ao_grad_lap`      | `atomic_orbital`       | f64    | **f32**  | low      | core       |
+| `mo_eval`          | `molecular_orbital`    | f64    | f64      | high\*   | core       |
+| `mo_grad_lap`      | `molecular_orbital`    | f64    | f64      | high     | core       |
+| `jastrow_eval`     | `jastrow_factor`       | f64    | **f32**  | low      | core†      |
+| `jastrow_grad_lap` | `jastrow_factor`       | f64    | **f32**  | low      | core       |
+| `jastrow_ratio`    | `jastrow_factor`       | f64    | **f32**  | low      | indirect‡  |
+| `det_eval`         | `determinant`          | f64    | f64      | high     | core       |
+| `det_grad_lap`     | `determinant`          | f64    | f64      | high     | core       |
+| `det_ratio`        | `determinant`          | f64    | f64      | high     | indirect‡  |
+| `coulomb`          | `coulomb_potential`    | f64    | **f32**  | low-med  | core       |
+| `wf_eval`          | `wavefunction`         | f64    | f64      | high     | core†      |
+| `wf_kinetic`       | `wavefunction`         | f64    | f64      | high     | core       |
+| `wf_ratio`         | `wavefunction`         | f64    | f64      | high     | no         |
+| `local_energy`     | `hamiltonians`         | f64    | f64      | high     | core       |
+| `swct`             | `swct`                 | f64    | f64      | high     | no         |
+
+\* `mo_eval` is high-risk even though the consumed AO values are fp32:
+the small `mo_coefficients @ aos` matmul runs in this zone, and its
+output feeds the determinant matrix where fp32 round-off is amplified
+by `log|det|`.
+
+† `jastrow_eval` and `wf_eval` are on the E_L core path but their
+forward values (J and ln|Psi|) do not enter the E_L formula directly
+(E_L depends on *derivatives* of ln|Psi|).  Diagnostics show zero E_L
+bias when these zones alone are fp32.
+
+‡ `det_ratio` and `jastrow_ratio` affect E_L **indirectly** through the
+ECP non-local potential, which evaluates `Psi(R')/Psi(R)` on a
+quadrature grid via rank-1 ratio updates.  In non-ECP systems these
+zones have no E_L impact.
 
 ## Workflow integration
 
@@ -67,17 +90,105 @@ those dicts directly or use `_set_zone()` after calling `configure()`.
 
 ## Design principles
 
-1. **Explicit dtype declaration** — Every function declares its Precision Zone
-   and specifies dtype for all arrays.  No reliance on JAX implicit promotion.
+The implementation rests on **three** principles documented at the top of
+`jqmc/_precision.py`.  Principle 3 is the most important in practice; almost
+every precision bug we have seen is a violation of 3a or 3b.
 
-2. **Zone boundaries** — When results cross zone boundaries (e.g. Jastrow
-   float32 → determinant float64), explicit casts ensure the higher-precision
-   zone receives correctly typed inputs.
+**Principle 1 — One Precision Zone is owned by exactly one module.**
+A zone (e.g. `ao_eval`, `coulomb`) is *defined and consumed* in a single
+module.  The mapping zone ↔ owning module is one-to-one.
 
-3. **Backward compatibility** — Default mode is `"full"` (all float64).
-   Existing input files work without modification.
+**Principle 2 — A module may own multiple Precision Zones.**
+Different code paths in the same module legitimately need different
+precisions (e.g. `ao_eval` vs `ao_grad_lap`, or `det_eval` vs `det_ratio`).
+Each zone is named for its *purpose*, not for its dtype.
+
+**Principle 3 — Cast responsibility lies with the function that does
+arithmetic on the value, never with passthrough wrappers.**
+
+* **3a (frozen args).** Function arguments are *frozen*: the parameter name
+  must not be rebound for the entire body of the function.  Writing
+  `arg = jnp.asarray(arg, dtype=...)` at the top of a function is forbidden
+  — it silently coerces the argument for every later use, including
+  forwarding to other functions.  When the function consumes `arg` as an
+  arithmetic operand, the cast appears **inside the expression**
+  (`arg.astype(dtype)`), or — if the cast result is reused — through a
+  *new* local variable (e.g. `arg_local = arg.astype(dtype)`).  The
+  original `arg` always remains frozen.
+
+* **3b (local cast at the point of arithmetic).** A function casts a value
+  to its own zone's dtype **immediately before** consuming it as an
+  operand.  Inputs and outputs of the function's arithmetic both live in
+  its zone.  For catastrophic cancellation (`r - R`): reconstruct the
+  difference in the dtype the values were received in (the
+  caller-supplied precision — fp64 in jQMC because the upstream MCMC
+  walker state is fp64), then down-cast the result to the function's own
+  zone.  The principle is "use the caller-supplied precision," **not**
+  "hardcode fp64."
+
+```python
+# WRONG (3a violation): rebinding `r_carts` silently forwards a
+# fp32-truncated array to compute_AOs even though `ao_eval` is fp64.
+def compute_coulomb(r_carts, R_carts):
+    dtype_jnp = get_dtype_jnp("coulomb")
+    r_carts = jnp.asarray(r_carts, dtype=dtype_jnp)  # <-- forbidden
+    ao = compute_AOs(..., r_carts, R_carts)          # downstream sees fp32
+    diff = r_carts - R_carts
+    ...
+
+# RIGHT: forwarding stays in caller's dtype; reconstruction is in
+# caller-supplied precision; downcast happens at the use site.
+def compute_coulomb(r_carts, R_carts):
+    ao = compute_AOs(..., r_carts, R_carts)          # forward as-is
+    dtype_jnp = get_dtype_jnp("coulomb")
+    diff = (r_carts - R_carts).astype(dtype_jnp)     # 3b
+    ...
+```
+
+### No hardcoded dtype literals
+
+Inside any module that owns a selectable-precision zone, **never hardcode**
+`jnp.float64` / `np.float64` / `jnp.float32` / `np.float32` for arrays the
+module produces or consumes.  Always go through `get_dtype_jnp("<zone>")`
+/ `get_dtype_np("<zone>")` so the dtype follows the active mode
+automatically.
+
+The exemptions (modules whose data is *always fp64 by construction*,
+independent of mode) are:
+
+* `mcmc` / `gfmc` — MCMC and GFMC walker state.
+* I/O modules — `structure`, `trexio_wrapper`, `_jqmc_utility`,
+  `jqmc_tool`, and the `_load_dataclass_from_hdf5` /
+  `_save_dataclass_to_hdf5` helpers in `hamiltonians`.  On-disk numerical
+  data (AO exponents/coefficients, nuclear coordinates, geminal
+  coefficients, etc.) is always fp64 because fp32 storage would silently
+  lose precision that no downstream upcast can recover.
+* **Basis-data storage accessors.** `_*_jnp` properties on
+  selectable-precision dataclasses whose underlying storage field is
+  typed `npt.NDArray[np.float64]` are *lift-only* adapters
+  (numpy → `jax.Array`), not arithmetic.  The dtype is fp64 by
+  construction (storage is loaded from HDF5/TREXIO/optimizer output);
+  the consumer is responsible for casting the lifted array to its own
+  zone at the use site (Principle 3b).  Concretely this covers
+  `_exponents_jnp` / `_coefficients_jnp` /
+  `_normalization_factorial_ratio_prim_jnp` in `atomic_orbital`,
+  `_mo_coefficients_jnp` in `molecular_orbital`,
+  `_lambda_matrix_jnp` in `determinant`, `_j_matrix_jnp` in
+  `jastrow_factor`, and the `ShellPrimMap.from_aos_data` constructor in
+  `atomic_orbital`.
 
 ## API reference
 
-See {py:mod}`jqmc._precision` for the programmatic API (`get_dtype`,
-`configure`, `get_tolerance`, etc.).
+See {py:mod}`jqmc._precision` for the programmatic API:
+
+* `get_dtype_jnp(zone)` / `get_dtype_np(zone)` — return the JAX / NumPy
+  dtype currently assigned to *zone*.
+* `get_eps(name, dtype)` — return a dtype-aware numerical-stability
+  constant (e.g. `"rcond_svd"`, `"stabilizing_ao"`).
+* `configure(mode)` — programmatically switch the active precision mode.
+* `get_tolerance(zone, level)` — return `(atol, rtol)` for tests, scaled
+  by the zone's current dtype (`level` = `"strict"` or `"loose"`).
+* `get_tolerance_min(zones, level)` — return the loosest `(atol, rtol)`
+  across the given zones.  Use this when a test compares two paths whose
+  combined dtype span crosses multiple zones; the achievable agreement
+  is bounded by the weakest zone on the path.

--- a/doc/notes/mixed_precision.md
+++ b/doc/notes/mixed_precision.md
@@ -30,7 +30,7 @@ Or keep the default (all float64, backward compatible):
 
 ## Precision zones
 
-jQMC divides the computation into 16 **Precision Zones**.  Each zone is
+jQMC divides the computation into 18 **Precision Zones**.  Each zone is
 owned by exactly one module and is named for its *purpose* (not its
 dtype).  The mapping from zone to dtype is determined entirely by the
 chosen mode.
@@ -38,9 +38,11 @@ chosen mode.
 | Zone               | Owning module          | `full` | `mixed`  | risk     | E_L path   |
 |--------------------|------------------------|--------|----------|----------|------------|
 | `ao_eval`          | `atomic_orbital`       | f64    | **f32**  | low      | core       |
-| `ao_grad_lap`      | `atomic_orbital`       | f64    | **f32**  | low      | core       |
+| `ao_grad`          | `atomic_orbital`       | f64    | **f32**  | low      | core       |
+| `ao_lap`           | `atomic_orbital`       | f64    | f64      | high§    | core       |
 | `mo_eval`          | `molecular_orbital`    | f64    | f64      | high\*   | core       |
-| `mo_grad_lap`      | `molecular_orbital`    | f64    | f64      | high     | core       |
+| `mo_grad`          | `molecular_orbital`    | f64    | f64      | high     | core       |
+| `mo_lap`           | `molecular_orbital`    | f64    | f64      | high     | core       |
 | `jastrow_eval`     | `jastrow_factor`       | f64    | **f32**  | low      | core†      |
 | `jastrow_grad_lap` | `jastrow_factor`       | f64    | **f32**  | low      | core       |
 | `jastrow_ratio`    | `jastrow_factor`       | f64    | **f32**  | low      | indirect‡  |
@@ -68,6 +70,17 @@ bias when these zones alone are fp32.
 ECP non-local potential, which evaluates `Psi(R')/Psi(R)` on a
 quadrature grid via rank-1 ratio updates.  In non-ECP systems these
 zones have no E_L impact.
+
+§ `ao_lap` is kept fp64 in `mixed` mode because the analytic Laplacian
+formula contains catastrophic-cancellation terms of the form
+`4 Z² r² − 6 Z` and `(safe_div − 2 Z·base)² − safe_div² − 2 Z` that
+amplify fp32 round-off into a force bias of order ~1 Ha/bohr in N₂
+(diagnostic `bug/fp32/diag_07_ao_grad_vs_lap_split.py`).  The grad
+counterpart `ao_grad` has no such cancellation and is safe at fp32
+(max|dF| ≈ 5e-6 Ha/bohr).  This is the only zone pair in jQMC where the
+grad and Laplacian halves take different dtypes, motivating the split
+of the original `ao_grad_lap` zone into separate `ao_grad` / `ao_lap`
+zones.
 
 ## Workflow integration
 
@@ -100,8 +113,8 @@ module.  The mapping zone ↔ owning module is one-to-one.
 
 **Principle 2 — A module may own multiple Precision Zones.**
 Different code paths in the same module legitimately need different
-precisions (e.g. `ao_eval` vs `ao_grad_lap`, or `det_eval` vs `det_ratio`).
-Each zone is named for its *purpose*, not for its dtype.
+precisions (e.g. `ao_eval` vs `ao_grad` vs `ao_lap`, or `det_eval` vs
+`det_ratio`).  Each zone is named for its *purpose*, not for its dtype.
 
 **Principle 3 — Cast responsibility lies with the function that does
 arithmetic on the value, never with passthrough wrappers.**

--- a/doc/notes/mixed_precision.md
+++ b/doc/notes/mixed_precision.md
@@ -1,0 +1,105 @@
+# Mixed Precision
+
+jQMC supports mixed precision computation, allowing selected parts of the
+calculation to run in float32 while keeping numerically sensitive operations
+in float64.  This can reduce memory usage by ~30-40% and improve GPU
+throughput by ~1.5-2x for large molecules, with negligible impact on the
+final energy.
+
+## Quick start
+
+Add a `[precision]` section to your TOML input file:
+
+```toml
+[precision]
+mode = "mixed"
+```
+
+Or keep the default (all float64, backward compatible):
+
+```toml
+# [precision] section omitted → mode="full"
+```
+
+## Precision modes
+
+| Mode    | Description |
+|---------|-------------|
+| `full`  | All zones float64 (default, backward compatible) |
+| `mixed` | Recommended mixed precision (see zone table below) |
+
+## Precision zones
+
+jQMC divides the computation into 10 **Precision Zones**, each independently
+configurable:
+
+| Zone           | Components                        | `full` | `mixed` | float32 risk |
+|----------------|-----------------------------------|--------|---------|--------------|
+| `orb_eval`     | AO/MO forward evaluation          | f64    | **f32** | low          |
+| `jastrow`      | Jastrow factor (J1/J2/J3)         | f64    | **f32** | low          |
+| `geminal`      | Geminal matrix elements            | f64    | **f32** | low          |
+| `determinant`  | log-det, SVD, AS regularization    | f64    | f64     | high         |
+| `coulomb`      | Coulomb + ECP potential            | f64    | **f32** | low-medium   |
+| `kinetic`      | Kinetic energy + AO/MO derivatives | f64    | f64     | high         |
+| `mcmc`         | MCMC sampling                      | f64    | f64     | high         |
+| `gfmc`         | GFMC propagation                   | f64    | f64     | high         |
+| `optimization` | SR matrix, parameter updates       | f64    | f64     | high         |
+| `io`           | I/O, structure data                | f64    | f64     | low-medium   |
+
+## Custom zone configuration
+
+Individual zones can be overridden regardless of the base mode:
+
+```toml
+[precision]
+mode = "mixed"          # start from recommended mixed defaults
+orb_eval = "float64"    # override: keep AO/MO in float64
+```
+
+```toml
+[precision]
+mode = "full"           # start from all float64
+orb_eval = "float32"    # override: only AO/MO in float32
+```
+
+## Workflow integration
+
+When using `jqmc_workflow`, pass precision settings to any workflow class:
+
+```python
+from jqmc_workflow import VMC_Workflow
+
+wf = VMC_Workflow(
+    server_machine_name="cluster",
+    num_opt_steps=20,
+    precision_mode="mixed",
+)
+```
+
+For custom per-zone overrides:
+
+```python
+wf = VMC_Workflow(
+    server_machine_name="cluster",
+    num_opt_steps=20,
+    precision_mode="mixed",
+    precision_overrides={"orb_eval": "float64"},
+)
+```
+
+## Design principles
+
+1. **Explicit dtype declaration** — Every function declares its Precision Zone
+   and specifies dtype for all arrays.  No reliance on JAX implicit promotion.
+
+2. **Zone boundaries** — When results cross zone boundaries (e.g. Jastrow
+   float32 → determinant float64), explicit casts ensure the higher-precision
+   zone receives correctly typed inputs.
+
+3. **Backward compatibility** — Default mode is `"full"` (all float64).
+   Existing input files work without modification.
+
+## API reference
+
+See {py:mod}`jqmc._precision` for the programmatic API (`get_dtype`,
+`configure`, `get_tolerance`, etc.).

--- a/doc/notes/mixed_precision.md
+++ b/doc/notes/mixed_precision.md
@@ -30,14 +30,14 @@ Or keep the default (all float64, backward compatible):
 
 ## Precision zones
 
-jQMC divides the computation into 10 **Precision Zones**, each independently
-configurable:
+jQMC divides the computation into 10 **Precision Zones**.  The mapping
+from zone to dtype is determined entirely by the chosen mode:
 
 | Zone           | Components                        | `full` | `mixed` | float32 risk |
 |----------------|-----------------------------------|--------|---------|--------------|
 | `orb_eval`     | AO/MO forward evaluation          | f64    | **f32** | low          |
 | `jastrow`      | Jastrow factor (J1/J2/J3)         | f64    | **f32** | low          |
-| `geminal`      | Geminal matrix elements            | f64    | **f32** | low          |
+| `geminal`      | Geminal matrix elements            | f64    | f64     | high         |
 | `determinant`  | log-det, SVD, AS regularization    | f64    | f64     | high         |
 | `coulomb`      | Coulomb + ECP potential            | f64    | **f32** | low-medium   |
 | `kinetic`      | Kinetic energy + AO/MO derivatives | f64    | f64     | high         |
@@ -46,25 +46,9 @@ configurable:
 | `optimization` | SR matrix, parameter updates       | f64    | f64     | high         |
 | `io`           | I/O, structure data                | f64    | f64     | low-medium   |
 
-## Custom zone configuration
-
-Individual zones can be overridden regardless of the base mode:
-
-```toml
-[precision]
-mode = "mixed"          # start from recommended mixed defaults
-orb_eval = "float64"    # override: keep AO/MO in float64
-```
-
-```toml
-[precision]
-mode = "full"           # start from all float64
-orb_eval = "float32"    # override: only AO/MO in float32
-```
-
 ## Workflow integration
 
-When using `jqmc_workflow`, pass precision settings to any workflow class:
+When using `jqmc_workflow`, pass the precision mode to any workflow class:
 
 ```python
 from jqmc_workflow import VMC_Workflow
@@ -76,16 +60,10 @@ wf = VMC_Workflow(
 )
 ```
 
-For custom per-zone overrides:
-
-```python
-wf = VMC_Workflow(
-    server_machine_name="cluster",
-    num_opt_steps=20,
-    precision_mode="mixed",
-    precision_overrides={"orb_eval": "float64"},
-)
-```
+Per-zone assignments are defined in `_FULL_PRECISION` / `_MIXED_PRECISION`
+inside `jqmc/_precision.py` and are not configurable from TOML or workflow
+parameters.  Developers who need per-zone control for diagnostics can edit
+those dicts directly or use `_set_zone()` after calling `configure()`.
 
 ## Design principles
 

--- a/examples/jqmc-example01/02vmc_JSD/vmc.toml
+++ b/examples/jqmc-example01/02vmc_JSD/vmc.toml
@@ -31,14 +31,3 @@ opt_lambda_basis_coeff = false
 
 # [precision]
 # mode = "full"  # "full" (default, all float64) or "mixed" (recommended mixed precision)
-# # Per-zone overrides (optional, override the mode defaults):
-# # orb_eval = "float32"     # AO/MO forward evaluation
-# # jastrow = "float32"      # Jastrow factor
-# # geminal = "float32"      # Geminal matrix elements
-# # determinant = "float64"  # log-det, SVD, AS regularization
-# # coulomb = "float32"      # Coulomb + ECP potential
-# # kinetic = "float64"      # Kinetic energy + derivatives
-# # mcmc = "float64"         # MCMC sampling
-# # gfmc = "float64"         # GFMC propagation
-# # optimization = "float64" # SR matrix, parameter updates
-# # io = "float64"           # I/O, structure data

--- a/examples/jqmc-example01/02vmc_JSD/vmc.toml
+++ b/examples/jqmc-example01/02vmc_JSD/vmc.toml
@@ -28,3 +28,17 @@ opt_J3_basis_exp = true
 opt_J3_basis_coeff = true
 opt_lambda_basis_exp = false
 opt_lambda_basis_coeff = false
+
+# [precision]
+# mode = "full"  # "full" (default, all float64) or "mixed" (recommended mixed precision)
+# # Per-zone overrides (optional, override the mode defaults):
+# # orb_eval = "float32"     # AO/MO forward evaluation
+# # jastrow = "float32"      # Jastrow factor
+# # geminal = "float32"      # Geminal matrix elements
+# # determinant = "float64"  # log-det, SVD, AS regularization
+# # coulomb = "float32"      # Coulomb + ECP potential
+# # kinetic = "float64"      # Kinetic energy + derivatives
+# # mcmc = "float64"         # MCMC sampling
+# # gfmc = "float64"         # GFMC propagation
+# # optimization = "float64" # SR matrix, parameter updates
+# # io = "float64"           # I/O, structure data

--- a/examples/jqmc-example01/03mcmc_JSD/mcmc.toml
+++ b/examples/jqmc-example01/03mcmc_JSD/mcmc.toml
@@ -14,3 +14,6 @@ num_mcmc_warmup_steps = 0 # Number of observable measurement steps for warmup (i
 num_mcmc_bin_blocks = 5 # Number of blocks for binning per MPI and Walker. i.e., the total number of binned blocks is num_mcmc_bin_blocks * mpi_size * number_of_walkers.
 Dt = 2.0 # Step size for the MCMC update (bohr).
 epsilon_AS = 0.0 # the epsilon parameter used in the Attacalite-Sandro regulatization method.
+
+# [precision]
+# mode = "full"  # "full" (default, all float64) or "mixed" (recommended mixed precision)

--- a/examples/jqmc-example01/04lrdmc_JSD/lrdmc.toml
+++ b/examples/jqmc-example01/04lrdmc_JSD/lrdmc.toml
@@ -17,3 +17,6 @@
   num_gfmc_bin_blocks = 50
   num_gfmc_collect_steps = 20
   E_scf = -17.00
+
+# [precision]
+# mode = "full"  # "full" (default, all float64) or "mixed" (recommended mixed precision)

--- a/examples/jqmc-workflow-example01/run_pes_pipeline.py
+++ b/examples/jqmc-workflow-example01/run_pes_pipeline.py
@@ -51,6 +51,10 @@ TARGET_VMC_ERROR = 5e-4  # Target statistical error (Ha)
 TARGET_MCMC_ERROR = 5e-5  # Target statistical error (Ha)
 TARGET_LRDMC_ERROR = 5e-5  # Target statistical error (Ha)
 
+# Mixed precision: set to "mixed" to enable float32 for low-risk zones,
+# or None (default) for all-float64. See doc/notes/mixed_precision.md.
+PRECISION_MODE = None  # "mixed" or None
+
 R_VALUES = [
     0.40,
     0.45,
@@ -281,6 +285,7 @@ def build_pipeline() -> tuple[list[Container], dict[float, Container], dict[floa
                 max_time=3000,
                 poll_interval=120,
                 max_continuation=1,
+                precision_mode=PRECISION_MODE,
             ),
         )
 
@@ -305,6 +310,7 @@ def build_pipeline() -> tuple[list[Container], dict[float, Container], dict[floa
                 max_time=3000,
                 poll_interval=120,
                 max_continuation=1,
+                precision_mode=PRECISION_MODE,
             ),
         )
 
@@ -330,6 +336,7 @@ def build_pipeline() -> tuple[list[Container], dict[float, Container], dict[floa
                 max_time=3000,
                 poll_interval=120,
                 max_continuation=1,
+                precision_mode=PRECISION_MODE,
             ),
         )
 

--- a/examples/jqmc-workflow-example01/run_pes_pipeline.py
+++ b/examples/jqmc-workflow-example01/run_pes_pipeline.py
@@ -51,9 +51,9 @@ TARGET_VMC_ERROR = 5e-4  # Target statistical error (Ha)
 TARGET_MCMC_ERROR = 5e-5  # Target statistical error (Ha)
 TARGET_LRDMC_ERROR = 5e-5  # Target statistical error (Ha)
 
-# Mixed precision: set to "mixed" to enable float32 for low-risk zones,
-# or None (default) for all-float64. See doc/notes/mixed_precision.md.
-PRECISION_MODE = None  # "mixed" or None
+# Mixed precision: set to "mixed" to enable float32 for low-risk zones.
+# Default "full" keeps all zones in float64. See doc/notes/mixed_precision.md.
+PRECISION_MODE = "full"  # "full" or "mixed"
 
 R_VALUES = [
     0.40,

--- a/jqmc/_jqmc_utility.py
+++ b/jqmc/_jqmc_utility.py
@@ -41,11 +41,8 @@ See :mod:`jqmc._precision` for details.
 from functools import lru_cache
 from logging import getLogger
 
-import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
-
-from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -102,8 +99,7 @@ def _generate_init_electron_configurations(
     min_dst = 0.1
     max_dst = 1.0
 
-    dtype = get_dtype("io")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = np.float64
 
     # 1) zeta[i] = integer valence count per atom
     nion = coords.shape[0]
@@ -405,7 +401,6 @@ def _cart_to_spherical_matrix(l: int) -> np.ndarray:
     ``A_sph = A_cart @ T`` under the normalization used in the codebase. Values
     are deterministic and cached to avoid runtime fitting.
     """
-
     precomputed: dict[int, np.ndarray] = {
         0: np.array([[1.0]], dtype=np.float64),
         1: np.array(
@@ -731,7 +726,6 @@ def _spherical_to_cart_matrix(l: int) -> np.ndarray:
     Only ``_cart_to_spherical_matrix`` stores the full analytic values; this helper
     exposes the inverse direction for readability and reuse.
     """
-
     return _cart_to_spherical_matrix(l).T
 
 

--- a/jqmc/_jqmc_utility.py
+++ b/jqmc/_jqmc_utility.py
@@ -1,4 +1,10 @@
-"""utility module."""
+"""utility module.
+
+Precision Zones:
+    - ``io``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -35,8 +41,11 @@
 from functools import lru_cache
 from logging import getLogger
 
+import jax.numpy as jnp
 import numpy as np
 import numpy.typing as npt
+
+from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -93,6 +102,9 @@ def _generate_init_electron_configurations(
     min_dst = 0.1
     max_dst = 1.0
 
+    dtype = get_dtype("io")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+
     # 1) zeta[i] = integer valence count per atom
     nion = coords.shape[0]
     zeta = np.array([int(round(c)) for c in charges], dtype=int)
@@ -120,8 +132,8 @@ def _generate_init_electron_configurations(
         i_prev = best_i
 
     # 4) Prepare storage for all walkers
-    r_carts_up = np.zeros((num_walkers, tot_num_electron_up, 3), dtype=float)
-    r_carts_dn = np.zeros((num_walkers, tot_num_electron_dn, 3), dtype=float)
+    r_carts_up = np.zeros((num_walkers, tot_num_electron_up, 3), dtype=dtype_np)
+    r_carts_dn = np.zeros((num_walkers, tot_num_electron_dn, 3), dtype=dtype_np)
     up_owner = np.zeros((num_walkers, tot_num_electron_up), dtype=int)
     dn_owner = np.zeros((num_walkers, tot_num_electron_dn), dtype=int)
 
@@ -143,7 +155,7 @@ def _generate_init_electron_configurations(
         # Phase 1a: Place all down-electrons under Hund’s limit first
         # -----------------------------------------
         ned_dn = tot_num_electron_dn
-        down_positions = np.zeros((ned_dn, 3), dtype=float)
+        down_positions = np.zeros((ned_dn, 3), dtype=dtype_np)
         j_counter = 0
 
         for idn in range(ned_dn):
@@ -209,7 +221,7 @@ def _generate_init_electron_configurations(
         sum_up_needed = int(np.sum(up_needed))
 
         ned_up = tot_num_electron_up
-        up_positions = np.zeros((ned_up, 3), dtype=float)
+        up_positions = np.zeros((ned_up, 3), dtype=dtype_np)
 
         # Case 1: ned_up <= sum_up_needed → place ned_up among those up_needed slots
         if ned_up <= sum_up_needed:

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -111,9 +111,14 @@ _DEFAULTS_FULL: dict[str, str] = {
 
 # --- mode="mixed" defaults (recommended mixed precision) ---
 # float32 risk:
-#   orb_eval    - low: smooth Gaussian basis + linear combination
+#   orb_eval    - low: smooth Gaussian basis + linear combination.
+#                 (Heavy AO eval stays in fp32; compute_MOs upcasts the small
+#                  matmul to the determinant zone, see molecular_orbital.py.)
 #   jastrow     - low: smooth correlation function, pre-exp value
-#   geminal     - low: building matrix elements only (pre-det)
+#   geminal     - HIGH: this matrix is the input to LU/det; even ε≈1e-7 on
+#                 entries amplifies into log|det| errors of O(1) for ~32x32
+#                 systems with non-trivial condition numbers
+#                 (see bug/fp32 diagnostics).  Kept in fp64.
 #   coulomb     - low-medium: sum of 1/r + ECP spherical quadrature
 #   determinant - high: log(det) cancellation, SVD 1/s, eigenvalue ops
 #   kinetic     - high: second derivative of ln|Psi|, cancellation-sensitive
@@ -122,9 +127,9 @@ _DEFAULTS_FULL: dict[str, str] = {
 #   optimization- high: S^{-1}F linear system, ill-conditioned matrix
 #   io          - low-medium: file I/O + nuclear coordinates
 _DEFAULTS_MIXED: dict[str, str] = {
-    "orb_eval": "float32",  # low risk
+    "orb_eval": "float32",  # low risk (heavy kernel only)
     "jastrow": "float32",  # low risk
-    "geminal": "float32",  # low risk
+    "geminal": "float64",  # high risk: feeds LU/det
     "determinant": "float64",  # high risk
     "coulomb": "float32",  # low-medium risk
     "kinetic": "float64",  # high risk

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -5,11 +5,16 @@ specifies dtype for all variables it creates or consumes.  This design
 does NOT rely on JAX's implicit dtype propagation, ensuring robustness
 against future changes in JAX's type promotion semantics.
 
-All zones are user-configurable.  Defaults depend on the mode:
+Users choose one of two modes:
 
-- ``mode="full"``  (default) — all zones float64 (backward compatible).
-- ``mode="mixed"`` — recommended mixed precision; low-risk zones become
+- ``"full"``  (default) — all zones float64 (backward compatible).
+- ``"mixed"`` — recommended mixed precision; low-risk zones become
   float32 while numerically sensitive zones stay float64.
+
+Individual zone assignments are **not** user-configurable; they are
+defined in ``_FULL_PRECISION`` and ``_MIXED_PRECISION`` below.
+Developers who need to tweak per-zone dtypes should edit those dicts
+directly in this file.
 
 Precision Zones
 ---------------
@@ -19,7 +24,7 @@ Zone            Components                    Default    Mixed     float32 risk
 ==============  ============================  =========  ========  ============
 ``orb_eval``    AO/MO forward evaluation      float64    float32   low
 ``jastrow``     Jastrow factor (J1/J2/J3)     float64    float32   low
-``geminal``     Geminal matrix elements        float64    float32   low
+``geminal``     Geminal matrix elements        float64    float64   high
 ``determinant`` log-det, SVD, AS reg.          float64    float64   high
 ``coulomb``     Coulomb + ECP potential        float64    float32   low-medium
 ``kinetic``     Kinetic energy + AO/MO derivs  float64    float64   high
@@ -95,8 +100,8 @@ import jax.numpy as jnp
 
 logger = logging.getLogger(__name__)
 
-# --- mode="full" defaults (all float64, backward compatible) ---
-_DEFAULTS_FULL: dict[str, str] = {
+# --- mode="full" (all float64, backward compatible) ---
+_FULL_PRECISION: dict[str, str] = {
     "orb_eval": "float64",  # AO/MO forward evaluation
     "jastrow": "float64",  # Jastrow factor
     "geminal": "float64",  # Geminal matrix elements
@@ -109,7 +114,7 @@ _DEFAULTS_FULL: dict[str, str] = {
     "io": "float64",  # I/O, structure data
 }
 
-# --- mode="mixed" defaults (recommended mixed precision) ---
+# --- mode="mixed" (recommended mixed precision) ---
 # float32 risk:
 #   orb_eval    - low: smooth Gaussian basis + linear combination.
 #                 (Heavy AO eval stays in fp32; compute_MOs upcasts the small
@@ -126,7 +131,7 @@ _DEFAULTS_FULL: dict[str, str] = {
 #   gfmc        - high: weighted branching/pruning, population collapse in float32
 #   optimization- high: S^{-1}F linear system, ill-conditioned matrix
 #   io          - low-medium: file I/O + nuclear coordinates
-_DEFAULTS_MIXED: dict[str, str] = {
+_MIXED_PRECISION: dict[str, str] = {
     "orb_eval": "float32",  # low risk (heavy kernel only)
     "jastrow": "float32",  # low risk
     "geminal": "float64",  # high risk: feeds LU/det
@@ -139,7 +144,7 @@ _DEFAULTS_MIXED: dict[str, str] = {
     "io": "float64",  # low-medium risk
 }
 
-ALL_ZONES = frozenset(_DEFAULTS_FULL.keys())
+ALL_ZONES = frozenset(_FULL_PRECISION.keys())
 
 # Runtime zone -> dtype mapping
 _zone_dtypes: dict[str, type] = {}
@@ -165,48 +170,46 @@ def _str_to_dtype(s: str) -> type:
         raise ValueError(f"Invalid dtype '{s}'. Must be 'float32' or 'float64'.")
 
 
-def configure(precision_config: dict[str, str]) -> None:
-    """Set zone-level dtypes from a TOML ``[precision]`` section.
+def configure(mode: str = "full") -> None:
+    """Activate a precision mode.
 
     Args:
-        precision_config: Mapping such as ``{"mode": "mixed", "orb_eval": "float32", ...}``.
-
-            - ``mode="full"`` (default): all zones float64.
-            - ``mode="mixed"``: recommended mixed precision defaults.
-            - ``mode`` omitted: same as ``"full"``.
-            - Per-zone overrides take highest priority regardless of *mode*.
+        mode: ``"full"`` (default, all float64) or ``"mixed"``
+            (recommended mixed precision).
 
     Raises:
-        ValueError: If *mode* is unknown, a zone name is invalid, or a dtype
-            string is not ``"float32"``/``"float64"``.
+        ValueError: If *mode* is not ``"full"`` or ``"mixed"``.
     """
     _zone_dtypes.clear()
 
-    mode = precision_config.get("mode", "full")
-
-    # Select base configuration
     if mode == "full":
-        base = dict(_DEFAULTS_FULL)
+        base = _FULL_PRECISION
     elif mode == "mixed":
-        base = dict(_DEFAULTS_MIXED)
+        base = _MIXED_PRECISION
     else:
         raise ValueError(f"Unknown precision mode '{mode}'. Must be 'full' or 'mixed'.")
 
-    # Apply per-zone overrides
-    for zone, dtype_str in precision_config.items():
-        if zone == "mode":
-            continue
-        if zone not in ALL_ZONES:
-            raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
-        _str_to_dtype(dtype_str)  # validate
-        base[zone] = dtype_str
-
-    # Build final mapping
     for zone, dtype_str in base.items():
         _zone_dtypes[zone] = _str_to_dtype(dtype_str)
 
-    # Log the precision configuration
     logger.info(summary())
+
+
+def _set_zone(zone: str, dtype_str: str) -> None:
+    """Override a single zone's dtype at runtime (developer use only).
+
+    Must be called **after** :func:`configure`.  This is intentionally
+    private — normal users select ``"full"`` or ``"mixed"`` mode and the
+    per-zone mapping is determined by ``_FULL_PRECISION`` /
+    ``_MIXED_PRECISION``.
+
+    Args:
+        zone: Precision Zone name.
+        dtype_str: ``"float32"`` or ``"float64"``.
+    """
+    if zone not in ALL_ZONES:
+        raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
+    _zone_dtypes[zone] = _str_to_dtype(dtype_str)
 
 
 def get_dtype(zone: str) -> type:

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -373,6 +373,12 @@ ALL_ZONES = frozenset(_FULL_PRECISION.keys())
 # Strings are stored (not numpy/jax dtype types) so the str -> jnp.* / np.*
 # conversion lives inside the per-flavor accessors below.  This keeps the
 # concrete dtype flavor (jnp vs np) cleanly separated at the API boundary.
+#
+# This module-level dict is the **single source of truth** for the precision
+# state within a Python process: ``configure(mode)`` clears and refills it,
+# and ``get_dtype_jnp`` / ``get_dtype_np`` read from it.  No other variable
+# (class attribute, environment variable, etc.) holds the active dtype
+# mapping — this dict is the only place to consult or mutate.
 _zone_dtypes: dict[str, str] = {}
 
 

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -20,7 +20,7 @@ the table below (and enforced by convention in ``_FULL_PRECISION`` /
 Principle 2 — A module may own multiple Precision Zones.
 ------------------------------------------------------------
 Different code paths in the same module legitimately need different precisions
-(e.g. ``ao_eval`` vs ``ao_grad_lap``, or ``det_eval`` vs ``det_ratio``). Each
+(e.g. ``ao_eval`` vs ``ao_grad``, or ``det_eval`` vs ``det_ratio``). Each
 zone is named for its *purpose*, not for its dtype.
 
 ------------------------------------------------------------
@@ -174,9 +174,11 @@ Precision Zones
 Zone                Owning module                      Default    Mixed     risk   E_L path
 ==================  =================================  =========  ========  =====  =========
 ``ao_eval``         atomic_orbital.py (forward)        float64    float32   low    core
-``ao_grad_lap``     atomic_orbital.py (grad/lap)       float64    float32   low    core
+``ao_grad``         atomic_orbital.py (gradient)       float64    float32   low    core
+``ao_lap``          atomic_orbital.py (Laplacian)      float64    float64   high§  core
 ``mo_eval``         molecular_orbital.py (forward)     float64    float64   high*  core
-``mo_grad_lap``     molecular_orbital.py (grad/lap)    float64    float64   high   core
+``mo_grad``         molecular_orbital.py (gradient)    float64    float64   high   core
+``mo_lap``          molecular_orbital.py (Laplacian)   float64    float64   high   core
 ``jastrow_eval``    jastrow_factor.py (forward)        float64    float32   low    core†
 ``jastrow_grad_lap`` jastrow_factor.py (grad/lap)      float64    float32   low    core
 ``jastrow_ratio``   jastrow_factor.py (ratio update)   float64    float32   low    indirect‡
@@ -200,6 +202,16 @@ amplified by log|det|.  See ``bug/fp32`` diagnostics.
 forward values (J and ln|Psi|) do not enter the E_L formula directly
 (E_L depends on *derivatives* of ln|Psi|).  Diagnostics show zero E_L
 bias when these zones alone are fp32.
+
+§ ``ao_lap`` is fp64 even in mixed mode because the analytic Laplacian
+kernel for spherical AOs contains catastrophic cancellation
+(``4 Z² r² − 6 Z`` and ``(safe_div − 2 Z·base)² − safe_div² − 2 Z``
+terms) that fp32 cannot resolve for tight Gaussians. Diagnostic
+``bug/fp32/diag_07_ao_grad_vs_lap_split.py`` showed that
+``ao_lap=fp32`` alone reproduces the full atomic-force bias
+(``max|dF| ≈ 1.9 Ha/bohr`` on N₂ at scale=0.3, ``≈ 2e−2 Ha/bohr`` on
+the water-cluster-8 system), while ``ao_grad=fp32`` alone is safe
+(``max|dF| < 8e−3 Ha/bohr``).
 
 ‡ ``det_ratio`` and ``jastrow_ratio`` affect E_L **indirectly** through
 the ECP non-local potential, which evaluates Psi(R')/Psi(R) on a
@@ -225,7 +237,7 @@ Usage::
         # NOTE: never reach for another module's zone (e.g.
         # ``get_dtype_jnp("local_energy")``) here — that violates
         # Principle 1 (zone ↔ owning module is 1:1). atomic_orbital.py
-        # may only consult ao_eval / ao_grad_lap.
+        # may only consult ao_eval / ao_grad / ao_lap.
         dtype_jnp = get_dtype_jnp("ao_eval")
         R_carts = aos_data._atomic_center_carts_jnp
         diff = (r_carts - R_carts).astype(dtype_jnp)
@@ -276,10 +288,12 @@ logger = logging.getLogger(__name__)
 _FULL_PRECISION: dict[str, str] = {
     # atomic_orbital.py
     "ao_eval": "float64",  # AO forward evaluation
-    "ao_grad_lap": "float64",  # AO gradient / Laplacian
+    "ao_grad": "float64",  # AO gradient
+    "ao_lap": "float64",  # AO Laplacian
     # molecular_orbital.py
     "mo_eval": "float64",  # MO forward evaluation (mo_coef @ AO)
-    "mo_grad_lap": "float64",  # MO gradient / Laplacian
+    "mo_grad": "float64",  # MO gradient
+    "mo_lap": "float64",  # MO Laplacian
     # jastrow_factor.py
     "jastrow_eval": "float64",  # Jastrow factor (J1/J2/J3)
     "jastrow_grad_lap": "float64",  # Jastrow gradient / Laplacian
@@ -307,13 +321,19 @@ _FULL_PRECISION: dict[str, str] = {
 #                      The downstream consumer (mo_eval / det_eval /
 #                      jastrow_eval) is fp64 and explicitly casts the AO
 #                      result up before any sensitive arithmetic.
-#   ao_grad_lap      - AO gradient / Laplacian kernel; same O(N_ao × N_e)
-#                      cost as ao_eval.  Diagnostics show bias < 6e-05 Ha
-#                      at 32 electrons (0.05 kcal/mol margin ×1.3).
+#   ao_grad          - AO analytic gradient kernel; same O(N_ao × N_e)
+#                      cost as ao_eval.  Diagnostics
+#                      (bug/fp32/diag_07) show grad-only fp32 yields
+#                      max|dF| < 8e-3 Ha/bohr (relative bias ~5e-5 on
+#                      water-cluster-8) — well within chemical accuracy.
 #   jastrow_eval     - smooth correlation function value (pre-exp).
-#   jastrow_grad_lap - nabla J, nabla^2 J; Jastrow is a smooth function
-#                      with low cancellation.  Diagnostics show bias
-#                      < 8e-06 Ha at 32 electrons (0.05 kcal/mol margin ×11).
+#   jastrow_grad_lap - nabla J, nabla^2 J; smooth Jastrow factor, low
+#                      cancellation. Diagnostics show bias < 8e-06 Ha
+#                      at 32 electrons (0.05 kcal/mol margin ×11).
+#                      Kept as a single zone (no grad/lap split) because
+#                      both halves share the same fp32 risk profile and
+#                      Jastrow grad/lap functions compute the two
+#                      together (``compute_grads_and_laplacian_*``).
 #   jastrow_ratio    - J(R')-J(R) log-ratio; smooth and well-behaved.
 #                      Diagnostics show bias < 2e-06 Ha (margin ×44).
 #
@@ -322,6 +342,12 @@ _FULL_PRECISION: dict[str, str] = {
 # unacceptable bias on E_L for ~32-electron systems, OR the
 # kernel is cheap enough that fp32 is not worth the bias:
 #
+#   ao_lap        - analytic Laplacian kernel for spherical/Cartesian AOs
+#                   contains catastrophic cancellation (``4 Z² r² − 6 Z``
+#                   and ``(safe_div − 2 Z·base)² − safe_div² − 2 Z``).
+#                   diag_07 showed lap=fp32 alone yields max|dF| ≈ 1.9
+#                   Ha/bohr on N₂ (scale=0.3), reproducing the entire
+#                   bias of grad+lap=fp32. fp64 mandatory.
 #   coulomb       - sum of 1/r + ECP spherical quadrature.  Cheap
 #                   (O(N_e^2) el-el + O(N_e * N_nuc) el-ion, vs
 #                   O(N_e * N_ao) AO eval) but contributes the
@@ -333,8 +359,15 @@ _FULL_PRECISION: dict[str, str] = {
 #   det_eval      - geminal matrix + log(det) + SVD; cancellation in
 #                   log(det), SVD 1/s near-singular, ε≈1e-7 entries
 #                   produce O(1) log|det| error.
-#   *_grad_lap    - second derivatives of ln|Psi|; cancellation-sensitive
-#                   (except ao_grad_lap and jastrow_grad_lap — smooth kernels).
+#   mo_grad / mo_lap / det_grad_lap
+#                 - second derivatives of ln|Psi|; cancellation-sensitive
+#                   on the determinant side (the AO-side fp32 is absorbed
+#                   by the fp64 mo_coef matmul). jastrow_grad_lap is the
+#                   exception (smooth Jastrow, no severe cancellation).
+#                   det_grad_lap is kept as a single zone (no grad/lap
+#                   split) for symmetry with jastrow_grad_lap and because
+#                   the determinant grad/lap functions naturally compute
+#                   both quantities together (``compute_grads_and_laplacian_*``).
 #   wf_kinetic    - sum (lap_J + lap_lnD) + |grad_J + grad_lnD|^2; cancellation.
 #   local_energy  - T + V assembly; small differences between large terms.
 #   det_ratio     - SM rank-1 ratio used by MCMC accept/reject AND
@@ -343,17 +376,19 @@ _FULL_PRECISION: dict[str, str] = {
 _MIXED_PRECISION: dict[str, str] = {
     # atomic_orbital.py
     "ao_eval": "float32",  # low risk (heavy kernel)
-    "ao_grad_lap": "float32",  # low risk (bias < 6e-05 Ha at 32e; heavy kernel)
+    "ao_grad": "float32",  # low risk (smooth grad kernel; bias < 8e-3 Ha/bohr atomic force)
+    "ao_lap": "float64",  # high risk (catastrophic cancellation in 4Z²r²-6Z terms)
     # molecular_orbital.py
     "mo_eval": "float64",  # high risk (feeds det_eval)
-    "mo_grad_lap": "float64",  # high risk
+    "mo_grad": "float64",  # high risk
+    "mo_lap": "float64",  # high risk
     # jastrow_factor.py
     "jastrow_eval": "float32",  # low risk
     "jastrow_grad_lap": "float32",  # low risk (smooth J; bias < 8e-06 Ha at 32e)
     "jastrow_ratio": "float32",  # low risk (smooth J ratio; bias < 2e-06 Ha at 32e)
     # determinant.py
     "det_eval": "float64",  # high risk (LU/det / SVD)
-    "det_grad_lap": "float64",  # high risk
+    "det_grad_lap": "float64",  # high risk (kept unsplit for symmetry with jastrow)
     "det_ratio": "float64",  # high risk (SM update error + ECP non-local ratio)
     # coulomb_potential.py
     "coulomb": "float64",  # cheap kernel + largest single fp32 bias (~6e-5 Ha)

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -1,0 +1,273 @@
+"""Mixed precision configuration for jQMC.
+
+Every computational function declares its Precision Zone and explicitly
+specifies dtype for all variables it creates or consumes.  This design
+does NOT rely on JAX's implicit dtype propagation, ensuring robustness
+against future changes in JAX's type promotion semantics.
+
+All zones are user-configurable.  Defaults depend on the mode:
+
+- ``mode="full"``  (default) — all zones float64 (backward compatible).
+- ``mode="mixed"`` — recommended mixed precision; low-risk zones become
+  float32 while numerically sensitive zones stay float64.
+
+Precision Zones
+---------------
+
+==============  ============================  =========  ========  ============
+Zone            Components                    Default    Mixed     float32 risk
+==============  ============================  =========  ========  ============
+``orb_eval``    AO/MO forward evaluation      float64    float32   low
+``jastrow``     Jastrow factor (J1/J2/J3)     float64    float32   low
+``geminal``     Geminal matrix elements        float64    float32   low
+``determinant`` log-det, SVD, AS reg.          float64    float64   high
+``coulomb``     Coulomb + ECP potential        float64    float32   low-medium
+``kinetic``     Kinetic energy + AO/MO derivs  float64    float64   high
+``mcmc``        MCMC sampling                  float64    float64   high
+``gfmc``        GFMC propagation               float64    float64   high
+``optimization``SR matrix, parameter updates   float64    float64   high
+``io``          I/O, structure data            float64    float64   low-medium
+==============  ============================  =========  ========  ============
+
+File-to-zone mapping
+--------------------
+
+- ``atomic_orbital.py``: ``orb_eval`` (forward), ``kinetic`` (grad/laplacian)
+- ``molecular_orbital.py``: ``orb_eval`` (forward), ``kinetic`` (grad/laplacian)
+- ``jastrow_factor.py``: ``jastrow`` (forward), ``kinetic`` (grad/laplacian),
+  ``mcmc`` (ratio/update)
+- ``determinant.py``: ``geminal`` (matrix elements), ``determinant`` (log-det/SVD),
+  ``kinetic`` (grad/laplacian)
+- ``coulomb_potential.py``: ``coulomb``
+- ``wavefunction.py``: ``kinetic`` + zone-boundary casts
+- ``hamiltonians.py``: ``kinetic`` (zone-boundary aggregation of T + V)
+- ``jqmc_mcmc.py``: ``mcmc`` (sampling), ``optimization`` (SR/LM)
+- ``jqmc_gfmc.py``: ``gfmc``
+- ``structure.py``, ``trexio_wrapper.py``, ``jqmc_tool.py``: ``io``
+- ``_jqmc_utility.py``: ``io``
+- ``swct.py``: ``kinetic``
+
+Usage::
+
+    from jqmc._precision import get_dtype
+
+    def compute_AOs(aos_data, r_carts):
+        dtype = get_dtype("orb_eval")
+        r_carts = jnp.asarray(r_carts, dtype=dtype)
+        ...
+"""
+
+# Copyright (C) 2024- Kosuke Nakano
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in
+#   the documentation and/or other materials provided with the
+#   distribution.
+#
+# * Neither the name of the jqmc project nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+
+import jax.numpy as jnp
+
+logger = logging.getLogger(__name__)
+
+# --- mode="full" defaults (all float64, backward compatible) ---
+_DEFAULTS_FULL: dict[str, str] = {
+    "orb_eval": "float64",  # AO/MO forward evaluation
+    "jastrow": "float64",  # Jastrow factor
+    "geminal": "float64",  # Geminal matrix elements
+    "determinant": "float64",  # log-det, SVD, AS regularization
+    "coulomb": "float64",  # Coulomb + ECP potential
+    "kinetic": "float64",  # Kinetic energy + AO/MO derivatives
+    "mcmc": "float64",  # MCMC sampling (proposal, SM update, accept/reject, accumulation)
+    "gfmc": "float64",  # GFMC propagation
+    "optimization": "float64",  # SR matrix, parameter updates
+    "io": "float64",  # I/O, structure data
+}
+
+# --- mode="mixed" defaults (recommended mixed precision) ---
+# float32 risk:
+#   orb_eval    - low: smooth Gaussian basis + linear combination
+#   jastrow     - low: smooth correlation function, pre-exp value
+#   geminal     - low: building matrix elements only (pre-det)
+#   coulomb     - low-medium: sum of 1/r + ECP spherical quadrature
+#   determinant - high: log(det) cancellation, SVD 1/s, eigenvalue ops
+#   kinetic     - high: second derivative of ln|Psi|, cancellation-sensitive
+#   mcmc        - high: SM inverse error accumulation, acceptance ratio, statistics
+#   gfmc        - high: weighted branching/pruning, population collapse in float32
+#   optimization- high: S^{-1}F linear system, ill-conditioned matrix
+#   io          - low-medium: file I/O + nuclear coordinates
+_DEFAULTS_MIXED: dict[str, str] = {
+    "orb_eval": "float32",  # low risk
+    "jastrow": "float32",  # low risk
+    "geminal": "float32",  # low risk
+    "determinant": "float64",  # high risk
+    "coulomb": "float32",  # low-medium risk
+    "kinetic": "float64",  # high risk
+    "mcmc": "float64",  # high risk
+    "gfmc": "float64",  # high risk
+    "optimization": "float64",  # high risk
+    "io": "float64",  # low-medium risk
+}
+
+ALL_ZONES = frozenset(_DEFAULTS_FULL.keys())
+
+# Runtime zone -> dtype mapping
+_zone_dtypes: dict[str, type] = {}
+
+
+def _str_to_dtype(s: str) -> type:
+    """Convert a string dtype name to the corresponding JAX/NumPy dtype type.
+
+    Args:
+        s: Either ``"float32"`` or ``"float64"``.
+
+    Returns:
+        ``jnp.float32`` or ``jnp.float64``.
+
+    Raises:
+        ValueError: If *s* is not one of the two accepted strings.
+    """
+    if s == "float32":
+        return jnp.float32
+    elif s == "float64":
+        return jnp.float64
+    else:
+        raise ValueError(f"Invalid dtype '{s}'. Must be 'float32' or 'float64'.")
+
+
+def configure(precision_config: dict[str, str]) -> None:
+    """Set zone-level dtypes from a TOML ``[precision]`` section.
+
+    Args:
+        precision_config: Mapping such as ``{"mode": "mixed", "orb_eval": "float32", ...}``.
+
+            - ``mode="full"`` (default): all zones float64.
+            - ``mode="mixed"``: recommended mixed precision defaults.
+            - ``mode`` omitted: same as ``"full"``.
+            - Per-zone overrides take highest priority regardless of *mode*.
+
+    Raises:
+        ValueError: If *mode* is unknown, a zone name is invalid, or a dtype
+            string is not ``"float32"``/``"float64"``.
+    """
+    _zone_dtypes.clear()
+
+    mode = precision_config.get("mode", "full")
+
+    # Select base configuration
+    if mode == "full":
+        base = dict(_DEFAULTS_FULL)
+    elif mode == "mixed":
+        base = dict(_DEFAULTS_MIXED)
+    else:
+        raise ValueError(f"Unknown precision mode '{mode}'. Must be 'full' or 'mixed'.")
+
+    # Apply per-zone overrides
+    for zone, dtype_str in precision_config.items():
+        if zone == "mode":
+            continue
+        if zone not in ALL_ZONES:
+            raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
+        _str_to_dtype(dtype_str)  # validate
+        base[zone] = dtype_str
+
+    # Build final mapping
+    for zone, dtype_str in base.items():
+        _zone_dtypes[zone] = _str_to_dtype(dtype_str)
+
+    # Log the precision configuration
+    logger.info(summary())
+
+
+def get_dtype(zone: str) -> type:
+    """Return the dtype for a Precision Zone.
+
+    When :func:`configure` has not been called, ``jnp.float64`` is returned
+    for any zone name (backward compatible).  After :func:`configure` has
+    been called, an unknown *zone* raises :class:`ValueError`.
+
+    Args:
+        zone: Precision Zone name (e.g. ``"orb_eval"``, ``"kinetic"``).
+
+    Returns:
+        ``jnp.float32`` or ``jnp.float64``.
+    """
+    if _zone_dtypes:
+        # configure() has been called: validate zone name
+        if zone not in ALL_ZONES:
+            raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
+    return _zone_dtypes.get(zone, jnp.float64)
+
+
+def is_mixed_precision_enabled() -> bool:
+    """Return ``True`` if at least one zone is set to float32."""
+    return any(d == jnp.float32 for d in _zone_dtypes.values())
+
+
+def get_tolerance(zone: str, level: str = "strict") -> tuple[float, float]:
+    """Return test tolerances ``(atol, rtol)`` scaled by the zone's dtype.
+
+    Args:
+        zone: Precision Zone name.
+        level: ``"strict"`` or ``"loose"``.
+
+    Returns:
+        ``(atol, rtol)`` tuple appropriate for the zone's current dtype.
+    """
+    from jqmc._setting import _TOLERANCE
+
+    dtype_key = "float32" if get_dtype(zone) == jnp.float32 else "float64"
+    return _TOLERANCE[level][dtype_key]
+
+
+def get_tolerance_min(zones, level: str = "strict") -> tuple[float, float]:
+    """Return ``(atol, rtol)`` loose enough for the lowest-precision zone.
+
+    Use for comparing two exact computations whose path crosses
+    multiple zones; the achievable agreement is bounded by the
+    weakest (largest tolerance) zone on the path.
+
+    Args:
+        zones: Iterable of Precision Zone names.
+        level: ``"strict"`` or ``"loose"``.
+
+    Returns:
+        ``(atol, rtol)`` tuple using the maximum of each component.
+    """
+    atols, rtols = zip(*(get_tolerance(z, level) for z in zones))
+    return max(atols), max(rtols)
+
+
+def summary() -> str:
+    """Return a human-readable summary of the current precision configuration."""
+    lines = ["Precision configuration:"]
+    for zone in sorted(ALL_ZONES):
+        dtype = get_dtype(zone)
+        tag = "float32" if dtype == jnp.float32 else "float64"
+        lines.append(f"  {zone}: {tag}")
+    return "\n".join(lines)

--- a/jqmc/_precision.py
+++ b/jqmc/_precision.py
@@ -1,9 +1,160 @@
-"""Mixed precision configuration for jQMC.
+r"""Mixed precision configuration for jQMC.
 
-Every computational function declares its Precision Zone and explicitly
-specifies dtype for all variables it creates or consumes.  This design
-does NOT rely on JAX's implicit dtype propagation, ensuring robustness
-against future changes in JAX's type promotion semantics.
+================================================================================
+DESIGN PRINCIPLES (READ THIS FIRST)
+================================================================================
+
+The mixed-precision implementation rests on **three** principles. Principle 3
+is the most important in practice; almost every precision bug we have seen is
+a violation of 3a or 3b.
+
+------------------------------------------------------------
+Principle 1 — One Precision Zone is owned by exactly one module.
+------------------------------------------------------------
+A zone (e.g. ``ao_eval``, ``coulomb``) is *defined and consumed* in a single
+module. The mapping zone ↔ owning module is one-to-one and is documented in
+the table below (and enforced by convention in ``_FULL_PRECISION`` /
+``_MIXED_PRECISION``).
+
+------------------------------------------------------------
+Principle 2 — A module may own multiple Precision Zones.
+------------------------------------------------------------
+Different code paths in the same module legitimately need different precisions
+(e.g. ``ao_eval`` vs ``ao_grad_lap``, or ``det_eval`` vs ``det_ratio``). Each
+zone is named for its *purpose*, not for its dtype.
+
+------------------------------------------------------------
+Principle 3 — Cast responsibility lies with the function that does
+              arithmetic on the value, never with passthrough wrappers.
+------------------------------------------------------------
+
+Definition. *arithmetic* means consuming a value as an operand of a numerical
+operation (``+ - * /``, ``jnp.linalg.norm``, ``jnp.dot``, ``@``, ``jnp.exp``,
+…) **or** as an input to ``jax.grad`` / ``jax.jacrev`` / ``jax.hessian``.
+Operations that do *not* count as arithmetic and therefore do *not* trigger a
+cast: ``len(x)``, ``x.shape``, ``x[i]`` (index lookup), the *target* of
+``.at[i].set(y)``, and forwarding ``x`` as an argument to another function.
+
+Principle 3a — Arguments are frozen.
+    Function arguments are treated as **frozen**, in the same sense as the
+    attributes of a ``@dataclass(frozen=True)``: the name introduced by the
+    parameter list **must not be rebound** for the entire body of the
+    function. In particular, ``arg = jnp.asarray(arg, dtype=...)`` at the
+    top of a function is forbidden — it silently coerces the argument for
+    every later use, including forwarding.
+
+    Consequences (not extra rules — direct corollaries of "frozen"):
+      * Forwarding neutrality. A value forwarded to a callee transits in
+        the dtype it was received in; the callee is responsible for casting
+        it to *its* own zone (Principle 3b).
+      * Cast at the use site. When the function consumes ``arg`` as an
+        operand of its own arithmetic, the cast appears **inside the
+        expression** (``arg.astype(dtype)``). Do *not* preemptively
+        introduce a local alias just to hold the cast — only do so when
+        the cast result is reused multiple times, in which case introduce
+        a *new* local variable with a different name (e.g.
+        ``arg_local = arg.astype(dtype)``). The original ``arg`` always
+        remains frozen.
+
+Principle 3b — Local cast at the point of arithmetic.
+    A function casts a value to its own zone's dtype **immediately before**
+    consuming it as an operand. Inputs and outputs of the function's
+    arithmetic both live in its zone. Intermediate computations may use a
+    higher precision when needed for numerical reasons (the canonical case
+    being ``r - R``: reconstruct the difference in the **dtype the value
+    was received in** — i.e. the precision chosen by the upper layer —
+    to avoid catastrophic cancellation, then down-cast the result back to
+    the function's own zone). In jQMC the upstream (mcmc walker state) is
+    always fp64, so in practice the reconstruction happens in fp64; the
+    *principle*, however, is "use the caller-supplied precision," not
+    "hardcode fp64." Concretely: do not write ``jnp.float64`` as a
+    literal, and avoid pinning the reconstruction to a specific zone
+    name when the incoming value's own dtype already carries the right
+    precision.
+
+Worked example (the ECP → AO bug this design prevents)::
+
+    # WRONG: rebinding `r_carts` at the top of compute_coulomb forwards a
+    # fp32-truncated array to compute_AOs, even though `ao_eval` is fp64.
+    def compute_coulomb(r_carts, R_carts):
+        dtype_jnp = get_dtype_jnp("coulomb")
+        r_carts = jnp.asarray(r_carts, dtype=dtype_jnp)  # 3a violation
+        R_carts = jnp.asarray(R_carts, dtype=dtype_jnp)
+        ao = compute_AOs(..., r_carts, R_carts)          # downstream sees fp32
+        diff = r_carts - R_carts
+        ...
+
+    # RIGHT: forwarding stays in the caller's dtype; the local arithmetic
+    # reconstructs the difference in the dtype the values were received in
+    # (the upper-layer precision — fp64 in jQMC because mcmc walker state
+    # is fp64) and casts the result back to the function's own zone.
+    def compute_coulomb(r_carts, R_carts):
+        ao = compute_AOs(..., r_carts, R_carts)          # 3a: forward as-is
+        dtype_jnp = get_dtype_jnp("coulomb")
+        # reconstruct in the caller-supplied precision, then down-cast
+        diff = (r_carts - R_carts).astype(dtype_jnp)     # 3b
+        ...
+
+Auditing recipe.
+    To verify a module:
+      * (3a) Search for ``arg = jnp.asarray(arg, dtype=...)`` at the top of
+        any public function. Each occurrence is a 3a candidate violation —
+        the rebind silently coerces the argument for any subsequent
+        forwarding too.
+      * (3b) For each arithmetic expression, check that all operands have
+        been cast to the function's zone in the immediately preceding lines.
+      * (catastrophic cancellation) For each ``r - R`` style difference of
+        coordinates, check the reconstruct-in-caller-precision-then-downcast
+        pattern (in jQMC this is fp64 in practice because the upstream is
+        always fp64, but the rule is "use the dtype the value was received
+        in," not "hardcode fp64").
+
+No hardcoded dtypes inside selectable-precision modules.
+    Inside any module that owns one or more selectable-precision zones
+    (i.e. any zone whose dtype can differ between ``"full"`` and
+    ``"mixed"`` mode), **never hardcode** ``jnp.float64`` / ``np.float64``
+    / ``jnp.float32`` / ``np.float32`` as a literal dtype for arrays the
+    module produces or consumes. Always go through the accessors
+    ``get_dtype_jnp("<zone>")`` / ``get_dtype_np("<zone>")`` so the dtype
+    follows the active mode automatically. The only legitimate exception
+    is a module whose owned data is **always fp64 by construction**,
+    independent of any selectable zone:
+
+      * ``mcmc`` / ``gfmc`` (MCMC and GFMC walker state, always fp64).
+      * I/O modules that load and store external numerical data
+        (``structure``, ``trexio_wrapper``, ``_jqmc_utility``,
+        ``jqmc_tool``, and the ``_load_dataclass_from_hdf5`` /
+        ``_save_dataclass_to_hdf5`` helpers in ``hamiltonians``):
+        on-disk numerical data (AO exponents/coefficients, nuclear
+        coordinates, geminal coefficients, etc.) is always fp64
+        because fp32 storage would silently lose precision that no
+        downstream fp64 upcast can recover.
+      * Basis-data storage accessors. ``_*_jnp`` properties on
+        selectable-precision dataclasses whose underlying storage
+        field is typed ``npt.NDArray[np.float64]`` are *lift-only*
+        adapters (numpy → ``jax.Array``), not arithmetic. The dtype
+        is fp64 by construction: storage is loaded from
+        HDF5/TREXIO/optimizer output (see Phase A1 numpy-storage
+        migration), and downcasting at the accessor would silently
+        lose precision that no downstream upcast can recover. The
+        consumer is responsible for casting the lifted array to its
+        own zone at the use site (Principle 3b). Concretely this
+        covers the ``_*_jnp`` accessors for AO exponents/coefficients
+        and normalization-factorial-ratio caches in
+        ``atomic_orbital``, ``_mo_coefficients_jnp`` in
+        ``molecular_orbital``, ``_lambda_matrix_jnp`` in
+        ``determinant``, ``_j_matrix_jnp`` in ``jastrow_factor``,
+        and the ``ShellPrimMap.from_aos_data`` constructor in
+        ``atomic_orbital``.
+
+    These modules may use ``jnp.float64`` / ``np.float64`` directly
+    because the dtype is not a function of ``mode``. Audit with::
+
+        grep -nE 'jnp\.float(32|64)|np\.float(32|64)' jqmc/<module>.py
+
+    Each hit inside a selectable-precision module is a candidate violation.
+
+================================================================================
 
 Users choose one of two modes:
 
@@ -19,46 +170,65 @@ directly in this file.
 Precision Zones
 ---------------
 
-==============  ============================  =========  ========  ============
-Zone            Components                    Default    Mixed     float32 risk
-==============  ============================  =========  ========  ============
-``orb_eval``    AO/MO forward evaluation      float64    float32   low
-``jastrow``     Jastrow factor (J1/J2/J3)     float64    float32   low
-``geminal``     Geminal matrix elements        float64    float64   high
-``determinant`` log-det, SVD, AS reg.          float64    float64   high
-``coulomb``     Coulomb + ECP potential        float64    float32   low-medium
-``kinetic``     Kinetic energy + AO/MO derivs  float64    float64   high
-``mcmc``        MCMC sampling                  float64    float64   high
-``gfmc``        GFMC propagation               float64    float64   high
-``optimization``SR matrix, parameter updates   float64    float64   high
-``io``          I/O, structure data            float64    float64   low-medium
-==============  ============================  =========  ========  ============
+==================  =================================  =========  ========  =====  =========
+Zone                Owning module                      Default    Mixed     risk   E_L path
+==================  =================================  =========  ========  =====  =========
+``ao_eval``         atomic_orbital.py (forward)        float64    float32   low    core
+``ao_grad_lap``     atomic_orbital.py (grad/lap)       float64    float32   low    core
+``mo_eval``         molecular_orbital.py (forward)     float64    float64   high*  core
+``mo_grad_lap``     molecular_orbital.py (grad/lap)    float64    float64   high   core
+``jastrow_eval``    jastrow_factor.py (forward)        float64    float32   low    core†
+``jastrow_grad_lap`` jastrow_factor.py (grad/lap)      float64    float32   low    core
+``jastrow_ratio``   jastrow_factor.py (ratio update)   float64    float32   low    indirect‡
+``det_eval``        determinant.py (geminal + log-det) float64    float64   high   core
+``det_grad_lap``    determinant.py (grad/lap of lnDet) float64    float64   high   core
+``det_ratio``       determinant.py (SM ratio update)   float64    float64   high   indirect‡
+``coulomb``         coulomb_potential.py               float64    float32   low-med core
+``wf_eval``         wavefunction.py (Psi, ln Psi)      float64    float64   high   core†
+``wf_kinetic``      wavefunction.py (T_L assembly)     float64    float64   high   core
+``wf_ratio``        wavefunction.py (Psi(R')/Psi(R))   float64    float64   high   no
+``local_energy``    hamiltonians.py (T + V assembly)   float64    float64   high   core
+``swct``            swct.py                            float64    float64   high   no
+==================  =================================  =========  ========  =====  =========
 
-File-to-zone mapping
---------------------
+\\* ``mo_eval`` is a high-risk zone even though the consumed AO values are
+fp32: the small ``mo_coefficients @ aos`` matmul is run in this zone, and
+its output feeds the determinant matrix, where fp32 round-off is
+amplified by log|det|.  See ``bug/fp32`` diagnostics.
 
-- ``atomic_orbital.py``: ``orb_eval`` (forward), ``kinetic`` (grad/laplacian)
-- ``molecular_orbital.py``: ``orb_eval`` (forward), ``kinetic`` (grad/laplacian)
-- ``jastrow_factor.py``: ``jastrow`` (forward), ``kinetic`` (grad/laplacian),
-  ``mcmc`` (ratio/update)
-- ``determinant.py``: ``geminal`` (matrix elements), ``determinant`` (log-det/SVD),
-  ``kinetic`` (grad/laplacian)
-- ``coulomb_potential.py``: ``coulomb``
-- ``wavefunction.py``: ``kinetic`` + zone-boundary casts
-- ``hamiltonians.py``: ``kinetic`` (zone-boundary aggregation of T + V)
-- ``jqmc_mcmc.py``: ``mcmc`` (sampling), ``optimization`` (SR/LM)
-- ``jqmc_gfmc.py``: ``gfmc``
-- ``structure.py``, ``trexio_wrapper.py``, ``jqmc_tool.py``: ``io``
-- ``_jqmc_utility.py``: ``io``
-- ``swct.py``: ``kinetic``
+† ``jastrow_eval`` and ``wf_eval`` are on the E_L core path but their
+forward values (J and ln|Psi|) do not enter the E_L formula directly
+(E_L depends on *derivatives* of ln|Psi|).  Diagnostics show zero E_L
+bias when these zones alone are fp32.
+
+‡ ``det_ratio`` and ``jastrow_ratio`` affect E_L **indirectly** through
+the ECP non-local potential, which evaluates Psi(R')/Psi(R) on a
+quadrature grid via rank-1 ratio updates (see
+``coulomb_potential.compute_ecp_non_local_parts_nearest_neighbors_fast_update``).
+In non-ECP systems these zones have no E_L impact.
 
 Usage::
 
-    from jqmc._precision import get_dtype
+    from jqmc._precision import get_dtype_jnp
 
     def compute_AOs(aos_data, r_carts):
-        dtype = get_dtype("orb_eval")
-        r_carts = jnp.asarray(r_carts, dtype=dtype)
+        # Forwarding-only path: do NOT rebind r_carts here (Principle 3a).
+        return _compute_AOs_kernel(aos_data, r_carts)
+
+    def _compute_AOs_kernel(aos_data, r_carts):
+        # This function performs arithmetic on r_carts, so it casts at the
+        # use site (Principle 3b). The (r - R) reconstruction is done in
+        # the dtype the values were received in (caller-supplied
+        # precision: fp64 in jQMC because mcmc walker state is fp64 and
+        # the atomic centers are loaded from disk as fp64). The result
+        # is then down-cast to this function's own zone (``ao_eval``).
+        # NOTE: never reach for another module's zone (e.g.
+        # ``get_dtype_jnp("local_energy")``) here — that violates
+        # Principle 1 (zone ↔ owning module is 1:1). atomic_orbital.py
+        # may only consult ao_eval / ao_grad_lap.
+        dtype_jnp = get_dtype_jnp("ao_eval")
+        R_carts = aos_data._atomic_center_carts_jnp
+        diff = (r_carts - R_carts).astype(dtype_jnp)
         ...
 """
 
@@ -97,77 +267,130 @@ Usage::
 import logging
 
 import jax.numpy as jnp
+import numpy as np
 
 logger = logging.getLogger(__name__)
 
 # --- mode="full" (all float64, backward compatible) ---
+# Zones are listed grouped by owning module for readability.
 _FULL_PRECISION: dict[str, str] = {
-    "orb_eval": "float64",  # AO/MO forward evaluation
-    "jastrow": "float64",  # Jastrow factor
-    "geminal": "float64",  # Geminal matrix elements
-    "determinant": "float64",  # log-det, SVD, AS regularization
+    # atomic_orbital.py
+    "ao_eval": "float64",  # AO forward evaluation
+    "ao_grad_lap": "float64",  # AO gradient / Laplacian
+    # molecular_orbital.py
+    "mo_eval": "float64",  # MO forward evaluation (mo_coef @ AO)
+    "mo_grad_lap": "float64",  # MO gradient / Laplacian
+    # jastrow_factor.py
+    "jastrow_eval": "float64",  # Jastrow factor (J1/J2/J3)
+    "jastrow_grad_lap": "float64",  # Jastrow gradient / Laplacian
+    "jastrow_ratio": "float64",  # Jastrow ratio (rank-1 update)
+    # determinant.py
+    "det_eval": "float64",  # geminal matrix elements + log-det / SVD / AS reg
+    "det_grad_lap": "float64",  # gradient / Laplacian of ln|Det|
+    "det_ratio": "float64",  # |Det(R')|/|Det(R)| Sherman-Morrison rank-1 update
+    # coulomb_potential.py
     "coulomb": "float64",  # Coulomb + ECP potential
-    "kinetic": "float64",  # Kinetic energy + AO/MO derivatives
-    "mcmc": "float64",  # MCMC sampling (proposal, SM update, accept/reject, accumulation)
-    "gfmc": "float64",  # GFMC propagation
-    "optimization": "float64",  # SR matrix, parameter updates
-    "io": "float64",  # I/O, structure data
+    # wavefunction.py
+    "wf_eval": "float64",  # Psi, ln Psi evaluators
+    "wf_kinetic": "float64",  # T_L = -1/2 (lap_lnPsi + |grad_lnPsi|^2) assembly
+    "wf_ratio": "float64",  # Psi(R')/Psi(R) = exp(J' - J) * det'/det (LRDMC discretized)
+    # hamiltonians.py
+    "local_energy": "float64",  # E_L = T + V assembly
+    # swct.py
+    "swct": "float64",  # SWCT omega / domega
 }
 
 # --- mode="mixed" (recommended mixed precision) ---
-# float32 risk:
-#   orb_eval    - low: smooth Gaussian basis + linear combination.
-#                 (Heavy AO eval stays in fp32; compute_MOs upcasts the small
-#                  matmul to the determinant zone, see molecular_orbital.py.)
-#   jastrow     - low: smooth correlation function, pre-exp value
-#   geminal     - HIGH: this matrix is the input to LU/det; even ε≈1e-7 on
-#                 entries amplifies into log|det| errors of O(1) for ~32x32
-#                 systems with non-trivial condition numbers
-#                 (see bug/fp32 diagnostics).  Kept in fp64.
-#   coulomb     - low-medium: sum of 1/r + ECP spherical quadrature
-#   determinant - high: log(det) cancellation, SVD 1/s, eigenvalue ops
-#   kinetic     - high: second derivative of ln|Psi|, cancellation-sensitive
-#   mcmc        - high: SM inverse error accumulation, acceptance ratio, statistics
-#   gfmc        - high: weighted branching/pruning, population collapse in float32
-#   optimization- high: S^{-1}F linear system, ill-conditioned matrix
-#   io          - low-medium: file I/O + nuclear coordinates
+# Five "low risk" zones drop to float32:
+#
+#   ao_eval          - smooth Gaussian basis kernel; the dominant cost.
+#                      The downstream consumer (mo_eval / det_eval /
+#                      jastrow_eval) is fp64 and explicitly casts the AO
+#                      result up before any sensitive arithmetic.
+#   ao_grad_lap      - AO gradient / Laplacian kernel; same O(N_ao × N_e)
+#                      cost as ao_eval.  Diagnostics show bias < 6e-05 Ha
+#                      at 32 electrons (0.05 kcal/mol margin ×1.3).
+#   jastrow_eval     - smooth correlation function value (pre-exp).
+#   jastrow_grad_lap - nabla J, nabla^2 J; Jastrow is a smooth function
+#                      with low cancellation.  Diagnostics show bias
+#                      < 8e-06 Ha at 32 electrons (0.05 kcal/mol margin ×11).
+#   jastrow_ratio    - J(R')-J(R) log-ratio; smooth and well-behaved.
+#                      Diagnostics show bias < 2e-06 Ha (margin ×44).
+#
+# All other zones stay fp64 because numerical experiments (see
+# bug/fp32 diagnostics) show fp32 in those zones produces
+# unacceptable bias on E_L for ~32-electron systems, OR the
+# kernel is cheap enough that fp32 is not worth the bias:
+#
+#   coulomb       - sum of 1/r + ECP spherical quadrature.  Cheap
+#                   (O(N_e^2) el-el + O(N_e * N_nuc) el-ion, vs
+#                   O(N_e * N_ao) AO eval) but contributes the
+#                   largest individual bias among fp32 candidates
+#                   (~6e-5 Ha at 64e/512 AO).  Cost/benefit favors fp64.
+#
+#   mo_eval       - mo_coef @ AO matmul feeds the determinant matrix;
+#                   fp32 here amplifies into log|det| errors of O(1).
+#   det_eval      - geminal matrix + log(det) + SVD; cancellation in
+#                   log(det), SVD 1/s near-singular, ε≈1e-7 entries
+#                   produce O(1) log|det| error.
+#   *_grad_lap    - second derivatives of ln|Psi|; cancellation-sensitive
+#                   (except ao_grad_lap and jastrow_grad_lap — smooth kernels).
+#   wf_kinetic    - sum (lap_J + lap_lnD) + |grad_J + grad_lnD|^2; cancellation.
+#   local_energy  - T + V assembly; small differences between large terms.
+#   det_ratio     - SM rank-1 ratio used by MCMC accept/reject AND
+#                   ECP non-local Psi(R')/Psi(R) quadrature.
+#   swct          - geometric SWCT correction, derivative-sensitive.
 _MIXED_PRECISION: dict[str, str] = {
-    "orb_eval": "float32",  # low risk (heavy kernel only)
-    "jastrow": "float32",  # low risk
-    "geminal": "float64",  # high risk: feeds LU/det
-    "determinant": "float64",  # high risk
-    "coulomb": "float32",  # low-medium risk
-    "kinetic": "float64",  # high risk
-    "mcmc": "float64",  # high risk
-    "gfmc": "float64",  # high risk
-    "optimization": "float64",  # high risk
-    "io": "float64",  # low-medium risk
+    # atomic_orbital.py
+    "ao_eval": "float32",  # low risk (heavy kernel)
+    "ao_grad_lap": "float32",  # low risk (bias < 6e-05 Ha at 32e; heavy kernel)
+    # molecular_orbital.py
+    "mo_eval": "float64",  # high risk (feeds det_eval)
+    "mo_grad_lap": "float64",  # high risk
+    # jastrow_factor.py
+    "jastrow_eval": "float32",  # low risk
+    "jastrow_grad_lap": "float32",  # low risk (smooth J; bias < 8e-06 Ha at 32e)
+    "jastrow_ratio": "float32",  # low risk (smooth J ratio; bias < 2e-06 Ha at 32e)
+    # determinant.py
+    "det_eval": "float64",  # high risk (LU/det / SVD)
+    "det_grad_lap": "float64",  # high risk
+    "det_ratio": "float64",  # high risk (SM update error + ECP non-local ratio)
+    # coulomb_potential.py
+    "coulomb": "float64",  # cheap kernel + largest single fp32 bias (~6e-5 Ha)
+    # wavefunction.py
+    "wf_eval": "float64",  # high risk
+    "wf_kinetic": "float64",  # high risk
+    "wf_ratio": "float64",  # high risk (exp(J'-J)*det'/det in LRDMC)
+    # hamiltonians.py
+    "local_energy": "float64",  # high risk
+    # swct.py
+    "swct": "float64",  # high risk
 }
 
 ALL_ZONES = frozenset(_FULL_PRECISION.keys())
 
-# Runtime zone -> dtype mapping
-_zone_dtypes: dict[str, type] = {}
+# Runtime zone -> dtype string mapping ("float32" or "float64").
+# Strings are stored (not numpy/jax dtype types) so the str -> jnp.* / np.*
+# conversion lives inside the per-flavor accessors below.  This keeps the
+# concrete dtype flavor (jnp vs np) cleanly separated at the API boundary.
+_zone_dtypes: dict[str, str] = {}
 
 
-def _str_to_dtype(s: str) -> type:
-    """Convert a string dtype name to the corresponding JAX/NumPy dtype type.
+def _validate_dtype_str(s: str) -> str:
+    """Validate that *s* is one of the accepted dtype strings.
 
     Args:
         s: Either ``"float32"`` or ``"float64"``.
 
     Returns:
-        ``jnp.float32`` or ``jnp.float64``.
+        The same string, unchanged.
 
     Raises:
         ValueError: If *s* is not one of the two accepted strings.
     """
-    if s == "float32":
-        return jnp.float32
-    elif s == "float64":
-        return jnp.float64
-    else:
+    if s not in ("float32", "float64"):
         raise ValueError(f"Invalid dtype '{s}'. Must be 'float32' or 'float64'.")
+    return s
 
 
 def configure(mode: str = "full") -> None:
@@ -190,9 +413,7 @@ def configure(mode: str = "full") -> None:
         raise ValueError(f"Unknown precision mode '{mode}'. Must be 'full' or 'mixed'.")
 
     for zone, dtype_str in base.items():
-        _zone_dtypes[zone] = _str_to_dtype(dtype_str)
-
-    logger.info(summary())
+        _zone_dtypes[zone] = _validate_dtype_str(dtype_str)
 
 
 def _set_zone(zone: str, dtype_str: str) -> None:
@@ -209,32 +430,52 @@ def _set_zone(zone: str, dtype_str: str) -> None:
     """
     if zone not in ALL_ZONES:
         raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
-    _zone_dtypes[zone] = _str_to_dtype(dtype_str)
+    _zone_dtypes[zone] = _validate_dtype_str(dtype_str)
 
 
-def get_dtype(zone: str) -> type:
-    """Return the dtype for a Precision Zone.
+def _get_zone_str(zone: str) -> str:
+    """Return the stored dtype string for *zone* (``"float32"`` or ``"float64"``).
 
-    When :func:`configure` has not been called, ``jnp.float64`` is returned
+    When :func:`configure` has not been called, ``"float64"`` is returned
     for any zone name (backward compatible).  After :func:`configure` has
     been called, an unknown *zone* raises :class:`ValueError`.
+    """
+    if _zone_dtypes:
+        if zone not in ALL_ZONES:
+            raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
+    return _zone_dtypes.get(zone, "float64")
+
+
+def get_dtype_jnp(zone: str) -> type:
+    """Return the JAX dtype for a Precision Zone.
 
     Args:
-        zone: Precision Zone name (e.g. ``"orb_eval"``, ``"kinetic"``).
+        zone: Precision Zone name (e.g. ``"ao_eval"``, ``"wf_kinetic"``).
 
     Returns:
         ``jnp.float32`` or ``jnp.float64``.
     """
-    if _zone_dtypes:
-        # configure() has been called: validate zone name
-        if zone not in ALL_ZONES:
-            raise ValueError(f"Unknown precision zone '{zone}'. Available zones: {sorted(ALL_ZONES)}")
-    return _zone_dtypes.get(zone, jnp.float64)
+    return jnp.float32 if _get_zone_str(zone) == "float32" else jnp.float64
+
+
+def get_dtype_np(zone: str) -> type:
+    """Return the numpy dtype for a Precision Zone.
+
+    Convenience helper for numpy-only code paths (e.g. ``_debug`` reference
+    implementations) where importing or branching on ``jnp`` is awkward.
+
+    Args:
+        zone: Precision Zone name (e.g. ``"ao_eval"``, ``"wf_kinetic"``).
+
+    Returns:
+        ``np.float32`` or ``np.float64``.
+    """
+    return np.float32 if _get_zone_str(zone) == "float32" else np.float64
 
 
 def is_mixed_precision_enabled() -> bool:
     """Return ``True`` if at least one zone is set to float32."""
-    return any(d == jnp.float32 for d in _zone_dtypes.values())
+    return any(s == "float32" for s in _zone_dtypes.values())
 
 
 def get_tolerance(zone: str, level: str = "strict") -> tuple[float, float]:
@@ -249,8 +490,7 @@ def get_tolerance(zone: str, level: str = "strict") -> tuple[float, float]:
     """
     from jqmc._setting import _TOLERANCE
 
-    dtype_key = "float32" if get_dtype(zone) == jnp.float32 else "float64"
-    return _TOLERANCE[level][dtype_key]
+    return _TOLERANCE[level][_get_zone_str(zone)]
 
 
 def get_tolerance_min(zones, level: str = "strict") -> tuple[float, float]:
@@ -271,11 +511,20 @@ def get_tolerance_min(zones, level: str = "strict") -> tuple[float, float]:
     return max(atols), max(rtols)
 
 
-def summary() -> str:
-    """Return a human-readable summary of the current precision configuration."""
-    lines = ["Precision configuration:"]
+def mode_label() -> str:
+    """Return a short label for the active precision mode.
+
+    Returns:
+        ``"Full Precision (FP64)"`` or ``"Mixed Precision (FP32 + FP64)"``.
+    """
+    if is_mixed_precision_enabled():
+        return "Mixed Precision (FP32 + FP64)"
+    return "Full Precision (FP64)"
+
+
+def zone_detail() -> str:
+    """Return a per-zone detail string of the current precision configuration."""
+    lines = []
     for zone in sorted(ALL_ZONES):
-        dtype = get_dtype(zone)
-        tag = "float32" if dtype == jnp.float32 else "float64"
-        lines.append(f"  {zone}: {tag}")
+        lines.append(f"  {zone}: {_get_zone_str(zone)}")
     return "\n".join(lines)

--- a/jqmc/_setting.py
+++ b/jqmc/_setting.py
@@ -102,9 +102,9 @@ _TOLERANCE: dict[str, dict[str, tuple[float, float]]] = {
 #   stabilizing_ao    — small epsilon for AO Cartesian derivative stabilization.
 #   rcond_svd         — threshold for SVD pseudoinverse of the geminal matrix.
 _EPS_DTYPE_AWARE: dict[str, dict[str, float]] = {
-    "machine_precision": {"float64": 1e-300, "float32": 1e-38},
-    "stabilizing_ao": {"float64": 1e-16, "float32": 1e-7},
-    "rcond_svd": {"float64": 1e-20, "float32": 1e-6},
+    "machine_precision": {"float64": 1e-38, "float32": 1e-38},
+    "stabilizing_ao": {"float64": 1e-16, "float32": 1e-12},
+    "rcond_svd": {"float64": 1e-20, "float32": 1e-16},
 }
 
 

--- a/jqmc/_setting.py
+++ b/jqmc/_setting.py
@@ -1,4 +1,8 @@
-"""setting."""
+"""Setting module.
+
+Contains physical constants, numerical stability parameters, and
+test tolerance definitions used across jQMC.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -31,6 +35,8 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
+
+import numpy as np
 
 # Unit conversion
 Bohr_to_Angstrom = 0.529177210903
@@ -67,6 +73,58 @@ atol_debug_vs_production = 1.0e-8
 rtol_debug_vs_production = 1.0e-6
 atol_consistency = 1.0e-8
 rtol_consistency = 1.0e-6
+
+# --- Test tolerance dict (dtype-aware) ---
+#
+# Accessed via ``_precision.get_tolerance(zone, level)`` which resolves the
+# zone's current dtype and returns ``(atol, rtol)``.
+#
+# Levels:
+#   strict — two exact implementations of the same quantity (debug vs
+#            production, analytic vs autodiff).  Difference is pure
+#            floating-point round-off.
+#   loose  — comparison involving numerical differentiation or quadrature.
+#            Finite-difference truncation error dominates, so tolerances
+#            are much wider.
+_TOLERANCE: dict[str, dict[str, tuple[float, float]]] = {
+    "strict": {"float64": (1e-8, 1e-6), "float32": (1e-5, 1e-3)},
+    "loose": {"float64": (1e-1, 1e-4), "float32": (1e-1, 1e-3)},
+}
+
+# --- Dtype-aware EPS constants ---
+#
+# Some EPS values are tuned for float64 and break under float32 (underflow,
+# loss of stabilization).  Use ``get_eps(name, dtype)`` to obtain the
+# appropriate value for the current precision zone.
+#
+# Constants:
+#   machine_precision — floor for safe ratio in diagnostics.
+#   stabilizing_ao    — small epsilon for AO Cartesian derivative stabilization.
+#   rcond_svd         — threshold for SVD pseudoinverse of the geminal matrix.
+_EPS_DTYPE_AWARE: dict[str, dict[str, float]] = {
+    "machine_precision": {"float64": 1e-300, "float32": 1e-38},
+    "stabilizing_ao": {"float64": 1e-16, "float32": 1e-7},
+    "rcond_svd": {"float64": 1e-20, "float32": 1e-6},
+}
+
+
+def get_eps(name: str, dtype) -> float:
+    """Return a dtype-aware numerical stability constant.
+
+    Args:
+        name: One of ``"machine_precision"``, ``"stabilizing_ao"``,
+            ``"rcond_svd"``.
+        dtype: A NumPy/JAX dtype (e.g. ``jnp.float32``, ``np.float64``).
+
+    Returns:
+        The appropriate epsilon value for the given dtype.
+
+    Raises:
+        KeyError: If *name* is not a known EPS constant.
+    """
+    dtype_key = "float32" if np.dtype(dtype) == np.float32 else "float64"
+    return _EPS_DTYPE_AWARE[name][dtype_key]
+
 
 # Numerical stability settings for AO
 EPS_stabilizing_jax_AO_cart_deriv = 1.0e-16

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -2329,11 +2329,21 @@ def _compute_S_l_m(
 def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Vectorized solid harmonics values, gradients, and Laplacians.
 
+    Pinned to the ``ao_lap`` zone (fp64 in mixed mode). The gradient
+    consumer (``_compute_AOs_grad_analytic_sphe``) lives in the
+    ``ao_grad`` zone (fp32 in mixed mode); it is responsible for
+    down-casting the grad output of this helper to its own zone at the
+    use site (Principle 3b). Running the helper at the higher of the
+    two precisions is intentional — the solid-harmonics polynomial
+    expansion is cheap (49 × num_R × num_e) compared to the contracted
+    AO formulas, so the perf cost of fp64 here is small while keeping
+    the laplacian path numerically safe.
+
     Returns:
         tuple: (values, grads, laps) where values has shape (49, num_R, num_r), grads has shape (49, num_R, num_r, 3),
         and laps has shape (49, num_R, num_r).
     """
-    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    dtype_jnp = get_dtype_jnp("ao_lap")
     S_L_M_COEFFS = (
         jnp.array([1.0], dtype=dtype_jnp),
         jnp.array([1.0], dtype=dtype_jnp),
@@ -2580,9 +2590,9 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 @jit
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for Cartesian AOs (contracted)."""
-    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    dtype_jnp = get_dtype_jnp("ao_lap")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
-    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # via JAX promotion, then downcast to the ao_lap zone (Principle 3b).
     # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
     # accessor on the basis-data dataclass.
     R_carts = aos_data._atomic_center_carts_prim_jnp
@@ -2629,9 +2639,9 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
 @jit
 def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for spherical AOs (contracted)."""
-    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    dtype_jnp = get_dtype_jnp("ao_lap")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
-    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # via JAX promotion, then downcast to the ao_lap zone (Principle 3b).
     # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
     # accessor on the basis-data dataclass.
     R_carts = aos_data._atomic_center_carts_prim_jnp
@@ -2892,9 +2902,9 @@ def _compute_AOs_laplacian_debug(
 @jit
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for Cartesian AOs (contracted)."""
-    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    dtype_jnp = get_dtype_jnp("ao_grad")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
-    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # via JAX promotion, then downcast to the ao_grad zone (Principle 3b).
     # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
     # accessor on the basis-data dataclass.
     R_carts = aos_data._atomic_center_carts_prim_jnp
@@ -2944,9 +2954,9 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
 @jit
 def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for spherical AOs (contracted)."""
-    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    dtype_jnp = get_dtype_jnp("ao_grad")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
-    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # via JAX promotion, then downcast to the ao_grad zone (Principle 3b).
     # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
     # accessor on the basis-data dataclass.
     R_carts = aos_data._atomic_center_carts_prim_jnp
@@ -2973,7 +2983,12 @@ def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarra
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
     max_ml, S_l_m_dup_all_l_m = _compute_S_l_m(r_R_diffs_uq)
+    # ``_compute_S_l_m_and_grad_lap`` is pinned to ``ao_lap`` (fp64); its
+    # grad output is therefore returned in fp64. Cast it down to the
+    # ``ao_grad`` zone at the use site (Principle 3b) so the contracted
+    # grad arithmetic below stays in this function's own zone.
     _, S_l_m_grad_all_l_m, _ = _compute_S_l_m_and_grad_lap(r_R_diffs_uq)
+    S_l_m_grad_all_l_m = S_l_m_grad_all_l_m.astype(dtype_jnp)
 
     S_l_m_dup_all_l_m_reshaped = S_l_m_dup_all_l_m.reshape(
         (S_l_m_dup_all_l_m.shape[0] * S_l_m_dup_all_l_m.shape[1], S_l_m_dup_all_l_m.shape[2]), order="F"

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -2,6 +2,11 @@
 
 Module containing classes and methods related to Atomic Orbitals
 
+Precision Zones:
+    - ``orb_eval``: forward AO evaluation (compute_AOs and internal helpers).
+    - ``kinetic``: AO gradient and Laplacian (compute_AOs_grad, compute_AOs_laplacian).
+
+See :mod:`jqmc._precision` for details.
 """
 
 from __future__ import annotations
@@ -52,6 +57,7 @@ from jax import typing as jnpt
 from numpy import linalg as LA
 
 from ._jqmc_utility import _spherical_to_cart_matrix
+from ._precision import get_dtype
 from ._setting import EPS_stabilizing_jax_AO_cart_deriv, atol_consistency, rtol_consistency
 from .structure import Structure_data
 
@@ -701,6 +707,7 @@ class AOs_cart_data:
     @property
     def _normalization_factorial_ratio_prim_jnp(self) -> jax.Array:
         """Return factorial ratio used in AO normalization (primitive-wise)."""
+        dtype = get_dtype("io")
         nx = self._polynominal_order_x_prim_np
         ny = self._polynominal_order_y_prim_np
         nz = self._polynominal_order_z_prim_np
@@ -714,18 +721,21 @@ class AOs_cart_data:
             * scipy.special.factorial(2 * ny, exact=True)
             * scipy.special.factorial(2 * nz, exact=True)
         )
-        ratio = np.asarray(num / den, dtype=np.float64)
-        return jnp.array(ratio, dtype=jnp.float64)
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        ratio = np.asarray(num / den, dtype=dtype_np)
+        return jnp.array(ratio, dtype=dtype)
 
     @property
     def _exponents_jnp(self) -> jax.Array:
         """Return exponents."""
-        return jnp.asarray(self.exponents, dtype=jnp.float64)
+        dtype = get_dtype("io")
+        return jnp.asarray(self.exponents, dtype=dtype)
 
     @property
     def _coefficients_jnp(self) -> jax.Array:
         """Return coefficients."""
-        return jnp.asarray(self.coefficients, dtype=jnp.float64)
+        dtype = get_dtype("io")
+        return jnp.asarray(self.coefficients, dtype=dtype)
 
     @property
     def _num_orb(self) -> int:
@@ -1268,12 +1278,14 @@ class AOs_sphe_data:
     @property
     def _exponents_jnp(self) -> jax.Array:
         """Return exponents."""
-        return jnp.asarray(self.exponents, dtype=jnp.float64)
+        dtype = get_dtype("io")
+        return jnp.asarray(self.exponents, dtype=dtype)
 
     @property
     def _coefficients_jnp(self) -> jax.Array:
         """Return coefficients."""
-        return jnp.asarray(self.coefficients, dtype=jnp.float64)
+        dtype = get_dtype("io")
+        return jnp.asarray(self.coefficients, dtype=dtype)
 
     @property
     def _num_orb(self) -> int:
@@ -1340,12 +1352,14 @@ class ShellPrimMap:
     @classmethod
     def from_aos_data(cls, aos_data: "AOs_sphe_data | AOs_cart_data") -> "ShellPrimMap":
         """Build a shell map from an AO dataclass instance."""
+        dtype = get_dtype("io")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
         ao_prims: dict[int, list[int]] = {}
         for prim_idx, ao_idx in enumerate(aos_data.orbital_indices):
             ao_prims.setdefault(ao_idx, []).append(prim_idx)
 
-        exps_np = np.asarray(aos_data.exponents, dtype=np.float64)
-        coefs_np = np.asarray(aos_data.coefficients, dtype=np.float64)
+        exps_np = np.asarray(aos_data.exponents, dtype=dtype_np)
+        coefs_np = np.asarray(aos_data.coefficients, dtype=dtype_np)
 
         shells: list[tuple[int, list[int]]] = []
         _shell_keys: list[tuple] = []
@@ -1406,8 +1420,10 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
         tuple: (AOs_cart_data, transform_matrix) where transform_matrix maps
         spherical -> Cartesian coefficients with shape (num_ao_sph, num_ao_cart).
     """
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     if isinstance(aos_data, AOs_cart_data):
-        transform_matrix = np.eye(aos_data.num_ao, dtype=np.float64)
+        transform_matrix = np.eye(aos_data.num_ao, dtype=dtype_np)
         return aos_data, transform_matrix
     if not isinstance(aos_data, AOs_sphe_data):
         raise ValueError("Cartesian conversion is only available from spherical AOs.")
@@ -1426,8 +1442,8 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
 
     for ao_idx in range(aos_sphe.num_ao):
         prim_indices = [i for i, v in enumerate(aos_sphe.orbital_indices) if v == ao_idx]
-        exps = np.asarray([aos_sphe.exponents[i] for i in prim_indices], dtype=np.float64)
-        coefs = np.asarray([aos_sphe.coefficients[i] for i in prim_indices], dtype=np.float64)
+        exps = np.asarray([aos_sphe.exponents[i] for i in prim_indices], dtype=dtype_np)
+        coefs = np.asarray([aos_sphe.coefficients[i] for i in prim_indices], dtype=dtype_np)
         nucleus = aos_sphe.nucleus_index[ao_idx]
         l = aos_sphe.angular_momentums[ao_idx]
 
@@ -1440,7 +1456,7 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
 
     total_cart = sum((shell["l"] + 1) * (shell["l"] + 2) // 2 for shell in shells)
     total_sph = aos_sphe.num_ao
-    transform_matrix = np.zeros((total_sph, total_cart), dtype=np.float64)
+    transform_matrix = np.zeros((total_sph, total_cart), dtype=dtype_np)
 
     new_nucleus_index: list[int] = []
     new_angular_momentums: list[int] = []
@@ -1485,8 +1501,8 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
         num_ao=total_cart,
         num_ao_prim=len(new_exponents),
         orbital_indices=new_orbital_indices,
-        exponents=jnp.array(new_exponents, dtype=jnp.float64),
-        coefficients=jnp.array(new_coefficients, dtype=jnp.float64),
+        exponents=jnp.array(new_exponents, dtype=dtype),
+        coefficients=jnp.array(new_coefficients, dtype=dtype),
         angular_momentums=new_angular_momentums,
         polynominal_order_x=new_polynominal_order_x,
         polynominal_order_y=new_polynominal_order_y,
@@ -1503,8 +1519,10 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
         tuple: (AOs_sphe_data, transform_pinv) where transform_pinv maps
         Cartesian -> spherical coefficients with shape (num_ao_cart, num_ao_sph).
     """
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     if isinstance(aos_data, AOs_sphe_data):
-        transform_pinv = np.eye(aos_data.num_ao, dtype=np.float64)
+        transform_pinv = np.eye(aos_data.num_ao, dtype=dtype_np)
         return aos_data, transform_pinv
     if not isinstance(aos_data, AOs_cart_data):
         raise ValueError("Spherical conversion is only available from Cartesian AOs.")
@@ -1523,8 +1541,8 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
 
     for ao_idx in range(aos_cart.num_ao):
         prim_indices = [i for i, v in enumerate(aos_cart.orbital_indices) if v == ao_idx]
-        exps = np.asarray([aos_cart.exponents[i] for i in prim_indices], dtype=np.float64)
-        coefs = np.asarray([aos_cart.coefficients[i] for i in prim_indices], dtype=np.float64)
+        exps = np.asarray([aos_cart.exponents[i] for i in prim_indices], dtype=dtype_np)
+        coefs = np.asarray([aos_cart.coefficients[i] for i in prim_indices], dtype=dtype_np)
         nucleus = aos_cart.nucleus_index[ao_idx]
         l = aos_cart.angular_momentums[ao_idx]
         order = (
@@ -1550,7 +1568,7 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
 
     total_sph = sum(2 * shell["l"] + 1 for shell in shells)
     total_cart = aos_cart.num_ao
-    transform_matrix = np.zeros((total_sph, total_cart), dtype=np.float64)
+    transform_matrix = np.zeros((total_sph, total_cart), dtype=dtype_np)
 
     new_nucleus_index: list[int] = []
     new_angular_momentums: list[int] = []
@@ -1598,8 +1616,8 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
         num_ao=total_sph,
         num_ao_prim=len(new_exponents),
         orbital_indices=new_orbital_indices,
-        exponents=jnp.array(new_exponents, dtype=jnp.float64),
-        coefficients=jnp.array(new_coefficients, dtype=jnp.float64),
+        exponents=jnp.array(new_exponents, dtype=dtype),
+        coefficients=jnp.array(new_coefficients, dtype=dtype),
         angular_momentums=new_angular_momentums,
         magnetic_quantum_numbers=new_magnetic_quantum_numbers,
     )
@@ -1650,18 +1668,20 @@ def _compute_overlap_1d_cart(
 
 def _compute_overlap_matrix_cart_analytic(aos_cart_data: AOs_cart_data) -> npt.NDArray[np.float64]:
     """Compute AO overlap matrix analytically for Cartesian contracted GTOs."""
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     num_ao = aos_cart_data.num_ao
-    overlap_matrix = np.zeros((num_ao, num_ao), dtype=np.float64)
+    overlap_matrix = np.zeros((num_ao, num_ao), dtype=dtype_np)
 
-    centers = np.asarray(aos_cart_data._atomic_center_carts_np, dtype=np.float64)
+    centers = np.asarray(aos_cart_data._atomic_center_carts_np, dtype=dtype_np)
     orbital_indices = list(aos_cart_data.orbital_indices)
 
     primitive_indices_by_ao: list[list[int]] = [[] for _ in range(num_ao)]
     for primitive_index, ao_index in enumerate(orbital_indices):
         primitive_indices_by_ao[ao_index].append(primitive_index)
 
-    exponents = np.asarray(aos_cart_data.exponents, dtype=np.float64)
-    coefficients = np.asarray(aos_cart_data.coefficients, dtype=np.float64)
+    exponents = np.asarray(aos_cart_data.exponents, dtype=dtype_np)
+    coefficients = np.asarray(aos_cart_data.coefficients, dtype=dtype_np)
 
     nx = np.asarray(aos_cart_data.polynominal_order_x, dtype=np.int32)
     ny = np.asarray(aos_cart_data.polynominal_order_y, dtype=np.int32)
@@ -1670,7 +1690,7 @@ def _compute_overlap_matrix_cart_analytic(aos_cart_data: AOs_cart_data) -> npt.N
     normalization = np.sqrt(
         (2.0 * exponents / np.pi) ** (3.0 / 2.0)
         * (8.0 * exponents) ** np.asarray(aos_cart_data._angular_momentums_prim_np, dtype=np.int32)
-        * np.asarray(aos_cart_data._normalization_factorial_ratio_prim_jnp, dtype=np.float64)
+        * np.asarray(aos_cart_data._normalization_factorial_ratio_prim_jnp, dtype=dtype_np)
     )
 
     for mu in range(num_ao):
@@ -1720,11 +1740,13 @@ def _estimate_overlap_integration_box(
     tail_tolerance: float = 1.0e-11,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Estimate finite integration bounds for numerical overlap integration."""
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     if tail_tolerance <= 0.0 or tail_tolerance >= 1.0:
         raise ValueError(f"tail_tolerance must satisfy 0 < tail_tolerance < 1. Got {tail_tolerance}.")
 
-    centers = np.asarray(aos_data.structure_data.positions, dtype=np.float64)
-    exponents = np.asarray(aos_data.exponents, dtype=np.float64)
+    centers = np.asarray(aos_data.structure_data.positions, dtype=dtype_np)
+    exponents = np.asarray(aos_data.exponents, dtype=dtype_np)
     positive_exponents = exponents[exponents > 0.0]
     if positive_exponents.size == 0:
         raise ValueError("All AO exponents are non-positive. Cannot estimate integration bounds.")
@@ -1744,6 +1766,8 @@ def _build_overlap_integration_grid(
     tail_tolerance: float,
 ) -> tuple[np.ndarray, float]:
     """Build a uniform midpoint grid and volume element for numerical overlap integration."""
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     if num_grid_points < 3:
         raise ValueError(f"num_grid_points must be >= 3. Got {num_grid_points}.")
 
@@ -1751,9 +1775,9 @@ def _build_overlap_integration_grid(
     lengths = upper - lower
     dx, dy, dz = lengths / float(num_grid_points)
 
-    x = lower[0] + (np.arange(num_grid_points, dtype=np.float64) + 0.5) * dx
-    y = lower[1] + (np.arange(num_grid_points, dtype=np.float64) + 0.5) * dy
-    z = lower[2] + (np.arange(num_grid_points, dtype=np.float64) + 0.5) * dz
+    x = lower[0] + (np.arange(num_grid_points, dtype=dtype_np) + 0.5) * dx
+    y = lower[1] + (np.arange(num_grid_points, dtype=dtype_np) + 0.5) * dy
+    z = lower[2] + (np.arange(num_grid_points, dtype=dtype_np) + 0.5) * dz
 
     xx, yy, zz = np.meshgrid(x, y, z, indexing="ij")
     r_carts = np.stack([xx, yy, zz], axis=-1).reshape((-1, 3))
@@ -1768,13 +1792,15 @@ def _compute_overlap_matrix_debug(
     tail_tolerance: float = 1.0e-11,
 ) -> npt.NDArray[np.float64]:
     """Numerically compute AO overlap matrix by 3D midpoint integration (debug)."""
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     r_carts, volume_element = _build_overlap_integration_grid(
         aos_data=aos_data,
         num_grid_points=num_grid_points,
         tail_tolerance=tail_tolerance,
     )
 
-    ao_values = np.asarray(_compute_AOs_debug(aos_data=aos_data, r_carts=r_carts), dtype=np.float64)
+    ao_values = np.asarray(_compute_AOs_debug(aos_data=aos_data, r_carts=r_carts), dtype=dtype_np)
     overlap_matrix = np.dot(ao_values, ao_values.T) * volume_element
     overlap_matrix = 0.5 * (overlap_matrix + overlap_matrix.T)
     return overlap_matrix
@@ -1786,6 +1812,7 @@ def compute_overlap_matrix(aos_data: AOs_sphe_data | AOs_cart_data) -> jax.Array
     For spherical AOs, the overlap is evaluated by conversion to Cartesian AOs and
     transformed back with the spherical-to-Cartesian matrix.
     """
+    dtype = get_dtype("orb_eval")
     aos_cart_data, transform_matrix = _aos_sphe_to_cart(aos_data)
     cart_overlap_matrix = _compute_overlap_matrix_cart_analytic(aos_cart_data)
 
@@ -1797,7 +1824,7 @@ def compute_overlap_matrix(aos_data: AOs_sphe_data | AOs_cart_data) -> jax.Array
         raise NotImplementedError
 
     overlap_matrix = 0.5 * (overlap_matrix + overlap_matrix.T)
-    return jnp.asarray(overlap_matrix, dtype=jnp.float64)
+    return jnp.asarray(overlap_matrix, dtype=dtype)
 
 
 def compute_AOs(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array) -> jax.Array:
@@ -1818,7 +1845,8 @@ def compute_AOs(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array) -> 
     Raises:
         NotImplementedError: If ``aos_data`` is neither Cartesian nor spherical.
     """
-    r_carts = jnp.asarray(r_carts, dtype=jnp.float64)
+    dtype = get_dtype("orb_eval")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
 
     if isinstance(aos_data, AOs_sphe_data):
         AOs = _compute_AOs_sphe(aos_data, r_carts)
@@ -1848,6 +1876,8 @@ def _compute_AOs_sphe_debug(aos_data: AOs_sphe_data, r_carts: npt.NDArray[np.flo
     The method is for computing the value of the given atomic orbital at r_carts
     for debugging purpose. See compute_AOs_api.
     """
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_values = []
 
     for ao_index in range(aos_data.num_ao):
@@ -1901,6 +1931,8 @@ def _compute_AOs_cart_debug(aos_data: AOs_cart_data, r_carts: npt.NDArray[np.flo
     The method is for computing the value of the given atomic orbital at r_carts
     for debugging purpose. See compute_AOs_api.
     """
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_values = []
 
     for ao_index in range(aos_data.num_ao):
@@ -2285,39 +2317,40 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
         tuple: (values, grads, laps) where values has shape (49, num_R, num_r), grads has shape (49, num_R, num_r, 3),
         and laps has shape (49, num_R, num_r).
     """
+    dtype = get_dtype("kinetic")
     S_L_M_COEFFS = (
-        jnp.array([1.0], dtype=jnp.float64),
-        jnp.array([1.0], dtype=jnp.float64),
-        jnp.array([1.0], dtype=jnp.float64),
-        jnp.array([1.0], dtype=jnp.float64),
-        jnp.array([1.7320508075688774], dtype=jnp.float64),
-        jnp.array([1.7320508075688774], dtype=jnp.float64),
-        jnp.array([1.0, -0.5, -0.5], dtype=jnp.float64),
-        jnp.array([1.7320508075688774], dtype=jnp.float64),
-        jnp.array([-0.8660254037844387, 0.8660254037844387], dtype=jnp.float64),
-        jnp.array([-0.7905694150420949, 2.3717082451262845], dtype=jnp.float64),
-        jnp.array([3.8729833462074166], dtype=jnp.float64),
-        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=jnp.float64),
-        jnp.array([1.0, -1.5, -1.5], dtype=jnp.float64),
-        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=jnp.float64),
-        jnp.array([-1.9364916731037083, 1.9364916731037083], dtype=jnp.float64),
-        jnp.array([-2.3717082451262845, 0.7905694150420949], dtype=jnp.float64),
-        jnp.array([-2.958039891549808, 2.958039891549808], dtype=jnp.float64),
-        jnp.array([-2.091650066335189, 6.274950199005566], dtype=jnp.float64),
-        jnp.array([6.708203932499371, -1.1180339887498951, -1.1180339887498951], dtype=jnp.float64),
-        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=jnp.float64),
-        jnp.array([1.0, -3.0, 0.375, -3.0, 0.75, 0.375], dtype=jnp.float64),
-        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=jnp.float64),
-        jnp.array([-3.3541019662496856, 0.5590169943749476, 3.3541019662496856, -0.5590169943749476], dtype=jnp.float64),
-        jnp.array([-6.274950199005566, 2.091650066335189], dtype=jnp.float64),
-        jnp.array([0.739509972887452, -4.437059837324712, 0.739509972887452], dtype=jnp.float64),
-        jnp.array([0.7015607600201141, -7.015607600201141, 3.5078038001005707], dtype=jnp.float64),
-        jnp.array([-8.874119674649426, 8.874119674649426], dtype=jnp.float64),
+        jnp.array([1.0], dtype=dtype),
+        jnp.array([1.0], dtype=dtype),
+        jnp.array([1.0], dtype=dtype),
+        jnp.array([1.0], dtype=dtype),
+        jnp.array([1.7320508075688774], dtype=dtype),
+        jnp.array([1.7320508075688774], dtype=dtype),
+        jnp.array([1.0, -0.5, -0.5], dtype=dtype),
+        jnp.array([1.7320508075688774], dtype=dtype),
+        jnp.array([-0.8660254037844387, 0.8660254037844387], dtype=dtype),
+        jnp.array([-0.7905694150420949, 2.3717082451262845], dtype=dtype),
+        jnp.array([3.8729833462074166], dtype=dtype),
+        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype),
+        jnp.array([1.0, -1.5, -1.5], dtype=dtype),
+        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype),
+        jnp.array([-1.9364916731037083, 1.9364916731037083], dtype=dtype),
+        jnp.array([-2.3717082451262845, 0.7905694150420949], dtype=dtype),
+        jnp.array([-2.958039891549808, 2.958039891549808], dtype=dtype),
+        jnp.array([-2.091650066335189, 6.274950199005566], dtype=dtype),
+        jnp.array([6.708203932499371, -1.1180339887498951, -1.1180339887498951], dtype=dtype),
+        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype),
+        jnp.array([1.0, -3.0, 0.375, -3.0, 0.75, 0.375], dtype=dtype),
+        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype),
+        jnp.array([-3.3541019662496856, 0.5590169943749476, 3.3541019662496856, -0.5590169943749476], dtype=dtype),
+        jnp.array([-6.274950199005566, 2.091650066335189], dtype=dtype),
+        jnp.array([0.739509972887452, -4.437059837324712, 0.739509972887452], dtype=dtype),
+        jnp.array([0.7015607600201141, -7.015607600201141, 3.5078038001005707], dtype=dtype),
+        jnp.array([-8.874119674649426, 8.874119674649426], dtype=dtype),
         jnp.array(
             [-4.183300132670378, 0.5229125165837972, 12.549900398011133, -1.0458250331675945, -1.5687375497513916],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([10.2469507659596, -5.1234753829798, -5.1234753829798], dtype=jnp.float64),
+        jnp.array([10.2469507659596, -5.1234753829798, -5.1234753829798], dtype=dtype),
         jnp.array(
             [
                 3.872983346207417,
@@ -2327,9 +2360,9 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.9682458365518543,
                 0.4841229182759271,
             ],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([1.0, -5.0, 1.875, -5.0, 3.75, 1.875], dtype=jnp.float64),
+        jnp.array([1.0, -5.0, 1.875, -5.0, 3.75, 1.875], dtype=dtype),
         jnp.array(
             [
                 3.872983346207417,
@@ -2339,21 +2372,21 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.9682458365518543,
                 0.4841229182759271,
             ],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([-5.1234753829798, 2.5617376914899, 5.1234753829798, -2.5617376914899], dtype=jnp.float64),
+        jnp.array([-5.1234753829798, 2.5617376914899, 5.1234753829798, -2.5617376914899], dtype=dtype),
         jnp.array(
             [-12.549900398011133, 1.5687375497513916, 4.183300132670378, 1.0458250331675945, -0.5229125165837972],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([2.2185299186623566, -13.311179511974139, 2.2185299186623566], dtype=jnp.float64),
-        jnp.array([3.5078038001005707, -7.015607600201141, 0.7015607600201141], dtype=jnp.float64),
-        jnp.array([4.030159736288377, -13.433865787627923, 4.030159736288377], dtype=jnp.float64),
-        jnp.array([2.3268138086232857, -23.268138086232856, 11.634069043116428], dtype=jnp.float64),
-        jnp.array([-19.843134832984433, 1.9843134832984433, 19.843134832984433, -1.9843134832984433], dtype=jnp.float64),
+        jnp.array([2.2185299186623566, -13.311179511974139, 2.2185299186623566], dtype=dtype),
+        jnp.array([3.5078038001005707, -7.015607600201141, 0.7015607600201141], dtype=dtype),
+        jnp.array([4.030159736288377, -13.433865787627923, 4.030159736288377], dtype=dtype),
+        jnp.array([2.3268138086232857, -23.268138086232856, 11.634069043116428], dtype=dtype),
+        jnp.array([-19.843134832984433, 1.9843134832984433, 19.843134832984433, -1.9843134832984433], dtype=dtype),
         jnp.array(
             [-7.245688373094719, 2.7171331399105196, 21.737065119284157, -5.434266279821039, -8.15139941973156],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
         jnp.array(
             [
@@ -2364,16 +2397,16 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 1.8114220932736798,
                 0.9057110466368399,
             ],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
         jnp.array(
             [4.58257569495584, -11.4564392373896, 2.8641098093474, -11.4564392373896, 5.7282196186948, 2.8641098093474],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([1.0, -7.5, 5.625, -0.3125, -7.5, 11.25, -0.9375, 5.625, -0.9375, -0.3125], dtype=jnp.float64),
+        jnp.array([1.0, -7.5, 5.625, -0.3125, -7.5, 11.25, -0.9375, 5.625, -0.9375, -0.3125], dtype=dtype),
         jnp.array(
             [4.58257569495584, -11.4564392373896, 2.8641098093474, -11.4564392373896, 5.7282196186948, 2.8641098093474],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
         jnp.array(
             [
@@ -2386,11 +2419,11 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.45285552331841994,
                 0.45285552331841994,
             ],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
         jnp.array(
             [-21.737065119284157, 8.15139941973156, 7.245688373094719, 5.434266279821039, -2.7171331399105196],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
         jnp.array(
             [
@@ -2402,10 +2435,10 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 2.480391854123054,
                 -0.4960783708246108,
             ],
-            dtype=jnp.float64,
+            dtype=dtype,
         ),
-        jnp.array([11.634069043116428, -23.268138086232856, 2.3268138086232857], dtype=jnp.float64),
-        jnp.array([-0.6716932893813962, 10.075399340720942, -10.075399340720942, 0.6716932893813962], dtype=jnp.float64),
+        jnp.array([11.634069043116428, -23.268138086232856, 2.3268138086232857], dtype=dtype),
+        jnp.array([-0.6716932893813962, 10.075399340720942, -10.075399340720942, 0.6716932893813962], dtype=dtype),
     )
 
     S_L_M_EXPS = (
@@ -2531,6 +2564,7 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 @jit
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for Cartesian AOs (contracted)."""
+    dtype = get_dtype("kinetic")
     r_carts = jnp.asarray(r_carts)
     R_carts = aos_data._atomic_center_carts_prim_jnp
     c = aos_data._coefficients_jnp
@@ -2575,6 +2609,7 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
 @jit
 def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for spherical AOs (contracted)."""
+    dtype = get_dtype("kinetic")
     r_carts = jnp.asarray(r_carts)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
     R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
@@ -2584,8 +2619,8 @@ def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.n
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    l_f64 = l_jnp.astype(jnp.float64)
-    Z_f64 = Z_jnp.astype(jnp.float64)
+    l_f64 = l_jnp.astype(dtype)
+    Z_f64 = Z_jnp.astype(dtype)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_f64 + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_f64 + 3.0))
 
@@ -2646,7 +2681,8 @@ def compute_AOs_laplacian(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.
     Raises:
         NotImplementedError: If ``aos_data`` is not Cartesian or spherical.
     """
-    r_carts = jnp.asarray(r_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
 
     if isinstance(aos_data, AOs_cart_data):
         return _compute_AOs_laplacian_analytic_cart(aos_data, r_carts)
@@ -2700,9 +2736,11 @@ def _compute_S_l_m_debug(
         They can be hardcoded into a code, or they can be computed analytically (e.g., https://en.wikipedia.org/wiki/Solid_harmonics).
         The latter one is the strategy employed in this code,
     """
+    dtype = get_dtype("orb_eval")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     R_cart = atomic_center_cart
-    x, y, z = np.array(r_cart) - np.array(R_cart)
-    r_norm = LA.norm(np.array(r_cart) - np.array(R_cart))
+    x, y, z = np.array(r_cart, dtype=dtype_np) - np.array(R_cart, dtype=dtype_np)
+    r_norm = LA.norm(np.array(r_cart, dtype=dtype_np) - np.array(R_cart, dtype=dtype_np))
     l, m = angular_momentum, magnetic_quantum_number
     m_abs = np.abs(m)
 
@@ -2756,6 +2794,7 @@ def _compute_AOs_laplacian_autodiff(aos_data: AOs_sphe_data | AOs_cart_data, r_c
     See compute_AOs_laplacian_api
 
     """
+    dtype = get_dtype("kinetic")  # noqa: F841
     # not very fast, but it works.
     ao_matrix_hessian = hessian(compute_AOs, argnums=1)(aos_data, r_carts)
     ao_matrix_laplacian = jnp.einsum("m i i u i u -> mi", ao_matrix_hessian)
@@ -2781,6 +2820,8 @@ def _compute_AOs_laplacian_debug(
             Array containing laplacians of the AOs at r_carts. The dim. is (num_ao, N_e)
 
     """
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32  # noqa: F841
     # Laplacians of AOs (numerical)
     diff_h = 1.0e-5
 
@@ -2829,6 +2870,7 @@ def _compute_AOs_laplacian_debug(
 @jit
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for Cartesian AOs (contracted)."""
+    dtype = get_dtype("kinetic")  # noqa: F841
     r_carts = jnp.asarray(r_carts)
     R_carts = aos_data._atomic_center_carts_prim_jnp
     c = aos_data._coefficients_jnp
@@ -2876,6 +2918,7 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
 @jit
 def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for spherical AOs (contracted)."""
+    dtype = get_dtype("kinetic")
     r_carts = jnp.asarray(r_carts)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
     R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
@@ -2885,8 +2928,8 @@ def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarra
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    l_f64 = l_jnp.astype(jnp.float64)
-    Z_f64 = Z_jnp.astype(jnp.float64)
+    l_f64 = l_jnp.astype(dtype)
+    Z_f64 = Z_jnp.astype(dtype)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_f64 + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_f64 + 3.0))
 
@@ -2955,7 +2998,8 @@ def compute_AOs_grad(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array
     Raises:
         NotImplementedError: If ``aos_data`` is neither Cartesian nor spherical.
     """
-    r_carts = jnp.asarray(r_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
 
     if isinstance(aos_data, AOs_cart_data):
         return _compute_AOs_grad_analytic_cart(aos_data, r_carts)
@@ -2983,6 +3027,7 @@ def _compute_AOs_grad_autodiff(
         The dim. of each matrix is (num_ao, N_e)
 
     """
+    dtype = get_dtype("kinetic")  # noqa: F841
     grad_full = jacrev(compute_AOs, argnums=1)(aos_data, r_carts)
     grad_diag = jnp.diagonal(grad_full, axis1=1, axis2=2)
     grad_diag = jnp.swapaxes(grad_diag, 1, 2)
@@ -3004,6 +3049,8 @@ def _compute_AOs_grad_debug(
     the given atomic orbital at r_carts using FDM for debugging JAX
     implementations. See compute_AOs_grad_api
     """
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32  # noqa: F841
     # Gradients of AOs (numerical)
     diff_h = 1.0e-5
 

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -58,7 +58,7 @@ from numpy import linalg as LA
 
 from ._jqmc_utility import _spherical_to_cart_matrix
 from ._precision import get_dtype
-from ._setting import EPS_stabilizing_jax_AO_cart_deriv, atol_consistency, rtol_consistency
+from ._setting import EPS_stabilizing_jax_AO_cart_deriv, atol_consistency, get_eps, rtol_consistency
 from .structure import Structure_data
 
 # set logger
@@ -1986,16 +1986,18 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     See compute_AOs_api
 
     """
-    # Indices with respect to the contracted AOs
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
-    c_jnp = aos_data._coefficients_jnp
-    Z_jnp = aos_data._exponents_jnp
+    # Downcast all float inputs to orb_eval zone dtype (P0-1, P0-2)
+    dtype = get_dtype("orb_eval")
+    r_carts = r_carts.astype(dtype)
+    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
     nx_jnp = aos_data._polynominal_order_x_prim_jnp
     ny_jnp = aos_data._polynominal_order_y_prim_jnp
     nz_jnp = aos_data._polynominal_order_z_prim_jnp
 
-    N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp
+    N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
     N_n_dup_Z_part = (2.0 * Z_jnp / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z_jnp) ** l_jnp
     N_n_dup = jnp.sqrt(N_n_dup_Z_part * N_n_dup_fuctorial_part)
     r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
@@ -2003,7 +2005,7 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
     x, y, z = r_R_diffs[..., 0], r_R_diffs[..., 1], r_R_diffs[..., 2]
-    eps = EPS_stabilizing_jax_AO_cart_deriv  # This is quite important to avoid some numerical instability in JAX!!
+    eps = get_eps("stabilizing_ao", dtype)
     P_l_nx_ny_nz_dup = (x + eps) ** (nx_jnp[:, None]) * (y + eps) ** (ny_jnp[:, None]) * (z + eps) ** (nz_jnp[:, None])
 
     """
@@ -2033,26 +2035,27 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
     See compute_AOs_api
 
     """
-    # Indices with respect to the contracted AOs
-    # compute R_n inc. the whole normalization factor
+    # Downcast all float inputs to orb_eval zone dtype (P0-1)
+    dtype = get_dtype("orb_eval")
+    r_carts = r_carts.astype(dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp
-    c_jnp = aos_data._coefficients_jnp
-    Z_jnp = aos_data._exponents_jnp
+    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    # use float64 gamma-based factorials to avoid float32 drift vs debug implementation
-    l_f64 = l_jnp.astype(jnp.float64)
-    Z_f64 = Z_jnp.astype(jnp.float64)
-    factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_f64 + 2.0))
-    factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_f64 + 3.0))
+    # Normalization constants computed in zone dtype (P0-1: replaces .astype(jnp.float64))
+    l_typed = l_jnp.astype(dtype)
+    factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_typed + 2.0))
+    factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_typed + 3.0))
 
     N_n_dup = jnp.sqrt(
-        (2.0 ** (2 * l_f64 + 3) * factorial_l_plus_1 * (2 * Z_f64) ** (l_f64 + 1.5)) / (factorial_2l_plus_2 * jnp.sqrt(jnp.pi))
+        (2.0 ** (2 * l_typed + 3) * factorial_l_plus_1 * (2 * Z_jnp) ** (l_typed + 1.5))
+        / (factorial_2l_plus_2 * jnp.sqrt(jnp.asarray(jnp.pi, dtype=dtype)))
     )
-    N_l_m_dup = jnp.sqrt((2 * l_f64 + 1) / (4 * jnp.pi))
+    N_l_m_dup = jnp.sqrt((2 * l_typed + 1) / (4 * jnp.asarray(jnp.pi, dtype=dtype)))
     r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
@@ -2565,24 +2568,25 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for Cartesian AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts)
-    R_carts = aos_data._atomic_center_carts_prim_jnp
-    c = aos_data._coefficients_jnp
-    Z = aos_data._exponents_jnp
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    R_carts = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    c = aos_data._coefficients_jnp.astype(dtype)
+    Z = aos_data._exponents_jnp.astype(dtype)
     l = aos_data._angular_momentums_prim_jnp
     nx = aos_data._polynominal_order_x_prim_jnp
     ny = aos_data._polynominal_order_y_prim_jnp
     nz = aos_data._polynominal_order_z_prim_jnp
 
-    N_fact = aos_data._normalization_factorial_ratio_prim_jnp
+    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
     diff = r_carts[None, :, :] - R_carts[:, None, :]
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    x = x + EPS_stabilizing_jax_AO_cart_deriv
-    y = y + EPS_stabilizing_jax_AO_cart_deriv
-    z = z + EPS_stabilizing_jax_AO_cart_deriv
+    eps = get_eps("stabilizing_ao", dtype)
+    x = x + eps
+    y = y + eps
+    z = z + eps
     r2 = jnp.sum(diff**2, axis=-1)
     pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
 
@@ -2610,12 +2614,12 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
 def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for spherical AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts)
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp
-    c_jnp = aos_data._coefficients_jnp
-    Z_jnp = aos_data._exponents_jnp
+    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
@@ -2794,7 +2798,8 @@ def _compute_AOs_laplacian_autodiff(aos_data: AOs_sphe_data | AOs_cart_data, r_c
     See compute_AOs_laplacian_api
 
     """
-    dtype = get_dtype("kinetic")  # noqa: F841
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
     # not very fast, but it works.
     ao_matrix_hessian = hessian(compute_AOs, argnums=1)(aos_data, r_carts)
     ao_matrix_laplacian = jnp.einsum("m i i u i u -> mi", ao_matrix_hessian)
@@ -2870,25 +2875,26 @@ def _compute_AOs_laplacian_debug(
 @jit
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for Cartesian AOs (contracted)."""
-    dtype = get_dtype("kinetic")  # noqa: F841
-    r_carts = jnp.asarray(r_carts)
-    R_carts = aos_data._atomic_center_carts_prim_jnp
-    c = aos_data._coefficients_jnp
-    Z = aos_data._exponents_jnp
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    R_carts = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    c = aos_data._coefficients_jnp.astype(dtype)
+    Z = aos_data._exponents_jnp.astype(dtype)
     l = aos_data._angular_momentums_prim_jnp
     nx = aos_data._polynominal_order_x_prim_jnp
     ny = aos_data._polynominal_order_y_prim_jnp
     nz = aos_data._polynominal_order_z_prim_jnp
 
-    N_fact = aos_data._normalization_factorial_ratio_prim_jnp
+    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
     diff = r_carts[None, :, :] - R_carts[:, None, :]
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    x = x + EPS_stabilizing_jax_AO_cart_deriv
-    y = y + EPS_stabilizing_jax_AO_cart_deriv
-    z = z + EPS_stabilizing_jax_AO_cart_deriv
+    eps = get_eps("stabilizing_ao", dtype)
+    x = x + eps
+    y = y + eps
+    z = z + eps
     r2 = jnp.sum(diff**2, axis=-1)
     pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
 
@@ -2919,12 +2925,12 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
 def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for spherical AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts)
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp
-    c_jnp = aos_data._coefficients_jnp
-    Z_jnp = aos_data._exponents_jnp
+    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -1988,8 +1988,13 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     """
     # Downcast all float inputs to orb_eval zone dtype (P0-1, P0-2)
     dtype = get_dtype("orb_eval")
-    r_carts = r_carts.astype(dtype)
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation when zone dtype is float32
+    # (positions can be ~50 Bohr; float32 difference loses ~6 digits of precision).
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
+    R_carts_jnp = _R_carts_f64.astype(dtype)
     c_jnp = aos_data._coefficients_jnp.astype(dtype)
     Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
@@ -2000,7 +2005,6 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
     N_n_dup_Z_part = (2.0 * Z_jnp / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z_jnp) ** l_jnp
     N_n_dup = jnp.sqrt(N_n_dup_Z_part * N_n_dup_fuctorial_part)
-    r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
@@ -2037,16 +2041,22 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
     """
     # Downcast all float inputs to orb_eval zone dtype (P0-1)
     dtype = get_dtype("orb_eval")
-    r_carts = r_carts.astype(dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
+    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    R_carts_jnp = _R_carts_f64.astype(dtype)
+    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
     c_jnp = aos_data._coefficients_jnp.astype(dtype)
     Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    # Normalization constants computed in zone dtype (P0-1: replaces .astype(jnp.float64))
+    # Normalization constants computed in zone dtype.
     l_typed = l_jnp.astype(dtype)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_typed + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_typed + 3.0))
@@ -2056,10 +2066,8 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
         / (factorial_2l_plus_2 * jnp.sqrt(jnp.asarray(jnp.pi, dtype=dtype)))
     )
     N_l_m_dup = jnp.sqrt((2 * l_typed + 1) / (4 * jnp.asarray(jnp.pi, dtype=dtype)))
-    r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
-    r_R_diffs_uq = r_carts[None, :, :] - R_carts_unique_jnp[:, None, :]
 
     max_ml, S_l_m_dup_all_l_m = _compute_S_l_m(r_R_diffs_uq)
     S_l_m_dup_all_l_m_reshaped = S_l_m_dup_all_l_m.reshape(
@@ -2568,8 +2576,12 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for Cartesian AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-    R_carts = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    diff = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
+    R_carts = _R_carts_f64.astype(dtype)
     c = aos_data._coefficients_jnp.astype(dtype)
     Z = aos_data._exponents_jnp.astype(dtype)
     l = aos_data._angular_momentums_prim_jnp
@@ -2581,7 +2593,6 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
-    diff = r_carts[None, :, :] - R_carts[:, None, :]
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
     eps = get_eps("stabilizing_ao", dtype)
     x = x + eps
@@ -2614,10 +2625,16 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
 def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for spherical AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
+    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    R_carts_jnp = _R_carts_f64.astype(dtype)
+    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
     c_jnp = aos_data._coefficients_jnp.astype(dtype)
     Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
@@ -2633,11 +2650,9 @@ def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.n
     )
     N_l_m_dup = jnp.sqrt((2 * l_f64 + 1) / (4 * jnp.pi))
 
-    r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
-    r_R_diffs_uq = r_carts[None, :, :] - R_carts_unique_jnp[:, None, :]
     S_l_m_vals_all, S_l_m_grads_all, S_l_m_laps_all = _compute_S_l_m_and_grad_lap(r_R_diffs_uq)
     max_ml = S_l_m_vals_all.shape[0]
 
@@ -2876,8 +2891,12 @@ def _compute_AOs_laplacian_debug(
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for Cartesian AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-    R_carts = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    diff = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
+    R_carts = _R_carts_f64.astype(dtype)
     c = aos_data._coefficients_jnp.astype(dtype)
     Z = aos_data._exponents_jnp.astype(dtype)
     l = aos_data._angular_momentums_prim_jnp
@@ -2889,7 +2908,6 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
-    diff = r_carts[None, :, :] - R_carts[:, None, :]
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
     eps = get_eps("stabilizing_ao", dtype)
     x = x + eps
@@ -2925,10 +2943,16 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
 def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for spherical AOs (contracted)."""
     dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
+    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
+    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
+    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
+    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
+    r_carts = _r_carts_f64.astype(dtype)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = aos_data._atomic_center_carts_prim_jnp.astype(dtype)
-    R_carts_unique_jnp = aos_data._atomic_center_carts_unique_jnp.astype(dtype)
+    R_carts_jnp = _R_carts_f64.astype(dtype)
+    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
     c_jnp = aos_data._coefficients_jnp.astype(dtype)
     Z_jnp = aos_data._exponents_jnp.astype(dtype)
     l_jnp = aos_data._angular_momentums_prim_jnp
@@ -2944,11 +2968,9 @@ def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarra
     )
     N_l_m_dup = jnp.sqrt((2 * l_f64 + 1) / (4 * jnp.pi))
 
-    r_R_diffs = r_carts[None, :, :] - R_carts_jnp[:, None, :]
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
-    r_R_diffs_uq = r_carts[None, :, :] - R_carts_unique_jnp[:, None, :]
     max_ml, S_l_m_dup_all_l_m = _compute_S_l_m(r_R_diffs_uq)
     _, S_l_m_grad_all_l_m, _ = _compute_S_l_m_and_grad_lap(r_R_diffs_uq)
 

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -57,8 +57,8 @@ from jax import typing as jnpt
 from numpy import linalg as LA
 
 from ._jqmc_utility import _spherical_to_cart_matrix
-from ._precision import get_dtype
-from ._setting import EPS_stabilizing_jax_AO_cart_deriv, atol_consistency, get_eps, rtol_consistency
+from ._precision import get_dtype_jnp, get_dtype_np
+from ._setting import atol_consistency, get_eps, rtol_consistency
 from .structure import Structure_data
 
 # set logger
@@ -86,8 +86,8 @@ class AOs_cart_data:
         num_ao (int): Number of contracted AOs.
         num_ao_prim (int): Number of primitive Gaussians.
         orbital_indices (list[int] | tuple[int]): For each primitive, the parent AO index (``len == num_ao_prim``).
-        exponents (list[float] | tuple[float]): Gaussian exponents for primitives (``len == num_ao_prim``).
-        coefficients (list[float] | tuple[float]): Contraction coefficients per primitive (``len == num_ao_prim``).
+        exponents (npt.NDArray[np.float64]): Gaussian exponents for primitives (``len == num_ao_prim``). dtype: float64.
+        coefficients (npt.NDArray[np.float64]): Contraction coefficients per primitive (``len == num_ao_prim``). dtype: float64.
         angular_momentums (list[int] | tuple[int]): Angular momentum quantum numbers ``l`` per AO (``len == num_ao``).
         polynominal_order_x (list[int] | tuple[int]): Cartesian power ``n_x`` for each AO (``len == num_ao``).
         polynominal_order_y (list[int] | tuple[int]): Cartesian power ``n_y`` for each AO (``len == num_ao``).
@@ -230,10 +230,12 @@ class AOs_cart_data:
     num_ao_prim: int = struct.field(pytree_node=False, default=0)
     #: For each primitive, the parent AO index (``len == num_ao_prim``).
     orbital_indices: list[int] | tuple[int] = struct.field(pytree_node=False, default_factory=tuple)
-    #: Gaussian exponents for primitives (``len == num_ao_prim``).
-    exponents: jax.Array = struct.field(pytree_node=True, default_factory=lambda: jnp.array([]))
-    #: Contraction coefficients per primitive (``len == num_ao_prim``).
-    coefficients: jax.Array = struct.field(pytree_node=True, default_factory=lambda: jnp.array([]))
+    #: Gaussian exponents for primitives (``len == num_ao_prim``). dtype: float64.
+    exponents: npt.NDArray[np.float64] = struct.field(pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64))
+    #: Contraction coefficients per primitive (``len == num_ao_prim``). dtype: float64.
+    coefficients: npt.NDArray[np.float64] = struct.field(
+        pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64)
+    )
     #: Angular momentum quantum numbers ``l`` per AO (``len == num_ao``).
     angular_momentums: list[int] | tuple[int] = struct.field(pytree_node=False, default_factory=tuple)
     #: Cartesian power ``n_x`` for each AO (``len == num_ao``).
@@ -287,10 +289,10 @@ class AOs_cart_data:
             raise ValueError(f"num_ao_prim = {type(self.num_ao_prim)} must be an int.")
         if not isinstance(self.orbital_indices, (tuple, list)):
             raise ValueError(f"orbital_indices = {type(self.orbital_indices)} must be a list or tuple.")
-        if not isinstance(self.exponents, (tuple, list, jax.Array, np.ndarray)):
-            raise ValueError(f"exponents = {type(self.exponents)} must be a jax.Array, np.ndarray, list, or tuple.")
-        if not isinstance(self.coefficients, (tuple, list, jax.Array, np.ndarray)):
-            raise ValueError(f"coefficients = {type(self.coefficients)} must be a jax.Array, np.ndarray, list, or tuple.")
+        if not isinstance(self.exponents, np.ndarray):
+            raise ValueError(f"exponents = {type(self.exponents)} must be an np.ndarray (float64).")
+        if not isinstance(self.coefficients, np.ndarray):
+            raise ValueError(f"coefficients = {type(self.coefficients)} must be an np.ndarray (float64).")
         if not isinstance(self.angular_momentums, (tuple, list)):
             raise ValueError(f"angular_momentums = {type(self.angular_momentums)} must be a list or tuple.")
         if not isinstance(self.polynominal_order_x, (tuple, list)):
@@ -431,8 +433,8 @@ class AOs_cart_data:
             num_ao=len(new_nucleus_index),
             num_ao_prim=len(new_orbital_indices),
             orbital_indices=new_orbital_indices,
-            exponents=new_exponents,
-            coefficients=new_coefficients,
+            exponents=np.array(new_exponents, dtype=np.float64),
+            coefficients=np.array(new_coefficients, dtype=np.float64),
             angular_momentums=new_angular_momentums,
             polynominal_order_x=new_polynominal_order_x,
             polynominal_order_y=new_polynominal_order_y,
@@ -707,7 +709,9 @@ class AOs_cart_data:
     @property
     def _normalization_factorial_ratio_prim_jnp(self) -> jax.Array:
         """Return factorial ratio used in AO normalization (primitive-wise)."""
-        dtype = get_dtype("io")
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        dtype_jnp = jnp.float64
         nx = self._polynominal_order_x_prim_np
         ny = self._polynominal_order_y_prim_np
         nz = self._polynominal_order_z_prim_np
@@ -721,21 +725,25 @@ class AOs_cart_data:
             * scipy.special.factorial(2 * ny, exact=True)
             * scipy.special.factorial(2 * nz, exact=True)
         )
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = np.float64
         ratio = np.asarray(num / den, dtype=dtype_np)
-        return jnp.array(ratio, dtype=dtype)
+        return jnp.array(ratio, dtype=dtype_jnp)
 
     @property
     def _exponents_jnp(self) -> jax.Array:
         """Return exponents."""
-        dtype = get_dtype("io")
-        return jnp.asarray(self.exponents, dtype=dtype)
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        dtype_jnp = jnp.float64
+        return jnp.asarray(self.exponents, dtype=dtype_jnp)
 
     @property
     def _coefficients_jnp(self) -> jax.Array:
         """Return coefficients."""
-        dtype = get_dtype("io")
-        return jnp.asarray(self.coefficients, dtype=dtype)
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        dtype_jnp = jnp.float64
+        return jnp.asarray(self.coefficients, dtype=dtype_jnp)
 
     @property
     def _num_orb(self) -> int:
@@ -756,8 +764,8 @@ class AOs_sphe_data:
         num_ao (int): Number of contracted AOs.
         num_ao_prim (int): Number of primitive Gaussians.
         orbital_indices (list[int] | tuple[int]): For each primitive, the parent AO index (``len == num_ao_prim``).
-        exponents (list[float] | tuple[float]): Gaussian exponents for primitives (``len == num_ao_prim``).
-        coefficients (list[float] | tuple[float]): Contraction coefficients per primitive (``len == num_ao_prim``).
+        exponents (npt.NDArray[np.float64]): Gaussian exponents for primitives (``len == num_ao_prim``). dtype: float64.
+        coefficients (npt.NDArray[np.float64]): Contraction coefficients per primitive (``len == num_ao_prim``). dtype: float64.
         angular_momentums (list[int] | tuple[int]): Angular momentum quantum numbers ``l`` per AO (``len == num_ao``).
         magnetic_quantum_numbers (list[int] | tuple[int]): Magnetic quantum numbers ``m`` per AO (``len == num_ao``),
             satisfying ``-l <= m <= l``.
@@ -883,10 +891,12 @@ class AOs_sphe_data:
     num_ao_prim: int = struct.field(pytree_node=False, default=0)
     #: For each primitive, the parent AO index (``len == num_ao_prim``).
     orbital_indices: list[int] | tuple[int] = struct.field(pytree_node=False, default_factory=tuple)
-    #: Gaussian exponents for primitives (``len == num_ao_prim``).
-    exponents: jax.Array = struct.field(pytree_node=True, default_factory=lambda: jnp.array([]))
-    #: Contraction coefficients per primitive (``len == num_ao_prim``).
-    coefficients: jax.Array = struct.field(pytree_node=True, default_factory=lambda: jnp.array([]))
+    #: Gaussian exponents for primitives (``len == num_ao_prim``). dtype: float64.
+    exponents: npt.NDArray[np.float64] = struct.field(pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64))
+    #: Contraction coefficients per primitive (``len == num_ao_prim``). dtype: float64.
+    coefficients: npt.NDArray[np.float64] = struct.field(
+        pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64)
+    )
     #: Angular momentum quantum numbers ``l`` per AO (``len == num_ao``).
     angular_momentums: list[int] | tuple[int] = struct.field(pytree_node=False, default_factory=tuple)
     #: Magnetic quantum numbers ``m`` per AO (``len == num_ao``; ``-l <= m <= l``).
@@ -929,10 +939,10 @@ class AOs_sphe_data:
             raise ValueError(f"num_ao_prim = {type(self.num_ao_prim)} must be an int.")
         if not isinstance(self.orbital_indices, (list, tuple)):
             raise ValueError(f"orbital_indices = {type(self.orbital_indices)} must be a list or tuple.")
-        if not isinstance(self.exponents, (list, tuple, jax.Array, np.ndarray)):
-            raise ValueError(f"exponents = {type(self.exponents)} must be a jax.Array, np.ndarray, list, or tuple.")
-        if not isinstance(self.coefficients, (list, tuple, jax.Array, np.ndarray)):
-            raise ValueError(f"coefficients = {type(self.coefficients)} must be a jax.Array, np.ndarray, list, or tuple.")
+        if not isinstance(self.exponents, np.ndarray):
+            raise ValueError(f"exponents = {type(self.exponents)} must be an np.ndarray (float64).")
+        if not isinstance(self.coefficients, np.ndarray):
+            raise ValueError(f"coefficients = {type(self.coefficients)} must be an np.ndarray (float64).")
         if not isinstance(self.angular_momentums, (list, tuple)):
             raise ValueError(f"angular_momentums = {type(self.angular_momentums)} must be a list or tuple.")
         if not isinstance(self.magnetic_quantum_numbers, (list, tuple)):
@@ -1051,8 +1061,8 @@ class AOs_sphe_data:
             num_ao=len(new_nucleus_index),
             num_ao_prim=len(new_orbital_indices),
             orbital_indices=new_orbital_indices,
-            exponents=new_exponents,
-            coefficients=new_coefficients,
+            exponents=np.array(new_exponents, dtype=np.float64),
+            coefficients=np.array(new_coefficients, dtype=np.float64),
             angular_momentums=new_angular_momentums,
             magnetic_quantum_numbers=new_magnetic_quantum_numbers,
         )
@@ -1278,14 +1288,18 @@ class AOs_sphe_data:
     @property
     def _exponents_jnp(self) -> jax.Array:
         """Return exponents."""
-        dtype = get_dtype("io")
-        return jnp.asarray(self.exponents, dtype=dtype)
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        dtype_jnp = jnp.float64
+        return jnp.asarray(self.exponents, dtype=dtype_jnp)
 
     @property
     def _coefficients_jnp(self) -> jax.Array:
         """Return coefficients."""
-        dtype = get_dtype("io")
-        return jnp.asarray(self.coefficients, dtype=dtype)
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        dtype_jnp = jnp.float64
+        return jnp.asarray(self.coefficients, dtype=dtype_jnp)
 
     @property
     def _num_orb(self) -> int:
@@ -1352,8 +1366,9 @@ class ShellPrimMap:
     @classmethod
     def from_aos_data(cls, aos_data: "AOs_sphe_data | AOs_cart_data") -> "ShellPrimMap":
         """Build a shell map from an AO dataclass instance."""
-        dtype = get_dtype("io")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        # Build-time copy of fp64 basis-data storage (see _precision.py exemption for
+        # basis-data storage accessors); used only for shell identity and indexing.
+        dtype_np = np.float64
         ao_prims: dict[int, list[int]] = {}
         for prim_idx, ao_idx in enumerate(aos_data.orbital_indices):
             ao_prims.setdefault(ao_idx, []).append(prim_idx)
@@ -1420,8 +1435,7 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
         tuple: (AOs_cart_data, transform_matrix) where transform_matrix maps
         spherical -> Cartesian coefficients with shape (num_ao_sph, num_ao_cart).
     """
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     if isinstance(aos_data, AOs_cart_data):
         transform_matrix = np.eye(aos_data.num_ao, dtype=dtype_np)
         return aos_data, transform_matrix
@@ -1501,8 +1515,8 @@ def _aos_sphe_to_cart(aos_data: AOs_sphe_data | AOs_cart_data) -> tuple[AOs_cart
         num_ao=total_cart,
         num_ao_prim=len(new_exponents),
         orbital_indices=new_orbital_indices,
-        exponents=jnp.array(new_exponents, dtype=dtype),
-        coefficients=jnp.array(new_coefficients, dtype=dtype),
+        exponents=np.array(new_exponents, dtype=np.float64),
+        coefficients=np.array(new_coefficients, dtype=np.float64),
         angular_momentums=new_angular_momentums,
         polynominal_order_x=new_polynominal_order_x,
         polynominal_order_y=new_polynominal_order_y,
@@ -1519,8 +1533,7 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
         tuple: (AOs_sphe_data, transform_pinv) where transform_pinv maps
         Cartesian -> spherical coefficients with shape (num_ao_cart, num_ao_sph).
     """
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     if isinstance(aos_data, AOs_sphe_data):
         transform_pinv = np.eye(aos_data.num_ao, dtype=dtype_np)
         return aos_data, transform_pinv
@@ -1616,8 +1629,8 @@ def _aos_cart_to_sphe(aos_data: AOs_cart_data | AOs_sphe_data) -> tuple[AOs_sphe
         num_ao=total_sph,
         num_ao_prim=len(new_exponents),
         orbital_indices=new_orbital_indices,
-        exponents=jnp.array(new_exponents, dtype=dtype),
-        coefficients=jnp.array(new_coefficients, dtype=dtype),
+        exponents=np.array(new_exponents, dtype=np.float64),
+        coefficients=np.array(new_coefficients, dtype=np.float64),
         angular_momentums=new_angular_momentums,
         magnetic_quantum_numbers=new_magnetic_quantum_numbers,
     )
@@ -1668,8 +1681,7 @@ def _compute_overlap_1d_cart(
 
 def _compute_overlap_matrix_cart_analytic(aos_cart_data: AOs_cart_data) -> npt.NDArray[np.float64]:
     """Compute AO overlap matrix analytically for Cartesian contracted GTOs."""
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     num_ao = aos_cart_data.num_ao
     overlap_matrix = np.zeros((num_ao, num_ao), dtype=dtype_np)
 
@@ -1740,8 +1752,7 @@ def _estimate_overlap_integration_box(
     tail_tolerance: float = 1.0e-11,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Estimate finite integration bounds for numerical overlap integration."""
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     if tail_tolerance <= 0.0 or tail_tolerance >= 1.0:
         raise ValueError(f"tail_tolerance must satisfy 0 < tail_tolerance < 1. Got {tail_tolerance}.")
 
@@ -1766,8 +1777,7 @@ def _build_overlap_integration_grid(
     tail_tolerance: float,
 ) -> tuple[np.ndarray, float]:
     """Build a uniform midpoint grid and volume element for numerical overlap integration."""
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     if num_grid_points < 3:
         raise ValueError(f"num_grid_points must be >= 3. Got {num_grid_points}.")
 
@@ -1792,8 +1802,7 @@ def _compute_overlap_matrix_debug(
     tail_tolerance: float = 1.0e-11,
 ) -> npt.NDArray[np.float64]:
     """Numerically compute AO overlap matrix by 3D midpoint integration (debug)."""
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     r_carts, volume_element = _build_overlap_integration_grid(
         aos_data=aos_data,
         num_grid_points=num_grid_points,
@@ -1812,7 +1821,7 @@ def compute_overlap_matrix(aos_data: AOs_sphe_data | AOs_cart_data) -> jax.Array
     For spherical AOs, the overlap is evaluated by conversion to Cartesian AOs and
     transformed back with the spherical-to-Cartesian matrix.
     """
-    dtype = get_dtype("orb_eval")
+    dtype_jnp = get_dtype_jnp("ao_eval")
     aos_cart_data, transform_matrix = _aos_sphe_to_cart(aos_data)
     cart_overlap_matrix = _compute_overlap_matrix_cart_analytic(aos_cart_data)
 
@@ -1824,7 +1833,7 @@ def compute_overlap_matrix(aos_data: AOs_sphe_data | AOs_cart_data) -> jax.Array
         raise NotImplementedError
 
     overlap_matrix = 0.5 * (overlap_matrix + overlap_matrix.T)
-    return jnp.asarray(overlap_matrix, dtype=dtype)
+    return jnp.asarray(overlap_matrix, dtype=dtype_jnp)
 
 
 def compute_AOs(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array) -> jax.Array:
@@ -1845,9 +1854,11 @@ def compute_AOs(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array) -> 
     Raises:
         NotImplementedError: If ``aos_data`` is neither Cartesian nor spherical.
     """
-    dtype = get_dtype("orb_eval")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-
+    # NOTE: do not pre-cast r_carts here. The internal kernels
+    # ``_compute_AOs_sphe`` / ``_compute_AOs_cart`` reconstruct ``r - R`` in
+    # float64 to avoid catastrophic cancellation (positions can be ~50 Bohr;
+    # an fp32 difference loses ~6 digits). Downcasting r_carts in this wrapper
+    # would destroy that precision *before* the fp64 reconstruction can use it.
     if isinstance(aos_data, AOs_sphe_data):
         AOs = _compute_AOs_sphe(aos_data, r_carts)
 
@@ -1876,8 +1887,6 @@ def _compute_AOs_sphe_debug(aos_data: AOs_sphe_data, r_carts: npt.NDArray[np.flo
     The method is for computing the value of the given atomic orbital at r_carts
     for debugging purpose. See compute_AOs_api.
     """
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_values = []
 
     for ao_index in range(aos_data.num_ao):
@@ -1931,8 +1940,6 @@ def _compute_AOs_cart_debug(aos_data: AOs_cart_data, r_carts: npt.NDArray[np.flo
     The method is for computing the value of the given atomic orbital at r_carts
     for debugging purpose. See compute_AOs_api.
     """
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_values = []
 
     for ao_index in range(aos_data.num_ao):
@@ -1986,30 +1993,29 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     See compute_AOs_api
 
     """
-    # Downcast all float inputs to orb_eval zone dtype (P0-1, P0-2)
-    dtype = get_dtype("orb_eval")
-    # Compute r-R in float64 to avoid catastrophic cancellation when zone dtype is float32
-    # (positions can be ~50 Bohr; float32 difference loses ~6 digits of precision).
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
-    R_carts_jnp = _R_carts_f64.astype(dtype)
-    c_jnp = aos_data._coefficients_jnp.astype(dtype)
-    Z_jnp = aos_data._exponents_jnp.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_eval")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion when one operand is fp64, then downcast to the ao_eval
+    # zone (Principle 3b — local cast at point of arithmetic). r_carts is
+    # forwarded as-is (Principle 3a) and R_carts is read from the fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    r_R_diffs = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
     nx_jnp = aos_data._polynominal_order_x_prim_jnp
     ny_jnp = aos_data._polynominal_order_y_prim_jnp
     nz_jnp = aos_data._polynominal_order_z_prim_jnp
 
-    N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
+    N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     N_n_dup_Z_part = (2.0 * Z_jnp / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z_jnp) ** l_jnp
     N_n_dup = jnp.sqrt(N_n_dup_Z_part * N_n_dup_fuctorial_part)
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
     x, y, z = r_R_diffs[..., 0], r_R_diffs[..., 1], r_R_diffs[..., 2]
-    eps = get_eps("stabilizing_ao", dtype)
+    eps = get_eps("stabilizing_ao", dtype_jnp)
     P_l_nx_ny_nz_dup = (x + eps) ** (nx_jnp[:, None]) * (y + eps) ** (ny_jnp[:, None]) * (z + eps) ** (nz_jnp[:, None])
 
     """
@@ -2039,33 +2045,32 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
     See compute_AOs_api
 
     """
-    # Downcast all float inputs to orb_eval zone dtype (P0-1)
-    dtype = get_dtype("orb_eval")
-    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
-    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_eval")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion when one operand is fp64, then downcast to the ao_eval
+    # zone (Principle 3b — local cast at point of arithmetic). r_carts is
+    # forwarded as-is (Principle 3a) and R_carts is read from the fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    R_carts_unique = aos_data._atomic_center_carts_unique_jnp
+    r_R_diffs = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    r_R_diffs_uq = (r_carts[None, :, :] - R_carts_unique[:, None, :]).astype(dtype_jnp)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = _R_carts_f64.astype(dtype)
-    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
-    c_jnp = aos_data._coefficients_jnp.astype(dtype)
-    Z_jnp = aos_data._exponents_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
     # Normalization constants computed in zone dtype.
-    l_typed = l_jnp.astype(dtype)
+    l_typed = l_jnp.astype(dtype_jnp)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_typed + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_typed + 3.0))
 
     N_n_dup = jnp.sqrt(
         (2.0 ** (2 * l_typed + 3) * factorial_l_plus_1 * (2 * Z_jnp) ** (l_typed + 1.5))
-        / (factorial_2l_plus_2 * jnp.sqrt(jnp.asarray(jnp.pi, dtype=dtype)))
+        / (factorial_2l_plus_2 * jnp.sqrt(jnp.asarray(jnp.pi, dtype=dtype_jnp)))
     )
-    N_l_m_dup = jnp.sqrt((2 * l_typed + 1) / (4 * jnp.asarray(jnp.pi, dtype=dtype)))
+    N_l_m_dup = jnp.sqrt((2 * l_typed + 1) / (4 * jnp.asarray(jnp.pi, dtype=dtype_jnp)))
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
@@ -2328,40 +2333,40 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
         tuple: (values, grads, laps) where values has shape (49, num_R, num_r), grads has shape (49, num_R, num_r, 3),
         and laps has shape (49, num_R, num_r).
     """
-    dtype = get_dtype("kinetic")
+    dtype_jnp = get_dtype_jnp("ao_grad_lap")
     S_L_M_COEFFS = (
-        jnp.array([1.0], dtype=dtype),
-        jnp.array([1.0], dtype=dtype),
-        jnp.array([1.0], dtype=dtype),
-        jnp.array([1.0], dtype=dtype),
-        jnp.array([1.7320508075688774], dtype=dtype),
-        jnp.array([1.7320508075688774], dtype=dtype),
-        jnp.array([1.0, -0.5, -0.5], dtype=dtype),
-        jnp.array([1.7320508075688774], dtype=dtype),
-        jnp.array([-0.8660254037844387, 0.8660254037844387], dtype=dtype),
-        jnp.array([-0.7905694150420949, 2.3717082451262845], dtype=dtype),
-        jnp.array([3.8729833462074166], dtype=dtype),
-        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype),
-        jnp.array([1.0, -1.5, -1.5], dtype=dtype),
-        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype),
-        jnp.array([-1.9364916731037083, 1.9364916731037083], dtype=dtype),
-        jnp.array([-2.3717082451262845, 0.7905694150420949], dtype=dtype),
-        jnp.array([-2.958039891549808, 2.958039891549808], dtype=dtype),
-        jnp.array([-2.091650066335189, 6.274950199005566], dtype=dtype),
-        jnp.array([6.708203932499371, -1.1180339887498951, -1.1180339887498951], dtype=dtype),
-        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype),
-        jnp.array([1.0, -3.0, 0.375, -3.0, 0.75, 0.375], dtype=dtype),
-        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype),
-        jnp.array([-3.3541019662496856, 0.5590169943749476, 3.3541019662496856, -0.5590169943749476], dtype=dtype),
-        jnp.array([-6.274950199005566, 2.091650066335189], dtype=dtype),
-        jnp.array([0.739509972887452, -4.437059837324712, 0.739509972887452], dtype=dtype),
-        jnp.array([0.7015607600201141, -7.015607600201141, 3.5078038001005707], dtype=dtype),
-        jnp.array([-8.874119674649426, 8.874119674649426], dtype=dtype),
+        jnp.array([1.0], dtype=dtype_jnp),
+        jnp.array([1.0], dtype=dtype_jnp),
+        jnp.array([1.0], dtype=dtype_jnp),
+        jnp.array([1.0], dtype=dtype_jnp),
+        jnp.array([1.7320508075688774], dtype=dtype_jnp),
+        jnp.array([1.7320508075688774], dtype=dtype_jnp),
+        jnp.array([1.0, -0.5, -0.5], dtype=dtype_jnp),
+        jnp.array([1.7320508075688774], dtype=dtype_jnp),
+        jnp.array([-0.8660254037844387, 0.8660254037844387], dtype=dtype_jnp),
+        jnp.array([-0.7905694150420949, 2.3717082451262845], dtype=dtype_jnp),
+        jnp.array([3.8729833462074166], dtype=dtype_jnp),
+        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype_jnp),
+        jnp.array([1.0, -1.5, -1.5], dtype=dtype_jnp),
+        jnp.array([2.4494897427831783, -0.6123724356957946, -0.6123724356957946], dtype=dtype_jnp),
+        jnp.array([-1.9364916731037083, 1.9364916731037083], dtype=dtype_jnp),
+        jnp.array([-2.3717082451262845, 0.7905694150420949], dtype=dtype_jnp),
+        jnp.array([-2.958039891549808, 2.958039891549808], dtype=dtype_jnp),
+        jnp.array([-2.091650066335189, 6.274950199005566], dtype=dtype_jnp),
+        jnp.array([6.708203932499371, -1.1180339887498951, -1.1180339887498951], dtype=dtype_jnp),
+        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype_jnp),
+        jnp.array([1.0, -3.0, 0.375, -3.0, 0.75, 0.375], dtype=dtype_jnp),
+        jnp.array([3.1622776601683795, -2.3717082451262845, -2.3717082451262845], dtype=dtype_jnp),
+        jnp.array([-3.3541019662496856, 0.5590169943749476, 3.3541019662496856, -0.5590169943749476], dtype=dtype_jnp),
+        jnp.array([-6.274950199005566, 2.091650066335189], dtype=dtype_jnp),
+        jnp.array([0.739509972887452, -4.437059837324712, 0.739509972887452], dtype=dtype_jnp),
+        jnp.array([0.7015607600201141, -7.015607600201141, 3.5078038001005707], dtype=dtype_jnp),
+        jnp.array([-8.874119674649426, 8.874119674649426], dtype=dtype_jnp),
         jnp.array(
             [-4.183300132670378, 0.5229125165837972, 12.549900398011133, -1.0458250331675945, -1.5687375497513916],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([10.2469507659596, -5.1234753829798, -5.1234753829798], dtype=dtype),
+        jnp.array([10.2469507659596, -5.1234753829798, -5.1234753829798], dtype=dtype_jnp),
         jnp.array(
             [
                 3.872983346207417,
@@ -2371,9 +2376,9 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.9682458365518543,
                 0.4841229182759271,
             ],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([1.0, -5.0, 1.875, -5.0, 3.75, 1.875], dtype=dtype),
+        jnp.array([1.0, -5.0, 1.875, -5.0, 3.75, 1.875], dtype=dtype_jnp),
         jnp.array(
             [
                 3.872983346207417,
@@ -2383,21 +2388,21 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.9682458365518543,
                 0.4841229182759271,
             ],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([-5.1234753829798, 2.5617376914899, 5.1234753829798, -2.5617376914899], dtype=dtype),
+        jnp.array([-5.1234753829798, 2.5617376914899, 5.1234753829798, -2.5617376914899], dtype=dtype_jnp),
         jnp.array(
             [-12.549900398011133, 1.5687375497513916, 4.183300132670378, 1.0458250331675945, -0.5229125165837972],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([2.2185299186623566, -13.311179511974139, 2.2185299186623566], dtype=dtype),
-        jnp.array([3.5078038001005707, -7.015607600201141, 0.7015607600201141], dtype=dtype),
-        jnp.array([4.030159736288377, -13.433865787627923, 4.030159736288377], dtype=dtype),
-        jnp.array([2.3268138086232857, -23.268138086232856, 11.634069043116428], dtype=dtype),
-        jnp.array([-19.843134832984433, 1.9843134832984433, 19.843134832984433, -1.9843134832984433], dtype=dtype),
+        jnp.array([2.2185299186623566, -13.311179511974139, 2.2185299186623566], dtype=dtype_jnp),
+        jnp.array([3.5078038001005707, -7.015607600201141, 0.7015607600201141], dtype=dtype_jnp),
+        jnp.array([4.030159736288377, -13.433865787627923, 4.030159736288377], dtype=dtype_jnp),
+        jnp.array([2.3268138086232857, -23.268138086232856, 11.634069043116428], dtype=dtype_jnp),
+        jnp.array([-19.843134832984433, 1.9843134832984433, 19.843134832984433, -1.9843134832984433], dtype=dtype_jnp),
         jnp.array(
             [-7.245688373094719, 2.7171331399105196, 21.737065119284157, -5.434266279821039, -8.15139941973156],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
         jnp.array(
             [
@@ -2408,16 +2413,16 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 1.8114220932736798,
                 0.9057110466368399,
             ],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
         jnp.array(
             [4.58257569495584, -11.4564392373896, 2.8641098093474, -11.4564392373896, 5.7282196186948, 2.8641098093474],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([1.0, -7.5, 5.625, -0.3125, -7.5, 11.25, -0.9375, 5.625, -0.9375, -0.3125], dtype=dtype),
+        jnp.array([1.0, -7.5, 5.625, -0.3125, -7.5, 11.25, -0.9375, 5.625, -0.9375, -0.3125], dtype=dtype_jnp),
         jnp.array(
             [4.58257569495584, -11.4564392373896, 2.8641098093474, -11.4564392373896, 5.7282196186948, 2.8641098093474],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
         jnp.array(
             [
@@ -2430,11 +2435,11 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 0.45285552331841994,
                 0.45285552331841994,
             ],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
         jnp.array(
             [-21.737065119284157, 8.15139941973156, 7.245688373094719, 5.434266279821039, -2.7171331399105196],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
         jnp.array(
             [
@@ -2446,10 +2451,10 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
                 2.480391854123054,
                 -0.4960783708246108,
             ],
-            dtype=dtype,
+            dtype=dtype_jnp,
         ),
-        jnp.array([11.634069043116428, -23.268138086232856, 2.3268138086232857], dtype=dtype),
-        jnp.array([-0.6716932893813962, 10.075399340720942, -10.075399340720942, 0.6716932893813962], dtype=dtype),
+        jnp.array([11.634069043116428, -23.268138086232856, 2.3268138086232857], dtype=dtype_jnp),
+        jnp.array([-0.6716932893813962, 10.075399340720942, -10.075399340720942, 0.6716932893813962], dtype=dtype_jnp),
     )
 
     S_L_M_EXPS = (
@@ -2575,26 +2580,26 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 @jit
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for Cartesian AOs (contracted)."""
-    dtype = get_dtype("kinetic")
-    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    diff = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
-    R_carts = _R_carts_f64.astype(dtype)
-    c = aos_data._coefficients_jnp.astype(dtype)
-    Z = aos_data._exponents_jnp.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    diff = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    c = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z = aos_data._exponents_jnp.astype(dtype_jnp)
     l = aos_data._angular_momentums_prim_jnp
     nx = aos_data._polynominal_order_x_prim_jnp
     ny = aos_data._polynominal_order_y_prim_jnp
     nz = aos_data._polynominal_order_z_prim_jnp
 
-    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
+    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    eps = get_eps("stabilizing_ao", dtype)
+    eps = get_eps("stabilizing_ao", dtype_jnp)
     x = x + eps
     y = y + eps
     z = z + eps
@@ -2624,24 +2629,23 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
 @jit
 def _compute_AOs_laplacian_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> jax.Array:
     """Analytic Laplacian for spherical AOs (contracted)."""
-    dtype = get_dtype("kinetic")
-    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
-    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    R_carts_unique = aos_data._atomic_center_carts_unique_jnp
+    r_R_diffs = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    r_R_diffs_uq = (r_carts[None, :, :] - R_carts_unique[:, None, :]).astype(dtype_jnp)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = _R_carts_f64.astype(dtype)
-    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
-    c_jnp = aos_data._coefficients_jnp.astype(dtype)
-    Z_jnp = aos_data._exponents_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    l_f64 = l_jnp.astype(dtype)
-    Z_f64 = Z_jnp.astype(dtype)
+    l_f64 = l_jnp.astype(dtype_jnp)
+    Z_f64 = Z_jnp.astype(dtype_jnp)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_f64 + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_f64 + 3.0))
 
@@ -2700,9 +2704,9 @@ def compute_AOs_laplacian(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.
     Raises:
         NotImplementedError: If ``aos_data`` is not Cartesian or spherical.
     """
-    dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-
+    # NOTE: do not pre-cast r_carts here. The analytic kernels reconstruct
+    # ``r - R`` in float64 internally to avoid catastrophic cancellation; a
+    # premature downcast in this wrapper would defeat that guard.
     if isinstance(aos_data, AOs_cart_data):
         return _compute_AOs_laplacian_analytic_cart(aos_data, r_carts)
 
@@ -2755,8 +2759,7 @@ def _compute_S_l_m_debug(
         They can be hardcoded into a code, or they can be computed analytically (e.g., https://en.wikipedia.org/wiki/Solid_harmonics).
         The latter one is the strategy employed in this code,
     """
-    dtype = get_dtype("orb_eval")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("ao_eval")
     R_cart = atomic_center_cart
     x, y, z = np.array(r_cart, dtype=dtype_np) - np.array(R_cart, dtype=dtype_np)
     r_norm = LA.norm(np.array(r_cart, dtype=dtype_np) - np.array(R_cart, dtype=dtype_np))
@@ -2813,8 +2816,9 @@ def _compute_AOs_laplacian_autodiff(aos_data: AOs_sphe_data | AOs_cart_data, r_c
     See compute_AOs_laplacian_api
 
     """
-    dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    # Forward r_carts as-is (Principle 3a — no parameter rebind). compute_AOs's
+    # inner kernels reconstruct r-R in caller-supplied precision and downcast to
+    # the ao_eval zone at the use site; the hessian inherits that dtype.
     # not very fast, but it works.
     ao_matrix_hessian = hessian(compute_AOs, argnums=1)(aos_data, r_carts)
     ao_matrix_laplacian = jnp.einsum("m i i u i u -> mi", ao_matrix_hessian)
@@ -2840,8 +2844,6 @@ def _compute_AOs_laplacian_debug(
             Array containing laplacians of the AOs at r_carts. The dim. is (num_ao, N_e)
 
     """
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32  # noqa: F841
     # Laplacians of AOs (numerical)
     diff_h = 1.0e-5
 
@@ -2890,26 +2892,26 @@ def _compute_AOs_laplacian_debug(
 @jit
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for Cartesian AOs (contracted)."""
-    dtype = get_dtype("kinetic")
-    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    diff = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
-    R_carts = _R_carts_f64.astype(dtype)
-    c = aos_data._coefficients_jnp.astype(dtype)
-    Z = aos_data._exponents_jnp.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    diff = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    c = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z = aos_data._exponents_jnp.astype(dtype_jnp)
     l = aos_data._angular_momentums_prim_jnp
     nx = aos_data._polynominal_order_x_prim_jnp
     ny = aos_data._polynominal_order_y_prim_jnp
     nz = aos_data._polynominal_order_z_prim_jnp
 
-    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype)
+    N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * (8.0 * Z) ** l
     N = jnp.sqrt(N_Z * N_fact)
 
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    eps = get_eps("stabilizing_ao", dtype)
+    eps = get_eps("stabilizing_ao", dtype_jnp)
     x = x + eps
     y = y + eps
     z = z + eps
@@ -2942,24 +2944,23 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
 @jit
 def _compute_AOs_grad_analytic_sphe(aos_data: AOs_sphe_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Analytic gradients for spherical AOs (contracted)."""
-    dtype = get_dtype("kinetic")
-    # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-    _r_carts_f64 = jnp.asarray(r_carts, dtype=jnp.float64)
-    _R_carts_f64 = jnp.asarray(aos_data._atomic_center_carts_prim_jnp, dtype=jnp.float64)
-    _R_carts_unique_f64 = jnp.asarray(aos_data._atomic_center_carts_unique_jnp, dtype=jnp.float64)
-    r_R_diffs = (_r_carts_f64[None, :, :] - _R_carts_f64[:, None, :]).astype(dtype)
-    r_R_diffs_uq = (_r_carts_f64[None, :, :] - _R_carts_unique_f64[:, None, :]).astype(dtype)
-    r_carts = _r_carts_f64.astype(dtype)
+    dtype_jnp = get_dtype_jnp("ao_grad_lap")
+    # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
+    # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
+    # r_carts forwarded as-is (Principle 3a); R_carts read from fp64 storage
+    # accessor on the basis-data dataclass.
+    R_carts = aos_data._atomic_center_carts_prim_jnp
+    R_carts_unique = aos_data._atomic_center_carts_unique_jnp
+    r_R_diffs = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
+    r_R_diffs_uq = (r_carts[None, :, :] - R_carts_unique[:, None, :]).astype(dtype_jnp)
     nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
-    R_carts_jnp = _R_carts_f64.astype(dtype)
-    R_carts_unique_jnp = _R_carts_unique_f64.astype(dtype)
-    c_jnp = aos_data._coefficients_jnp.astype(dtype)
-    Z_jnp = aos_data._exponents_jnp.astype(dtype)
+    c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
+    Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
     m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
-    l_f64 = l_jnp.astype(dtype)
-    Z_f64 = Z_jnp.astype(dtype)
+    l_f64 = l_jnp.astype(dtype_jnp)
+    Z_f64 = Z_jnp.astype(dtype_jnp)
     factorial_l_plus_1 = jnp.exp(jscipy.special.gammaln(l_f64 + 2.0))
     factorial_2l_plus_2 = jnp.exp(jscipy.special.gammaln(2.0 * l_f64 + 3.0))
 
@@ -3026,9 +3027,9 @@ def compute_AOs_grad(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array
     Raises:
         NotImplementedError: If ``aos_data`` is neither Cartesian nor spherical.
     """
-    dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-
+    # NOTE: do not pre-cast r_carts here. The analytic kernels reconstruct
+    # ``r - R`` in float64 internally to avoid catastrophic cancellation; a
+    # premature downcast in this wrapper would defeat that guard.
     if isinstance(aos_data, AOs_cart_data):
         return _compute_AOs_grad_analytic_cart(aos_data, r_carts)
 
@@ -3055,7 +3056,6 @@ def _compute_AOs_grad_autodiff(
         The dim. of each matrix is (num_ao, N_e)
 
     """
-    dtype = get_dtype("kinetic")  # noqa: F841
     grad_full = jacrev(compute_AOs, argnums=1)(aos_data, r_carts)
     grad_diag = jnp.diagonal(grad_full, axis1=1, axis2=2)
     grad_diag = jnp.swapaxes(grad_diag, 1, 2)
@@ -3077,8 +3077,6 @@ def _compute_AOs_grad_debug(
     the given atomic orbital at r_carts using FDM for debugging JAX
     implementations. See compute_AOs_grad_api
     """
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32  # noqa: F841
     # Gradients of AOs (numerical)
     diff_h = 1.0e-5
 

--- a/jqmc/coulomb_potential.py
+++ b/jqmc/coulomb_potential.py
@@ -1167,6 +1167,7 @@ def compute_ecp_local_parts_all_pairs(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_cart,
             i_atom=i_atom,
+            dtype=dtype,
         )
         V_l = (
             jnp.linalg.norm(rel_R_cart_min_dist) ** -2.0
@@ -1213,10 +1214,11 @@ def compute_ecp_local_parts_all_pairs(
     r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
     r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
 
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     i_atom_np = np.array(coulomb_potential_data._nucleus_index_local_part)
-    exponent_np = np.array(coulomb_potential_data._exponents_local_part)
-    coefficient_np = np.array(coulomb_potential_data._coefficients_local_part)
-    power_np = np.array(coulomb_potential_data._powers_local_part)
+    exponent_np = np.array(coulomb_potential_data._exponents_local_part, dtype=dtype_np)
+    coefficient_np = np.array(coulomb_potential_data._coefficients_local_part, dtype=dtype_np)
+    power_np = np.array(coulomb_potential_data._powers_local_part, dtype=dtype_np)
 
     V_ecp_up = jnp.sum(
         vmap_vmap_compute_ecp_up(
@@ -1349,6 +1351,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
                     structure_data=coulomb_potential_data.structure_data,
                     r_cart=r_cart,
                     i_atom=i_atom,
+                    dtype=dtype,
                 )
             )(i_atom_list)
 
@@ -1576,6 +1579,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
                     structure_data=coulomb_potential_data.structure_data,
                     r_cart=r_cart,
                     i_atom=i_atom,
+                    dtype=dtype,
                 )
             )(i_atom_list)
 
@@ -1859,6 +1863,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_cart,
             i_atom=i_atom,
+            dtype=dtype,
         )
         V_l = (
             jnp.linalg.norm(rel_R_cart_min_dist) ** -2.0
@@ -1877,6 +1882,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_up_cart,
             i_atom=i_atom,
+            dtype=dtype,
         )
         r_up_carts_on_mesh = r_up_carts
         r_up_carts_on_mesh = r_up_carts_on_mesh.at[r_up_i].set(
@@ -1897,6 +1903,9 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
         det_numerator_up = compute_det_geminal_all_elements(wavefunction_data.geminal_data, r_up_carts_on_mesh, r_dn_carts)
 
         wf_ratio_up = jnp.exp(jastrow_numerator_up - jastrow_denominator) * det_numerator_up / det_denominator
+        # Cast back to coulomb zone: det/jastrow live in fp64 zones and would otherwise
+        # promote the entire P_l / V_ecp output to fp64.
+        wf_ratio_up = jnp.asarray(wf_ratio_up, dtype=dtype)
 
         P_l_up = (2 * ang_mom + 1) * jnp_legendre_tablated(ang_mom, cos_theta_up) * weight * wf_ratio_up
 
@@ -1910,6 +1919,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_dn_cart,
             i_atom=i_atom,
+            dtype=dtype,
         )
         r_dn_carts_on_mesh = r_dn_carts
         r_dn_carts_on_mesh = r_dn_carts_on_mesh.at[r_dn_i].set(
@@ -1930,6 +1940,8 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
         det_numerator_dn = compute_det_geminal_all_elements(wavefunction_data.geminal_data, r_up_carts, r_dn_carts_on_mesh)
 
         wf_ratio_dn = jnp.exp(jastrow_numerator_dn - jastrow_denominator) * det_numerator_dn / det_denominator
+        # Cast back to coulomb zone (see compute_P_l_up).
+        wf_ratio_dn = jnp.asarray(wf_ratio_dn, dtype=dtype)
 
         P_l_dn = (2 * ang_mom + 1) * jnp_legendre_tablated(ang_mom, cos_theta_dn) * weight * wf_ratio_dn
         return r_dn_carts_on_mesh, P_l_dn
@@ -2005,9 +2017,9 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
 
     i_atom_np = jnp.array(coulomb_potential_data._nucleus_index_non_local_part)
     ang_mom_np = jnp.array(coulomb_potential_data._ang_mom_non_local_part)
-    exponent_np = jnp.array(coulomb_potential_data._exponents_non_local_part)
-    coefficient_np = jnp.array(coulomb_potential_data._coefficients_non_local_part)
-    power_np = jnp.array(coulomb_potential_data._powers_non_local_part)
+    exponent_np = jnp.array(coulomb_potential_data._exponents_non_local_part, dtype=dtype)
+    coefficient_np = jnp.array(coulomb_potential_data._coefficients_non_local_part, dtype=dtype)
+    power_np = jnp.array(coulomb_potential_data._powers_non_local_part, dtype=dtype)
 
     r_up_carts_on_mesh, V_ecp_up = vmap_vmap_compute_ecp_up(
         r_up_i_jnp,
@@ -2242,7 +2254,7 @@ def compute_bare_coulomb_potential_el_ion_element_wise(
     dtype = get_dtype("coulomb")
     dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
-    R_charges = np.array(coulomb_potential_data._effective_charges)
+    R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
     r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
     r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
@@ -2287,7 +2299,7 @@ def compute_discretized_bare_coulomb_potential_el_ion_element_wise(
     dtype = get_dtype("coulomb")
     dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
-    R_charges = np.array(coulomb_potential_data._effective_charges)
+    R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
     r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
     r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
@@ -2457,8 +2469,9 @@ def compute_bare_coulomb_potential_ion_ion(
         float: Ion–ion Coulomb energy.
     """
     dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
-    R_charges = np.array(coulomb_potential_data._effective_charges)
+    R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
 
     all_charges = R_charges
     all_carts = R_carts

--- a/jqmc/coulomb_potential.py
+++ b/jqmc/coulomb_potential.py
@@ -3,6 +3,11 @@
 Module containing classes and methods related to Effective core potential
 and bare Coulomb potentials
 
+Precision Zones:
+    - ``coulomb``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+
 Todo:
     Remove the native 'for' loops for up and down electron positions in the function
     '_compute_ecp_non_local_parts_NN_jax' and replace them with e.g., jax.lax.scan.
@@ -63,6 +68,7 @@ from .determinant import (
 )
 from ._function_collections import _legendre_tablated as jnp_legendre_tablated
 from .jastrow_factor import _compute_ratio_Jastrow_part_split_spin, compute_Jastrow_part
+from ._precision import get_dtype
 from ._setting import NN_default, Nv_default
 from .structure import (
     Structure_data,
@@ -606,6 +612,11 @@ def _compute_ecp_local_parts_all_pairs_debug(
     Returns:
         float: The sum of local part of the given ECPs with r_up_carts and r_dn_carts.
     """
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+
     V_local = 0.0
     for i_atom in range(coulomb_potential_data.structure_data.natom):
         max_ang_mom_plus_1 = coulomb_potential_data.max_ang_mom_plus_1[i_atom]
@@ -675,6 +686,12 @@ def _compute_ecp_non_local_parts_all_pairs_debug(
         list[float]: The list of non-local part of the given ECPs with r_up_carts and r_dn_carts.
         float: sum of the V_nonlocal
     """
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    RT = np.asarray(RT, dtype=dtype_np)
+
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
         grid_points = tetrahedron_sym_mesh_Nv4.grid_points
@@ -858,6 +875,12 @@ def _compute_ecp_non_local_parts_nearest_neighbors_debug(
         list[float]: The list of non-local part of the given ECPs with r_up_carts and r_dn_carts.
         float: sum of the V_nonlocal
     """
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    RT = np.asarray(RT, dtype=dtype_np)
+
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
         grid_points = tetrahedron_sym_mesh_Nv4.grid_points
@@ -1094,6 +1117,12 @@ def _compute_ecp_coulomb_potential_debug(
     Returns:
         float: The sum of non-local part of the given ECPs with r_up_carts and r_dn_carts.
     """
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    RT = np.asarray(RT, dtype=dtype_np)
+
     ecp_local_parts = _compute_ecp_local_parts_all_pairs_debug(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
     )
@@ -1180,8 +1209,9 @@ def compute_ecp_local_parts_all_pairs(
     )
 
     # Vectrized (flatten) arguments are prepared here.
-    r_up_carts_jnp = jnp.array(r_up_carts)
-    r_dn_carts_jnp = jnp.array(r_dn_carts)
+    dtype = get_dtype("coulomb")
+    r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
 
     i_atom_np = np.array(coulomb_potential_data._nucleus_index_local_part)
     exponent_np = np.array(coulomb_potential_data._exponents_local_part)
@@ -1243,18 +1273,23 @@ def compute_ecp_non_local_parts_nearest_neighbors(
             - Non-local ECP contributions per configuration (flattened).
             - Scalar sum of all non-local contributions.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     if Nv == 4:
-        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights)
-        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points)
+        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype)
+        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype)
     elif Nv == 6:
-        weights = jnp.array(octahedron_sym_mesh_Nv6.weights)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points)
+        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype)
     elif Nv == 12:
-        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights)
-        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points)
+        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype)
+        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype)
     elif Nv == 18:
-        weights = jnp.array(octahedron_sym_mesh_Nv18.weights)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points)
+        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype)
     else:
         raise NotImplementedError
 
@@ -1266,8 +1301,8 @@ def compute_ecp_non_local_parts_nearest_neighbors(
     global_max_ang_mom_plus_1 = coulomb_potential_data._global_max_ang_mom_plus_1
 
     # stored
-    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3))
-    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3))
+    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype)
+    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype)
     # cos_theta_all = jnp.zeros((0,))
     # weight_all = jnp.zeros((0,))
     # V_l_mapped_all = jnp.zeros((global_max_ang_mom_plus_1, 0))
@@ -1293,11 +1328,11 @@ def compute_ecp_non_local_parts_nearest_neighbors(
         n_other = other_carts.shape[0]
         if n_spin == 0:
             return (
-                jnp.zeros((0, n_spin, 3)),
-                jnp.zeros((0, n_other, 3)),
-                jnp.zeros((n_spin, 0, global_max_ang_mom_plus_1)),
-                jnp.zeros((0,)),
-                jnp.zeros((0,)),
+                jnp.zeros((0, n_spin, 3), dtype=dtype),
+                jnp.zeros((0, n_other, 3), dtype=dtype),
+                jnp.zeros((n_spin, 0, global_max_ang_mom_plus_1), dtype=dtype),
+                jnp.zeros((0,), dtype=dtype),
+                jnp.zeros((0,), dtype=dtype),
             )
 
         i_atom_lists = vmap(
@@ -1328,7 +1363,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
         base = r_carts[None, None, None, :, :]
         r_carts_on_mesh = base + delta_full  # (n_spin, NN, Nv, n_spin, 3)
         if n_other == 0:
-            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3))
+            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype)
         else:
             other_carts_on_mesh = jnp.broadcast_to(other_carts, (n_spin, NN, grid_points.shape[0], n_other, 3))
 
@@ -1350,7 +1385,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
 
         r_mesh = r_carts_on_mesh.reshape(-1, n_spin, 3)
         if n_other == 0:
-            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3))
+            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype)
         else:
             other_mesh = other_carts_on_mesh.reshape(-1, n_other, 3)
         return r_mesh, other_mesh, V_l_mapped, cos_theta.reshape(-1), weight.reshape(-1)
@@ -1465,18 +1500,23 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         used in the MCMC loop.  Passing an inverse from a different configuration
         silently produces incorrect non-local ECP contributions.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     if Nv == 4:
-        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights)
-        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points)
+        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype)
+        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype)
     elif Nv == 6:
-        weights = jnp.array(octahedron_sym_mesh_Nv6.weights)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points)
+        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype)
     elif Nv == 12:
-        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights)
-        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points)
+        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype)
+        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype)
     elif Nv == 18:
-        weights = jnp.array(octahedron_sym_mesh_Nv18.weights)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points)
+        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype)
     else:
         raise NotImplementedError
 
@@ -1488,8 +1528,8 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
     global_max_ang_mom_plus_1 = coulomb_potential_data._global_max_ang_mom_plus_1
 
     # stored
-    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3))
-    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3))
+    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype)
+    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype)
     # cos_theta_all = jnp.zeros((0,))
     # weight_all = jnp.zeros((0,))
     # V_l_mapped_all = jnp.zeros((global_max_ang_mom_plus_1, 0))
@@ -1515,11 +1555,11 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         n_other = other_carts.shape[0]
         if n_spin == 0:
             return (
-                jnp.zeros((0, n_spin, 3)),
-                jnp.zeros((0, n_other, 3)),
-                jnp.zeros((global_max_ang_mom_plus_1, 0)),
-                jnp.zeros((0,)),
-                jnp.zeros((0,)),
+                jnp.zeros((0, n_spin, 3), dtype=dtype),
+                jnp.zeros((0, n_other, 3), dtype=dtype),
+                jnp.zeros((global_max_ang_mom_plus_1, 0), dtype=dtype),
+                jnp.zeros((0,), dtype=dtype),
+                jnp.zeros((0,), dtype=dtype),
             )
 
         i_atom_lists = vmap(
@@ -1550,7 +1590,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         base = r_carts[None, None, None, :, :]
         r_carts_on_mesh = base + delta_full  # (n_spin, NN, Nv, n_spin, 3)
         if n_other == 0:
-            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3))
+            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype)
         else:
             other_carts_on_mesh = jnp.broadcast_to(other_carts, (n_spin, NN, grid_points.shape[0], n_other, 3))
 
@@ -1574,7 +1614,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
 
         r_mesh = r_carts_on_mesh.reshape(-1, n_spin, 3)
         if n_other == 0:
-            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3))
+            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype)
         else:
             other_mesh = other_carts_on_mesh.reshape(-1, n_other, 3)
         return r_mesh, other_mesh, V_l_all, cos_theta.reshape(-1), weight.reshape(-1)
@@ -1662,6 +1702,11 @@ def compute_ecp_non_local_parts_all_pairs(
             - Non-local ECP contributions per configuration (flattened).
             - Scalar sum of all non-local contributions.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
         grid_points = tetrahedron_sym_mesh_Nv4.grid_points
@@ -1793,8 +1838,11 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
     """
     # V_l_cutoff = 1e-5
 
-    weights = jnp.array(weights)
-    grid_points = jnp.array(grid_points)
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    weights = jnp.array(weights, dtype=dtype)
+    grid_points = jnp.array(grid_points, dtype=dtype)
 
     jastrow_denominator = lax.switch(
         flag_determinant_only,
@@ -1951,9 +1999,9 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
 
     # Vectrized (flatten) arguments are prepared here.
     r_up_i_jnp = jnp.arange(len(r_up_carts))
-    r_up_carts_jnp = jnp.array(r_up_carts)
+    r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
     r_dn_i_jnp = jnp.arange(len(r_dn_carts))
-    r_dn_carts_jnp = jnp.array(r_dn_carts)
+    r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
 
     i_atom_np = jnp.array(coulomb_potential_data._nucleus_index_non_local_part)
     ang_mom_np = jnp.array(coulomb_potential_data._ang_mom_non_local_part)
@@ -2010,6 +2058,11 @@ def compute_ecp_coulomb_potential(
     Returns:
         float: Sum of local and non-local ECP contributions for the given geometry.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     ecp_local_parts = compute_ecp_local_parts_all_pairs(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
     )
@@ -2081,6 +2134,11 @@ def compute_ecp_coulomb_potential_fast(
         :func:`compute_ecp_non_local_parts_nearest_neighbors_fast_update` becomes incorrect
         and the non-local ratios will be silently wrong.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     ecp_local_parts = compute_ecp_local_parts_all_pairs(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
     )
@@ -2108,6 +2166,11 @@ def _compute_bare_coulomb_potential_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See compute_bare_coulomb_potential_api."""
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+
     R_carts = coulomb_potential_data.structure_data._positions_cart_np
     R_charges = coulomb_potential_data._effective_charges
     r_up_charges = [-1 for _ in range(len(r_up_carts))]
@@ -2142,6 +2205,10 @@ def compute_bare_coulomb_potential(
     Returns:
         float: Total bare Coulomb energy.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     interactions_ion_ion = compute_bare_coulomb_potential_ion_ion(coulomb_potential_data)
     interactions_el_ion_elements_up, interactions_el_ion_elements_dn = compute_bare_coulomb_potential_el_ion_element_wise(
         coulomb_potential_data, r_up_carts, r_dn_carts
@@ -2172,13 +2239,15 @@ def compute_bare_coulomb_potential_el_ion_element_wise(
     Returns:
         tuple[jax.Array, jax.Array]: Element-wise ion–electron interactions for up spins and down spins (shape ``(N_up,)`` and ``(N_dn,)``).
     """
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp)
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
     R_charges = np.array(coulomb_potential_data._effective_charges)
-    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=np.float64)
-    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=np.float64)
+    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
+    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
-    r_up_carts = jnp.array(r_up_carts)
-    r_dn_carts = jnp.array(r_dn_carts)
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j):
@@ -2215,13 +2284,15 @@ def compute_discretized_bare_coulomb_potential_el_ion_element_wise(
     Returns:
         tuple[jax.Array, jax.Array]: Element-wise ion–electron interactions for up spins and down spins (shape ``(N_up,)`` and ``(N_dn,)``).
     """
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp)
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
     R_charges = np.array(coulomb_potential_data._effective_charges)
-    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=np.float64)
-    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=np.float64)
+    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
+    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
-    r_up_carts = jnp.array(r_up_carts)
-    r_dn_carts = jnp.array(r_dn_carts)
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j, alat):
@@ -2248,6 +2319,11 @@ def _compute_bare_coulomb_potential_el_ion_element_wise_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """See compute_bare_coulomb_potential_api."""
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+
     R_carts = coulomb_potential_data.structure_data._positions_cart_np
     R_charges = coulomb_potential_data._effective_charges
     r_up_charges = [-1 for _ in range(len(r_up_carts))]
@@ -2282,6 +2358,11 @@ def _compute_discretized_bare_coulomb_potential_el_ion_element_wise_debug(
     alat: float,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """See compute_bare_coulomb_potential_api."""
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+
     R_carts = coulomb_potential_data.structure_data._positions_cart_np
     R_charges = coulomb_potential_data._effective_charges
     r_up_charges = [-1 for _ in range(len(r_up_carts))]
@@ -2323,11 +2404,13 @@ def compute_bare_coulomb_potential_el_el(
     Returns:
         float: Electron–electron Coulomb energy.
     """
-    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=np.float64)
-    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=np.float64)
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
+    r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
-    r_up_carts = jnp.array(r_up_carts)
-    r_dn_carts = jnp.array(r_dn_carts)
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     all_charges = np.hstack([r_up_charges, r_dn_charges])
     all_carts = jnp.vstack([r_up_carts, r_dn_carts])
@@ -2373,7 +2456,8 @@ def compute_bare_coulomb_potential_ion_ion(
     Returns:
         float: Ion–ion Coulomb energy.
     """
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp)
+    dtype = get_dtype("coulomb")
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
     R_charges = np.array(coulomb_potential_data._effective_charges)
 
     all_charges = R_charges
@@ -2424,6 +2508,10 @@ def compute_bare_coulomb_potential_el_ion(
     Returns:
         float: Electron–ion Coulomb energy.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     interactions_el_ion_elements_up, interactions_el_ion_elements_dn = compute_bare_coulomb_potential_el_ion_element_wise(
         coulomb_potential_data, r_up_carts, r_dn_carts
     )
@@ -2441,6 +2529,12 @@ def _compute_coulomb_potential_debug(
     wavefunction_data: Wavefunction_data = None,
 ) -> float:
     """See compute_coulomb_potential_api."""
+    dtype = get_dtype("coulomb")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    RT = np.asarray(RT, dtype=dtype_np)
+
     # all-electron
     if not coulomb_potential_data.ecp_flag:
         bare_coulomb_potential = _compute_bare_coulomb_potential_debug(
@@ -2494,6 +2588,11 @@ def compute_coulomb_potential(
     Returns:
         float: Sum of bare Coulomb (ion–ion, electron–ion, electron–electron) and ECP (local + non-local) energies.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     # all-electron
     if not coulomb_potential_data.ecp_flag:
         bare_coulomb_potential = compute_bare_coulomb_potential(
@@ -2559,6 +2658,11 @@ def compute_coulomb_potential_fast(
         electrons have moved simultaneously the underlying Sherman–Morrison rank-1 update is
         incorrect and non-local ratios will be silently wrong.
     """
+    dtype = get_dtype("coulomb")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    RT = jnp.asarray(RT, dtype=dtype)
+
     # all-electron — no ECP, no need for A_old_inv
     if not coulomb_potential_data.ecp_flag:
         bare_coulomb_potential = compute_bare_coulomb_potential(

--- a/jqmc/coulomb_potential.py
+++ b/jqmc/coulomb_potential.py
@@ -2263,7 +2263,9 @@ def compute_bare_coulomb_potential_el_ion_element_wise(
 
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j):
-        distance = jnp.linalg.norm(r_i - r_j, axis=1)
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        distance = jnp.linalg.norm(diff, axis=1)
         interaction = (Z_i * Z_j) / distance
         return interaction
 
@@ -2308,7 +2310,9 @@ def compute_discretized_bare_coulomb_potential_el_ion_element_wise(
 
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j, alat):
-        distance = jnp.maximum(jnp.linalg.norm(r_i - r_j, axis=1), alat)
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        distance = jnp.maximum(jnp.linalg.norm(diff, axis=1), alat)
         interaction = (Z_i * Z_j) / distance
         return interaction
 
@@ -2443,7 +2447,9 @@ def compute_bare_coulomb_potential_el_el(
 
     # Define a function to compute interaction for a pair
     def el_el_interaction(Z_i, Z_j, r_i, r_j):
-        distance = jnp.linalg.norm(r_i - r_j)
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        distance = jnp.linalg.norm(diff)
         interaction = (Z_i * Z_j) / distance
         return interaction
 
@@ -2492,7 +2498,9 @@ def compute_bare_coulomb_potential_ion_ion(
 
     # Define a function to compute interaction for a pair
     def ion_ion_interaction(Z_i, Z_j, r_i, r_j):
-        distance = jnp.linalg.norm(r_i - r_j)
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        distance = jnp.linalg.norm(diff)
         interaction = (Z_i * Z_j) / distance
         return interaction
 

--- a/jqmc/coulomb_potential.py
+++ b/jqmc/coulomb_potential.py
@@ -61,15 +61,15 @@ from jax import jit, lax, vmap
 from jax.scipy import linalg as jsp_linalg
 from scipy.special import eval_legendre
 
+from ._function_collections import _legendre_tablated as jnp_legendre_tablated
+from ._precision import get_dtype_jnp, get_dtype_np
+from ._setting import NN_default, Nv_default
 from .determinant import (
     _compute_ratio_determinant_part_split_spin,
     compute_det_geminal_all_elements,
     compute_geminal_all_elements,
 )
-from ._function_collections import _legendre_tablated as jnp_legendre_tablated
 from .jastrow_factor import _compute_ratio_Jastrow_part_split_spin, compute_Jastrow_part
-from ._precision import get_dtype
-from ._setting import NN_default, Nv_default
 from .structure import (
     Structure_data,
     _find_nearest_nucleus_indices_jnp,
@@ -612,10 +612,9 @@ def _compute_ecp_local_parts_all_pairs_debug(
     Returns:
         float: The sum of local part of the given ECPs with r_up_carts and r_dn_carts.
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). The
+    # accumulated scalar V_local is cast to the coulomb zone before return.
+    dtype_np = get_dtype_np("coulomb")
 
     V_local = 0.0
     for i_atom in range(coulomb_potential_data.structure_data.natom):
@@ -654,7 +653,8 @@ def _compute_ecp_local_parts_all_pairs_debug(
                     for a, n, b in zip(coefficients, powers, exponents, strict=True)
                 ]
             )
-    return V_local
+    # Cast accumulator to coulomb zone (Principle 3b).
+    return np.asarray(V_local, dtype=dtype_np)
 
 
 def _compute_ecp_non_local_parts_all_pairs_debug(
@@ -686,11 +686,9 @@ def _compute_ecp_non_local_parts_all_pairs_debug(
         list[float]: The list of non-local part of the given ECPs with r_up_carts and r_dn_carts.
         float: sum of the V_nonlocal
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-    RT = np.asarray(RT, dtype=dtype_np)
+    # Forward r_up/dn_carts/RT as-is (Principle 3a — no parameter rebind).
+    # Cast RT to coulomb zone at the use site (the grid_points rotation below).
+    dtype_np = get_dtype_np("coulomb")  # noqa: F841
 
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
@@ -707,7 +705,8 @@ def _compute_ecp_non_local_parts_all_pairs_debug(
     else:
         raise NotImplementedError
 
-    grid_points = grid_points @ RT  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
+    # Cast RT to coulomb zone at the use site (Principle 3b).
+    grid_points = grid_points @ np.asarray(RT, dtype=dtype_np)  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
 
     mesh_non_local_ecp_part = []
     V_nonlocal = []
@@ -875,11 +874,9 @@ def _compute_ecp_non_local_parts_nearest_neighbors_debug(
         list[float]: The list of non-local part of the given ECPs with r_up_carts and r_dn_carts.
         float: sum of the V_nonlocal
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-    RT = np.asarray(RT, dtype=dtype_np)
+    # Forward r_up/dn_carts/RT as-is (Principle 3a — no parameter rebind).
+    # Cast RT to coulomb zone at the use site (the grid_points rotation below).
+    dtype_np = get_dtype_np("coulomb")  # noqa: F841
 
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
@@ -896,7 +893,8 @@ def _compute_ecp_non_local_parts_nearest_neighbors_debug(
     else:
         raise NotImplementedError
 
-    grid_points = grid_points @ RT  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
+    # Cast RT to coulomb zone at the use site (Principle 3b).
+    grid_points = grid_points @ np.asarray(RT, dtype=dtype_np)  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
 
     V_nonlocal = []
     sum_V_nonlocal = 0.0
@@ -1117,11 +1115,7 @@ def _compute_ecp_coulomb_potential_debug(
     Returns:
         float: The sum of non-local part of the given ECPs with r_up_carts and r_dn_carts.
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-    RT = np.asarray(RT, dtype=dtype_np)
+    # Forward r_up/dn_carts/RT as-is (Principle 3a — no parameter rebind).
 
     ecp_local_parts = _compute_ecp_local_parts_all_pairs_debug(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
@@ -1167,7 +1161,7 @@ def compute_ecp_local_parts_all_pairs(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_cart,
             i_atom=i_atom,
-            dtype=dtype,
+            dtype=dtype_jnp,
         )
         V_l = (
             jnp.linalg.norm(rel_R_cart_min_dist) ** -2.0
@@ -1210,11 +1204,14 @@ def compute_ecp_local_parts_all_pairs(
     )
 
     # Vectrized (flatten) arguments are prepared here.
-    dtype = get_dtype("coulomb")
-    r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here. _get_min_dist_rel_R_cart_jnp
+    # (called inside compute_V_l) reconstructs R - r in fp64 internally; pre-casting to
+    # fp32 here would destroy precision before that reconstruction.
+    dtype_jnp = get_dtype_jnp("coulomb")
+    r_up_carts_jnp = r_up_carts
+    r_dn_carts_jnp = r_dn_carts
 
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("coulomb")
     i_atom_np = np.array(coulomb_potential_data._nucleus_index_local_part)
     exponent_np = np.array(coulomb_potential_data._exponents_local_part, dtype=dtype_np)
     coefficient_np = np.array(coulomb_potential_data._coefficients_local_part, dtype=dtype_np)
@@ -1275,27 +1272,29 @@ def compute_ecp_non_local_parts_nearest_neighbors(
             - Non-local ECP contributions per configuration (flattened).
             - Scalar sum of all non-local contributions.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here. They are forwarded to
+    # compute_Jastrow_part / compute_det_geminal_all_elements (fp64 zones); pre-casting
+    # to the coulomb (fp32) zone would silently down-cast inputs to those fp64 zones.
+    # RT is also forwarded as-is (Principle 3a); cast at the use site below.
+    dtype_jnp = get_dtype_jnp("coulomb")
 
     if Nv == 4:
-        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype)
-        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype)
+        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype_jnp)
     elif Nv == 6:
-        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype)
+        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype_jnp)
     elif Nv == 12:
-        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype)
-        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype)
+        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype_jnp)
     elif Nv == 18:
-        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype)
+        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype_jnp)
     else:
         raise NotImplementedError
 
-    grid_points = grid_points @ RT  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
+    # Cast RT to coulomb zone at the use site (Principle 3b).
+    grid_points = grid_points @ RT.astype(dtype_jnp)  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
     grid_norm = jnp.linalg.norm(grid_points, axis=1, keepdims=True)
 
     # jnp variables
@@ -1303,8 +1302,8 @@ def compute_ecp_non_local_parts_nearest_neighbors(
     global_max_ang_mom_plus_1 = coulomb_potential_data._global_max_ang_mom_plus_1
 
     # stored
-    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype)
-    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype)
+    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype_jnp)
+    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype_jnp)
     # cos_theta_all = jnp.zeros((0,))
     # weight_all = jnp.zeros((0,))
     # V_l_mapped_all = jnp.zeros((global_max_ang_mom_plus_1, 0))
@@ -1330,11 +1329,11 @@ def compute_ecp_non_local_parts_nearest_neighbors(
         n_other = other_carts.shape[0]
         if n_spin == 0:
             return (
-                jnp.zeros((0, n_spin, 3), dtype=dtype),
-                jnp.zeros((0, n_other, 3), dtype=dtype),
-                jnp.zeros((n_spin, 0, global_max_ang_mom_plus_1), dtype=dtype),
-                jnp.zeros((0,), dtype=dtype),
-                jnp.zeros((0,), dtype=dtype),
+                jnp.zeros((0, n_spin, 3), dtype=dtype_jnp),
+                jnp.zeros((0, n_other, 3), dtype=dtype_jnp),
+                jnp.zeros((n_spin, 0, global_max_ang_mom_plus_1), dtype=dtype_jnp),
+                jnp.zeros((0,), dtype=dtype_jnp),
+                jnp.zeros((0,), dtype=dtype_jnp),
             )
 
         i_atom_lists = vmap(
@@ -1351,7 +1350,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
                     structure_data=coulomb_potential_data.structure_data,
                     r_cart=r_cart,
                     i_atom=i_atom,
-                    dtype=dtype,
+                    dtype=dtype_jnp,
                 )
             )(i_atom_list)
 
@@ -1366,7 +1365,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
         base = r_carts[None, None, None, :, :]
         r_carts_on_mesh = base + delta_full  # (n_spin, NN, Nv, n_spin, 3)
         if n_other == 0:
-            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype)
+            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype_jnp)
         else:
             other_carts_on_mesh = jnp.broadcast_to(other_carts, (n_spin, NN, grid_points.shape[0], n_other, 3))
 
@@ -1388,7 +1387,7 @@ def compute_ecp_non_local_parts_nearest_neighbors(
 
         r_mesh = r_carts_on_mesh.reshape(-1, n_spin, 3)
         if n_other == 0:
-            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype)
+            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype_jnp)
         else:
             other_mesh = other_carts_on_mesh.reshape(-1, n_other, 3)
         return r_mesh, other_mesh, V_l_mapped, cos_theta.reshape(-1), weight.reshape(-1)
@@ -1417,6 +1416,12 @@ def compute_ecp_non_local_parts_nearest_neighbors(
         wavefunction_data.geminal_data, non_local_ecp_part_r_carts_up, non_local_ecp_part_r_carts_dn
     )
 
+    # Cast all ratio inputs to the local coulomb zone dtype before arithmetic.
+    # This follows the consumer-zone rule and avoids any implicit promotion.
+    jastrow_x = jnp.asarray(jastrow_x, dtype=dtype_jnp)
+    jastrow_xp = jnp.asarray(jastrow_xp, dtype=dtype_jnp)
+    det_x = jnp.asarray(det_x, dtype=dtype_jnp)
+    det_xp = jnp.asarray(det_xp, dtype=dtype_jnp)
     wf_ratio_all = jnp.exp(jastrow_xp - jastrow_x) * det_xp / det_x
 
     # Split ratios for up/dn blocks to avoid big concat of V_l / cos / weight.
@@ -1503,27 +1508,27 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         used in the MCMC loop.  Passing an inverse from a different configuration
         silently produces incorrect non-local ECP contributions.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here (forwarded to fp64 Jastrow/det zones).
+    # RT is also forwarded as-is (Principle 3a); cast at the use site below.
+    dtype_jnp = get_dtype_jnp("coulomb")
 
     if Nv == 4:
-        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype)
-        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype)
+        weights = jnp.array(tetrahedron_sym_mesh_Nv4.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(tetrahedron_sym_mesh_Nv4.grid_points, dtype=dtype_jnp)
     elif Nv == 6:
-        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype)
+        weights = jnp.array(octahedron_sym_mesh_Nv6.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv6.grid_points, dtype=dtype_jnp)
     elif Nv == 12:
-        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype)
-        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype)
+        weights = jnp.array(icosahedron_sym_mesh_Nv12.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(icosahedron_sym_mesh_Nv12.grid_points, dtype=dtype_jnp)
     elif Nv == 18:
-        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype)
-        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype)
+        weights = jnp.array(octahedron_sym_mesh_Nv18.weights, dtype=dtype_jnp)
+        grid_points = jnp.array(octahedron_sym_mesh_Nv18.grid_points, dtype=dtype_jnp)
     else:
         raise NotImplementedError
 
-    grid_points = grid_points @ RT  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
+    # Cast RT to coulomb zone at the use site (Principle 3b).
+    grid_points = grid_points @ RT.astype(dtype_jnp)  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
     grid_norm = jnp.linalg.norm(grid_points, axis=1, keepdims=True)
 
     # jnp variables
@@ -1531,8 +1536,8 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
     global_max_ang_mom_plus_1 = coulomb_potential_data._global_max_ang_mom_plus_1
 
     # stored
-    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype)
-    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype)
+    non_local_ecp_part_r_carts_up = jnp.zeros((0, len(r_up_carts), 3), dtype=dtype_jnp)
+    non_local_ecp_part_r_carts_dn = jnp.zeros((0, len(r_dn_carts), 3), dtype=dtype_jnp)
     # cos_theta_all = jnp.zeros((0,))
     # weight_all = jnp.zeros((0,))
     # V_l_mapped_all = jnp.zeros((global_max_ang_mom_plus_1, 0))
@@ -1558,11 +1563,11 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         n_other = other_carts.shape[0]
         if n_spin == 0:
             return (
-                jnp.zeros((0, n_spin, 3), dtype=dtype),
-                jnp.zeros((0, n_other, 3), dtype=dtype),
-                jnp.zeros((global_max_ang_mom_plus_1, 0), dtype=dtype),
-                jnp.zeros((0,), dtype=dtype),
-                jnp.zeros((0,), dtype=dtype),
+                jnp.zeros((0, n_spin, 3), dtype=dtype_jnp),
+                jnp.zeros((0, n_other, 3), dtype=dtype_jnp),
+                jnp.zeros((global_max_ang_mom_plus_1, 0), dtype=dtype_jnp),
+                jnp.zeros((0,), dtype=dtype_jnp),
+                jnp.zeros((0,), dtype=dtype_jnp),
             )
 
         i_atom_lists = vmap(
@@ -1579,7 +1584,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
                     structure_data=coulomb_potential_data.structure_data,
                     r_cart=r_cart,
                     i_atom=i_atom,
-                    dtype=dtype,
+                    dtype=dtype_jnp,
                 )
             )(i_atom_list)
 
@@ -1594,7 +1599,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         base = r_carts[None, None, None, :, :]
         r_carts_on_mesh = base + delta_full  # (n_spin, NN, Nv, n_spin, 3)
         if n_other == 0:
-            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype)
+            other_carts_on_mesh = jnp.zeros((n_spin, NN, grid_points.shape[0], 0, 3), dtype=dtype_jnp)
         else:
             other_carts_on_mesh = jnp.broadcast_to(other_carts, (n_spin, NN, grid_points.shape[0], n_other, 3))
 
@@ -1618,7 +1623,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
 
         r_mesh = r_carts_on_mesh.reshape(-1, n_spin, 3)
         if n_other == 0:
-            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype)
+            other_mesh = jnp.zeros((r_mesh.shape[0], 0, 3), dtype=dtype_jnp)
         else:
             other_mesh = other_carts_on_mesh.reshape(-1, n_other, 3)
         return r_mesh, other_mesh, V_l_all, cos_theta.reshape(-1), weight.reshape(-1)
@@ -1640,6 +1645,9 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
         new_r_up_shifted=up_mesh_r_up,
         new_r_dn_shifted=dn_mesh_r_dn,
     )
+    # Cast determinant/Jastrow ratio terms to the local coulomb zone dtype
+    # before downstream contractions; avoid relying on implicit promotion.
+    det_ratio = jnp.asarray(det_ratio, dtype=dtype_jnp)
     if flag_determinant_only:
         wf_ratio_all = det_ratio
     else:
@@ -1650,6 +1658,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
             new_r_up_shifted=up_mesh_r_up,
             new_r_dn_shifted=dn_mesh_r_dn,
         )
+        jastrow_ratio = jnp.asarray(jastrow_ratio, dtype=dtype_jnp)
         wf_ratio_all = det_ratio * jastrow_ratio
 
     # Split ratios for up/dn blocks to avoid big concat of V_l / cos / weight.
@@ -1660,7 +1669,7 @@ def compute_ecp_non_local_parts_nearest_neighbors_fast_update(
     def _contract_chunk(V_l_chunk, cos_chunk, weight_chunk, wf_ratio_chunk):
         cos_chunk = jnp.array(cos_chunk)
         weight_chunk = jnp.array(weight_chunk)
-        wf_ratio_chunk = jnp.array(wf_ratio_chunk)
+        wf_ratio_chunk = jnp.array(wf_ratio_chunk, dtype=dtype_jnp)
         P_l_chunk = vmap(vmap(compute_P_l, in_axes=(None, 0, 0, 0)), in_axes=(0, None, None, None))(
             jnp.arange(global_max_ang_mom_plus_1), cos_chunk, weight_chunk, wf_ratio_chunk
         )
@@ -1706,10 +1715,9 @@ def compute_ecp_non_local_parts_all_pairs(
             - Non-local ECP contributions per configuration (flattened).
             - Scalar sum of all non-local contributions.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here (forwarded to fp64 Jastrow/det zones).
+    # RT is also forwarded as-is (Principle 3a); cast at the use site below.
+    dtype_jnp = get_dtype_jnp("coulomb")
 
     if Nv == 4:
         weights = tetrahedron_sym_mesh_Nv4.weights
@@ -1726,7 +1734,8 @@ def compute_ecp_non_local_parts_all_pairs(
     else:
         raise NotImplementedError
 
-    grid_points = grid_points @ RT  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
+    # Cast RT to coulomb zone at the use site (Principle 3b).
+    grid_points = grid_points @ RT.astype(dtype_jnp)  # rotate the grid points. dim. (N,3) @ (3,3) = (N,3)
 
     # start = time.perf_counter()
     r_up_carts_on_mesh, r_dn_carts_on_mesh, V_ecp_up, V_ecp_dn, sum_V_nonlocal = (
@@ -1842,11 +1851,12 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
     """
     # V_l_cutoff = 1e-5
 
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    weights = jnp.array(weights, dtype=dtype)
-    grid_points = jnp.array(grid_points, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here. They are forwarded to
+    # compute_Jastrow_part / compute_det_geminal_all_elements (fp64 zones); pre-casting
+    # to the coulomb (fp32) zone would silently down-cast inputs to those fp64 zones.
+    dtype_jnp = get_dtype_jnp("coulomb")
+    weights = jnp.array(weights, dtype=dtype_jnp)
+    grid_points = jnp.array(grid_points, dtype=dtype_jnp)
 
     jastrow_denominator = lax.switch(
         flag_determinant_only,
@@ -1863,7 +1873,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_cart,
             i_atom=i_atom,
-            dtype=dtype,
+            dtype=dtype_jnp,
         )
         V_l = (
             jnp.linalg.norm(rel_R_cart_min_dist) ** -2.0
@@ -1882,7 +1892,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_up_cart,
             i_atom=i_atom,
-            dtype=dtype,
+            dtype=dtype_jnp,
         )
         r_up_carts_on_mesh = r_up_carts
         r_up_carts_on_mesh = r_up_carts_on_mesh.at[r_up_i].set(
@@ -1902,10 +1912,15 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
 
         det_numerator_up = compute_det_geminal_all_elements(wavefunction_data.geminal_data, r_up_carts_on_mesh, r_dn_carts)
 
-        wf_ratio_up = jnp.exp(jastrow_numerator_up - jastrow_denominator) * det_numerator_up / det_denominator
-        # Cast back to coulomb zone: det/jastrow live in fp64 zones and would otherwise
-        # promote the entire P_l / V_ecp output to fp64.
-        wf_ratio_up = jnp.asarray(wf_ratio_up, dtype=dtype)
+        # Consumer-zone explicit cast: cast ALL upstream values to the local
+        # coulomb zone dtype before any arithmetic, so the wf_ratio computation
+        # never relies on JAX implicit fp32 x fp64 -> fp64 promotion and never
+        # borrows another zone's dtype.
+        jastrow_numerator_up = jnp.asarray(jastrow_numerator_up, dtype=dtype_jnp)
+        jastrow_denominator_c = jnp.asarray(jastrow_denominator, dtype=dtype_jnp)
+        det_numerator_up = jnp.asarray(det_numerator_up, dtype=dtype_jnp)
+        det_denominator_c = jnp.asarray(det_denominator, dtype=dtype_jnp)
+        wf_ratio_up = jnp.exp(jastrow_numerator_up - jastrow_denominator_c) * det_numerator_up / det_denominator_c
 
         P_l_up = (2 * ang_mom + 1) * jnp_legendre_tablated(ang_mom, cos_theta_up) * weight * wf_ratio_up
 
@@ -1919,7 +1934,7 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
             structure_data=coulomb_potential_data.structure_data,
             r_cart=r_dn_cart,
             i_atom=i_atom,
-            dtype=dtype,
+            dtype=dtype_jnp,
         )
         r_dn_carts_on_mesh = r_dn_carts
         r_dn_carts_on_mesh = r_dn_carts_on_mesh.at[r_dn_i].set(
@@ -1939,9 +1954,12 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
 
         det_numerator_dn = compute_det_geminal_all_elements(wavefunction_data.geminal_data, r_up_carts, r_dn_carts_on_mesh)
 
-        wf_ratio_dn = jnp.exp(jastrow_numerator_dn - jastrow_denominator) * det_numerator_dn / det_denominator
-        # Cast back to coulomb zone (see compute_P_l_up).
-        wf_ratio_dn = jnp.asarray(wf_ratio_dn, dtype=dtype)
+        # Consumer-zone explicit cast (see compute_P_l_up).
+        jastrow_numerator_dn = jnp.asarray(jastrow_numerator_dn, dtype=dtype_jnp)
+        jastrow_denominator_c = jnp.asarray(jastrow_denominator, dtype=dtype_jnp)
+        det_numerator_dn = jnp.asarray(det_numerator_dn, dtype=dtype_jnp)
+        det_denominator_c = jnp.asarray(det_denominator, dtype=dtype_jnp)
+        wf_ratio_dn = jnp.exp(jastrow_numerator_dn - jastrow_denominator_c) * det_numerator_dn / det_denominator_c
 
         P_l_dn = (2 * ang_mom + 1) * jnp_legendre_tablated(ang_mom, cos_theta_dn) * weight * wf_ratio_dn
         return r_dn_carts_on_mesh, P_l_dn
@@ -2010,16 +2028,19 @@ def compute_ecp_non_local_part_all_pairs_jax_weights_grid_points(
     )
 
     # Vectrized (flatten) arguments are prepared here.
+    # NOTE: Keep r_up_carts/r_dn_carts as fp64 here; the inner closures (compute_P_l_*)
+    # forward derived mesh coords to fp64 Jastrow/det zones, so any fp32 down-cast here
+    # would propagate to those zones.
     r_up_i_jnp = jnp.arange(len(r_up_carts))
-    r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
+    r_up_carts_jnp = r_up_carts
     r_dn_i_jnp = jnp.arange(len(r_dn_carts))
-    r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
+    r_dn_carts_jnp = r_dn_carts
 
     i_atom_np = jnp.array(coulomb_potential_data._nucleus_index_non_local_part)
     ang_mom_np = jnp.array(coulomb_potential_data._ang_mom_non_local_part)
-    exponent_np = jnp.array(coulomb_potential_data._exponents_non_local_part, dtype=dtype)
-    coefficient_np = jnp.array(coulomb_potential_data._coefficients_non_local_part, dtype=dtype)
-    power_np = jnp.array(coulomb_potential_data._powers_non_local_part, dtype=dtype)
+    exponent_np = jnp.array(coulomb_potential_data._exponents_non_local_part, dtype=dtype_jnp)
+    coefficient_np = jnp.array(coulomb_potential_data._coefficients_non_local_part, dtype=dtype_jnp)
+    power_np = jnp.array(coulomb_potential_data._powers_non_local_part, dtype=dtype_jnp)
 
     r_up_carts_on_mesh, V_ecp_up = vmap_vmap_compute_ecp_up(
         r_up_i_jnp,
@@ -2070,10 +2091,8 @@ def compute_ecp_coulomb_potential(
     Returns:
         float: Sum of local and non-local ECP contributions for the given geometry.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts/RT here (forwarded to downstream
+    # functions that handle their own use-site casts — Principle 3a).
 
     ecp_local_parts = compute_ecp_local_parts_all_pairs(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
@@ -2146,10 +2165,8 @@ def compute_ecp_coulomb_potential_fast(
         :func:`compute_ecp_non_local_parts_nearest_neighbors_fast_update` becomes incorrect
         and the non-local ratios will be silently wrong.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts/RT here (forwarded to downstream
+    # functions that handle their own use-site casts — Principle 3a).
 
     ecp_local_parts = compute_ecp_local_parts_all_pairs(
         coulomb_potential_data=coulomb_potential_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts
@@ -2178,10 +2195,9 @@ def _compute_bare_coulomb_potential_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See compute_bare_coulomb_potential_api."""
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). The
+    # accumulated scalar is cast to the coulomb zone before return (Principle 3b).
+    dtype_np = get_dtype_np("coulomb")
 
     R_carts = coulomb_potential_data.structure_data._positions_cart_np
     R_charges = coulomb_potential_data._effective_charges
@@ -2198,7 +2214,7 @@ def _compute_bare_coulomb_potential_debug(
         ]
     )
 
-    return bare_coulomb_potential
+    return np.asarray(bare_coulomb_potential, dtype=dtype_np)
 
 
 @jit
@@ -2217,10 +2233,8 @@ def compute_bare_coulomb_potential(
     Returns:
         float: Total bare Coulomb energy.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts here. Downstream el_ion / el_el helpers
+    # reconstruct r_i - r_j in fp64 internally; pre-casting would destroy that precision.
     interactions_ion_ion = compute_bare_coulomb_potential_ion_ion(coulomb_potential_data)
     interactions_el_ion_elements_up, interactions_el_ion_elements_dn = compute_bare_coulomb_potential_el_ion_element_wise(
         coulomb_potential_data, r_up_carts, r_dn_carts
@@ -2251,20 +2265,22 @@ def compute_bare_coulomb_potential_el_ion_element_wise(
     Returns:
         tuple[jax.Array, jax.Array]: Element-wise ion–electron interactions for up spins and down spins (shape ``(N_up,)`` and ``(N_dn,)``).
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts. el_ion_interaction reconstructs
+    # r_i - r_j in fp64 internally to avoid catastrophic cancellation; a fp32 pre-cast
+    # here would silently destroy that precision before the reconstruction can take effect.
+    dtype_jnp = get_dtype_jnp("coulomb")
+    dtype_np = get_dtype_np("coulomb")
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype_jnp)
     R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
     r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
     r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j):
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # coulomb zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_i - r_j).astype(dtype_jnp)
         distance = jnp.linalg.norm(diff, axis=1)
         interaction = (Z_i * Z_j) / distance
         return interaction
@@ -2298,20 +2314,21 @@ def compute_discretized_bare_coulomb_potential_el_ion_element_wise(
     Returns:
         tuple[jax.Array, jax.Array]: Element-wise ion–electron interactions for up spins and down spins (shape ``(N_up,)`` and ``(N_dn,)``).
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts. el_ion_interaction reconstructs
+    # r_i - r_j in fp64 internally to avoid catastrophic cancellation.
+    dtype_jnp = get_dtype_jnp("coulomb")
+    dtype_np = get_dtype_np("coulomb")
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype_jnp)
     R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
     r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
     r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
 
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-
     # Define a function to compute interaction for a pair
     def el_ion_interaction(Z_i, Z_j, r_i, r_j, alat):
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # coulomb zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_i - r_j).astype(dtype_jnp)
         distance = jnp.maximum(jnp.linalg.norm(diff, axis=1), alat)
         interaction = (Z_i * Z_j) / distance
         return interaction
@@ -2335,12 +2352,10 @@ def _compute_bare_coulomb_potential_el_ion_element_wise_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """See compute_bare_coulomb_potential_api."""
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-
-    R_carts = coulomb_potential_data.structure_data._positions_cart_np
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). The
+    # accumulators are cast to the coulomb zone before return (Principle 3b).
+    dtype_np = get_dtype_np("coulomb")
+    R_carts = coulomb_potential_data.structure_data._positions_cart_np  # fp64 storage accessor
     R_charges = coulomb_potential_data._effective_charges
     r_up_charges = [-1 for _ in range(len(r_up_carts))]
     r_dn_charges = [-1 for _ in range(len(r_dn_carts))]
@@ -2349,9 +2364,11 @@ def _compute_bare_coulomb_potential_el_ion_element_wise_debug(
     interactions_R_r_dn = np.zeros(len(r_dn_carts))
 
     for i, (r_up_charge, r_up_cart) in enumerate(zip(r_up_charges, r_up_carts, strict=True)):
+        # Reconstruct R - r in caller-supplied precision then downcast to the
+        # coulomb zone at the use site (Principle 3b).
         interactions_R_r_up[i] = np.sum(
             [
-                (R_charge * r_up_charge) / np.linalg.norm(R_cart - r_up_cart)
+                (R_charge * r_up_charge) / np.linalg.norm((R_cart - r_up_cart).astype(dtype_np))
                 for R_charge, R_cart in zip(R_charges, R_carts, strict=True)
             ]
         )
@@ -2359,12 +2376,15 @@ def _compute_bare_coulomb_potential_el_ion_element_wise_debug(
     for i, (r_dn_charge, r_dn_cart) in enumerate(zip(r_dn_charges, r_dn_carts, strict=True)):
         interactions_R_r_dn[i] = np.sum(
             [
-                (R_charge * r_dn_charge) / np.linalg.norm(R_cart - r_dn_cart)
+                (R_charge * r_dn_charge) / np.linalg.norm((R_cart - r_dn_cart).astype(dtype_np))
                 for R_charge, R_cart in zip(R_charges, R_carts, strict=True)
             ]
         )
 
-    return interactions_R_r_up, interactions_R_r_dn
+    return (
+        np.asarray(interactions_R_r_up, dtype=dtype_np),
+        np.asarray(interactions_R_r_dn, dtype=dtype_np),
+    )
 
 
 def _compute_discretized_bare_coulomb_potential_el_ion_element_wise_debug(
@@ -2374,12 +2394,10 @@ def _compute_discretized_bare_coulomb_potential_el_ion_element_wise_debug(
     alat: float,
 ) -> tuple[npt.NDArray[np.float64], npt.NDArray[np.float64]]:
     """See compute_bare_coulomb_potential_api."""
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-
-    R_carts = coulomb_potential_data.structure_data._positions_cart_np
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). The
+    # accumulators are cast to the coulomb zone before return (Principle 3b).
+    dtype_np = get_dtype_np("coulomb")
+    R_carts = coulomb_potential_data.structure_data._positions_cart_np  # fp64 storage accessor
     R_charges = coulomb_potential_data._effective_charges
     r_up_charges = [-1 for _ in range(len(r_up_carts))]
     r_dn_charges = [-1 for _ in range(len(r_dn_carts))]
@@ -2388,9 +2406,11 @@ def _compute_discretized_bare_coulomb_potential_el_ion_element_wise_debug(
     interactions_R_r_dn = np.zeros(len(r_dn_carts))
 
     for i, (r_up_charge, r_up_cart) in enumerate(zip(r_up_charges, r_up_carts, strict=True)):
+        # Reconstruct R - r in caller-supplied precision then downcast to the
+        # coulomb zone at the use site (Principle 3b).
         interactions_R_r_up[i] = np.sum(
             [
-                (R_charge * r_up_charge) / np.maximum(np.linalg.norm(R_cart - r_up_cart), alat)
+                (R_charge * r_up_charge) / np.maximum(np.linalg.norm((R_cart - r_up_cart).astype(dtype_np)), alat)
                 for R_charge, R_cart in zip(R_charges, R_carts, strict=True)
             ]
         )
@@ -2398,12 +2418,15 @@ def _compute_discretized_bare_coulomb_potential_el_ion_element_wise_debug(
     for i, (r_dn_charge, r_dn_cart) in enumerate(zip(r_dn_charges, r_dn_carts, strict=True)):
         interactions_R_r_dn[i] = np.sum(
             [
-                (R_charge * r_dn_charge) / np.maximum(np.linalg.norm(R_cart - r_dn_cart), alat)
+                (R_charge * r_dn_charge) / np.maximum(np.linalg.norm((R_cart - r_dn_cart).astype(dtype_np)), alat)
                 for R_charge, R_cart in zip(R_charges, R_carts, strict=True)
             ]
         )
 
-    return interactions_R_r_up, interactions_R_r_dn
+    return (
+        np.asarray(interactions_R_r_up, dtype=dtype_np),
+        np.asarray(interactions_R_r_dn, dtype=dtype_np),
+    )
 
 
 @jit
@@ -2420,13 +2443,12 @@ def compute_bare_coulomb_potential_el_el(
     Returns:
         float: Electron–electron Coulomb energy.
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts. el_el_interaction reconstructs
+    # r_i - r_j in fp64 internally to avoid catastrophic cancellation.
+    dtype_np = get_dtype_np("coulomb")
+    dtype_jnp = get_dtype_jnp("coulomb")
     r_up_charges = np.full(len(r_up_carts), -1.0, dtype=dtype_np)
     r_dn_charges = np.full(len(r_dn_carts), -1.0, dtype=dtype_np)
-
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     all_charges = np.hstack([r_up_charges, r_dn_charges])
     all_carts = jnp.vstack([r_up_carts, r_dn_carts])
@@ -2447,8 +2469,10 @@ def compute_bare_coulomb_potential_el_el(
 
     # Define a function to compute interaction for a pair
     def el_el_interaction(Z_i, Z_j, r_i, r_j):
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # coulomb zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_i - r_j).astype(dtype_jnp)
         distance = jnp.linalg.norm(diff)
         interaction = (Z_i * Z_j) / distance
         return interaction
@@ -2474,9 +2498,9 @@ def compute_bare_coulomb_potential_ion_ion(
     Returns:
         float: Ion–ion Coulomb energy.
     """
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("coulomb")
+    dtype_np = get_dtype_np("coulomb")
+    R_carts = jnp.array(coulomb_potential_data.structure_data._positions_cart_jnp, dtype=dtype_jnp)
     R_charges = np.array(coulomb_potential_data._effective_charges, dtype=dtype_np)
 
     all_charges = R_charges
@@ -2498,8 +2522,10 @@ def compute_bare_coulomb_potential_ion_ion(
 
     # Define a function to compute interaction for a pair
     def ion_ion_interaction(Z_i, Z_j, r_i, r_j):
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_i.astype(jnp.float64) - r_j.astype(jnp.float64)).astype(r_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # coulomb zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_i - r_j).astype(dtype_jnp)
         distance = jnp.linalg.norm(diff)
         interaction = (Z_i * Z_j) / distance
         return interaction
@@ -2529,10 +2555,7 @@ def compute_bare_coulomb_potential_el_ion(
     Returns:
         float: Electron–ion Coulomb energy.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts (forwarded to el_ion_element_wise which reconstructs in fp64).
     interactions_el_ion_elements_up, interactions_el_ion_elements_dn = compute_bare_coulomb_potential_el_ion_element_wise(
         coulomb_potential_data, r_up_carts, r_dn_carts
     )
@@ -2550,11 +2573,10 @@ def _compute_coulomb_potential_debug(
     wavefunction_data: Wavefunction_data = None,
 ) -> float:
     """See compute_coulomb_potential_api."""
-    dtype = get_dtype("coulomb")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
-    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
-    RT = np.asarray(RT, dtype=dtype_np)
+    # Forward r_up/dn_carts and RT as-is (Principle 3a — no parameter rebind).
+    # Each downstream debug function casts to its own zone at the use site;
+    # the accumulated scalar is cast to the coulomb zone before return.
+    dtype_np = get_dtype_np("coulomb")
 
     # all-electron
     if not coulomb_potential_data.ecp_flag:
@@ -2583,7 +2605,7 @@ def _compute_coulomb_potential_debug(
             NN=NN,
         )
 
-    return bare_coulomb_potential + ecp_coulomb_potential
+    return np.asarray(bare_coulomb_potential + ecp_coulomb_potential, dtype=dtype_np)
 
 
 def compute_coulomb_potential(
@@ -2609,10 +2631,8 @@ def compute_coulomb_potential(
     Returns:
         float: Sum of bare Coulomb (ion–ion, electron–ion, electron–electron) and ECP (local + non-local) energies.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts/RT (forwarded to downstream
+    # functions that handle their own use-site casts — Principle 3a).
 
     # all-electron
     if not coulomb_potential_data.ecp_flag:
@@ -2679,10 +2699,8 @@ def compute_coulomb_potential_fast(
         electrons have moved simultaneously the underlying Sherman–Morrison rank-1 update is
         incorrect and non-local ratios will be silently wrong.
     """
-    dtype = get_dtype("coulomb")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    RT = jnp.asarray(RT, dtype=dtype)
+    # NOTE: Do NOT pre-cast r_up_carts/r_dn_carts/RT (forwarded to downstream
+    # functions that handle their own use-site casts — Principle 3a).
 
     # all-electron — no ECP, no need for A_old_inv
     if not coulomb_potential_data.ecp_flag:

--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -1392,14 +1392,16 @@ def _compute_geminal_all_elements_debug(
 @jax.jit
 def compute_geminal_up_one_row_elements(
     geminal_data,
-    r_up_cart: jax.Array,  # shape: (3,) or (1,3)
+    r_up_cart: jax.Array,  # shape: (1, 3)
     r_dn_carts: jax.Array,  # shape: (N_dn, 3)
 ) -> jax.Array:
     """Single row of the geminal matrix for one spin-up electron.
 
     Args:
         geminal_data: Geminal parameters and orbital references.
-        r_up_cart: Cartesian coordinate for one spin-up electron with shape ``(3,)`` or ``(1, 3)``.
+        r_up_cart: Cartesian coordinate for one spin-up electron with shape ``(1, 3)``.
+            ``compute_orb_api`` requires a 2D ``(N, 3)`` batch; pass a single
+            electron as ``(1, 3)``, not ``(3,)``.
         r_dn_carts: Cartesian coordinates for all spin-down electrons with shape ``(N_dn, 3)``.
 
     Returns:
@@ -1440,14 +1442,16 @@ def compute_geminal_up_one_row_elements(
 def compute_geminal_dn_one_column_elements(
     geminal_data,
     r_up_carts: jax.Array,  # shape: (N_up, 3)
-    r_dn_cart: jax.Array,  # shape: (3,) or (1,3)
+    r_dn_cart: jax.Array,  # shape: (1, 3)
 ) -> jax.Array:
     """Single column of the geminal matrix for one spin-down electron.
 
     Args:
         geminal_data: Geminal parameters and orbital references.
         r_up_carts: Cartesian coordinates of spin-up electrons with shape ``(N_up, 3)``.
-        r_dn_cart: Cartesian coordinate for one spin-down electron with shape ``(3,)`` or ``(1, 3)``.
+        r_dn_cart: Cartesian coordinate for one spin-down electron with shape ``(1, 3)``.
+            ``compute_orb_api`` requires a 2D ``(N, 3)`` batch; pass a single
+            electron as ``(1, 3)``, not ``(3,)``.
 
     Returns:
         jax.Array: Column vector for the paired block with shape ``(N_up,)``.

--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -1,4 +1,12 @@
-"""Determinant module."""
+"""Determinant module.
+
+Precision Zones:
+    - ``geminal``: matrix elements (compute_geminal_*).
+    - ``determinant``: log-det, SVD, antisymmetrisation (compute_ln_det_*, compute_AS_*).
+    - ``kinetic``: determinant derivatives (compute_grads_and_laplacian_ln_Det*).
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -49,7 +57,8 @@ import numpy.typing as npt
 from flax import struct
 from jax import jit, vmap
 
-from ._setting import EPS_rcond_SVD, atol_consistency, rtol_consistency
+from ._precision import get_dtype
+from ._setting import EPS_rcond_SVD, atol_consistency, get_eps, rtol_consistency
 from .atomic_orbital import (
     AOs_cart_data,
     AOs_sphe_data,
@@ -998,13 +1007,10 @@ def compute_ln_det_geminal_all_elements(
     Returns:
         float: Scalar log-determinant of the geminal matrix.
     """
-    return jnp.log(
-        jnp.abs(
-            jnp.linalg.det(
-                compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
-            )
-        )
-    )
+    dtype = get_dtype("determinant")
+    G = compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
+    return jnp.log(jnp.abs(jnp.linalg.det(G)))
 
 
 # Forward pass for custom VJP.
@@ -1020,7 +1026,9 @@ def _ln_det_fwd(geminal_data, r_up_carts, r_dn_carts):
         - primal output: ln|det(G)|
         - residuals: (inputs and SVD factors) for use in backward pass
     """
+    dtype = get_dtype("determinant")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
     ln_det = jnp.log(jnp.abs(jnp.linalg.det(G)))
     # Compute SVD: G = U_svd @ diag(s) @ Vt
     U_svd, s, Vt = jnp.linalg.svd(G, full_matrices=False)
@@ -1051,8 +1059,10 @@ def _ln_det_bwd(res, g):
     geminal_data, r_up_carts, r_dn_carts, U_svd, s, Vt = res
 
     # Compute G^{-1} via SVD pseudoinverse with thresholding.
-    # Singular values below EPS_rcond_SVD * s_max are zeroed to avoid NaN from 1/~0.
-    s_inv = jnp.where(s > EPS_rcond_SVD * s[0], 1.0 / s, 0.0)
+    # Singular values below eps_rcond * s_max are zeroed to avoid NaN from 1/~0.
+    dtype = get_dtype("determinant")
+    eps_rcond = get_eps("rcond_svd", dtype)
+    s_inv = jnp.where(s > eps_rcond * s[0], jnp.asarray(1.0, dtype=dtype) / s, jnp.asarray(0.0, dtype=dtype))
     X = (Vt.T * s_inv[jnp.newaxis, :]) @ U_svd.T  # G^{-1}, shape (n, n)
 
     # d ln|det G| / dG = (G^{-1})^T, scaled by incoming cotangent g
@@ -1101,7 +1111,9 @@ def compute_ln_det_geminal_all_elements_fast(
         used in the MCMC loop.  Passing an inverse that corresponds to different
         electron positions silently produces incorrect gradients.
     """
+    dtype = get_dtype("determinant")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
     return jnp.log(jnp.abs(jnp.linalg.det(G)))
 
 
@@ -1111,14 +1123,18 @@ def _ln_det_fast_fwd(
     r_dn_carts: jax.Array,
     geminal_inv: jax.Array,
 ):
+    dtype = get_dtype("determinant")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
     val = jnp.log(jnp.abs(jnp.linalg.det(G)))
     # Save inputs for backward (geminal_inv replaces G^{-1} in bwd)
     return val, (geminal_data, r_up_carts, r_dn_carts, geminal_inv)
 
 
 def _ln_det_fast_bwd(res, g):
+    dtype = get_dtype("determinant")
     geminal_data, r_up_carts, r_dn_carts, geminal_inv = res
+    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype)
     # d(ln|det G|)/d(G_{ij}) = (G^{-T})_{ij}
     # Use the pre-computed inverse instead of re-solving.
     G_bar = g * geminal_inv.T  # cotangent w.r.t. G, shape (N_up, N_up)
@@ -1149,7 +1165,10 @@ def compute_det_geminal_all_elements(
     Returns:
         float: Scalar determinant of the geminal matrix.
     """
-    return jnp.linalg.det(compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts))
+    dtype = get_dtype("determinant")
+    G = compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
+    return jnp.linalg.det(G)
 
 
 def _compute_det_geminal_all_elements_debug(
@@ -1158,13 +1177,15 @@ def _compute_det_geminal_all_elements_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> np.float64:
     """See compute_det_geminal_all_elements_api."""
-    return np.linalg.det(
-        _compute_geminal_all_elements_debug(
-            geminal_data=geminal_data,
-            r_up_carts=r_up_carts,
-            r_dn_carts=r_dn_carts,
-        )
+    dtype = get_dtype("determinant")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    G = _compute_geminal_all_elements_debug(
+        geminal_data=geminal_data,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
+    G = np.asarray(G, dtype=dtype_np)
+    return np.linalg.det(G)
 
 
 def compute_AS_regularization_factor_fast_update(
@@ -1179,6 +1200,9 @@ def compute_AS_regularization_factor_fast_update(
     Returns:
         jax.Array: Scalar AS regularization factor.
     """
+    dtype = get_dtype("determinant")
+    geminal = jnp.asarray(geminal, dtype=dtype)
+    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype)
     # compute the AS factor
     theta = 3.0 / 8.0
 
@@ -1208,7 +1232,10 @@ def _compute_AS_regularization_factor_debug(
     geminal_data: Geminal_data, r_up_carts: npt.NDArray[np.float64], r_dn_carts: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     """See compute_AS_regularization_factor_jax."""
+    dtype = get_dtype("determinant")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     geminal = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    geminal = np.asarray(geminal, dtype=dtype_np)
 
     # compute the AS factor
     theta = 3.0 / 8.0
@@ -1241,15 +1268,20 @@ def compute_AS_regularization_factor(geminal_data: Geminal_data, r_up_carts: jax
     Returns:
         jax.Array: Scalar AS regularization factor.
     """
+    dtype = get_dtype("determinant")
     geminal = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    geminal = jnp.asarray(geminal, dtype=dtype)
 
     # compute the AS factor
     theta = 3.0 / 8.0
 
     # compute F \equiv the square of Frobenius norm of geminal_inv
     # Use SVD with conservative threshold to avoid Inf from 1/sigma^2 for tiny sigma
+    eps_rcond = get_eps("rcond_svd", dtype)
     sigma = jnp.linalg.svd(geminal, compute_uv=False)
-    sigma_sq_inv = jnp.where(sigma > EPS_rcond_SVD * sigma[0], 1.0 / (sigma**2), 0.0)
+    sigma_sq_inv = jnp.where(
+        sigma > eps_rcond * sigma[0], jnp.asarray(1.0, dtype=dtype) / (sigma**2), jnp.asarray(0.0, dtype=dtype)
+    )
     F = jnp.sum(sigma_sq_inv)
 
     # compute the scaling factor
@@ -1281,6 +1313,9 @@ def compute_geminal_all_elements(geminal_data: Geminal_data, r_up_carts: jax.Arr
     Returns:
         jax.Array: Geminal matrix with shape ``(N_up, N_up)`` combining paired and unpaired blocks.
     """
+    dtype = get_dtype("geminal")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     if len(r_up_carts) != geminal_data.num_electron_up or len(r_dn_carts) != geminal_data.num_electron_dn:
         logger.info(
             f"Number of up and dn electrons (N_up, N_dn) = ({len(r_up_carts)}, {len(r_dn_carts)}) are not consistent "
@@ -1313,7 +1348,10 @@ def _compute_geminal_all_elements(
     r_dn_carts: jax.Array,
 ) -> jax.Array:
     """See compute_geminal_all_elements_api."""
+    dtype = get_dtype("geminal")
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
     orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
@@ -1332,7 +1370,13 @@ def _compute_geminal_all_elements_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """See compute_geminal_all_elements_api."""
+    dtype = get_dtype("geminal")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
     lambda_matrix_paired, lambda_matrix_unpaired = np.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = np.asarray(lambda_matrix_paired, dtype=dtype_np)
+    lambda_matrix_unpaired = np.asarray(lambda_matrix_unpaired, dtype=dtype_np)
 
     orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
     orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
@@ -1361,10 +1405,15 @@ def compute_geminal_up_one_row_elements(
     Returns:
         jax.Array: Row vector with shape ``(N_dn + N_unpaired,)``.
     """
+    dtype = get_dtype("geminal")
+    r_up_cart = jnp.asarray(r_up_cart, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     # Split lambda into paired/unpaired blocks along columns
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(
         geminal_data.lambda_matrix, [geminal_data.orb_num_dn]
     )  # shapes: (n_orb_up, n_orb_dn), (n_orb_up, num_unpaired)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     # Orbital values:
     # - up: single position -> 1D vector (n_orb_up,)
@@ -1403,10 +1452,14 @@ def compute_geminal_dn_one_column_elements(
     Returns:
         jax.Array: Column vector for the paired block with shape ``(N_up,)``.
     """
+    dtype = get_dtype("geminal")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_cart = jnp.asarray(r_dn_cart, dtype=dtype)
     # Split lambda into paired/unpaired blocks along columns
     lambda_matrix_paired, _lambda_matrix_unpaired = jnp.hsplit(
         geminal_data.lambda_matrix, [geminal_data.orb_num_dn]
     )  # lambda_matrix_paired: (n_orb_up, n_orb_dn)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
 
     # Orbital values:
     # - up: batched positions -> (n_orb_up, N_up)
@@ -1463,6 +1516,12 @@ def _compute_ratio_determinant_part_rank1_update(
         grid generated by the MCMC loop, where exactly one electron is displaced
         per grid point by construction.
     """
+    dtype = get_dtype("geminal")
+    A_old_inv = jnp.asarray(A_old_inv, dtype=dtype)
+    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
+    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
+    new_r_up_carts_arr = jnp.asarray(new_r_up_carts_arr, dtype=dtype)
+    new_r_dn_carts_arr = jnp.asarray(new_r_dn_carts_arr, dtype=dtype)
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
 
@@ -1497,6 +1556,8 @@ def _compute_ratio_determinant_part_rank1_update(
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.split(
         geminal_data.lambda_matrix, indices_or_sections=[geminal_data.orb_num_dn], axis=1
     )
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     # Precompute old AO matrices once.
     orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts)
@@ -1567,6 +1628,12 @@ def _compute_ratio_determinant_part_split_spin(
         exclusively for the block-structured non-local ECP grids produced by
         the MCMC loop.
     """
+    dtype = get_dtype("geminal")
+    A_old_inv = jnp.asarray(A_old_inv, dtype=dtype)
+    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
+    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
+    new_r_up_shifted = jnp.asarray(new_r_up_shifted, dtype=dtype)
+    new_r_dn_shifted = jnp.asarray(new_r_dn_shifted, dtype=dtype)
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
 
@@ -1587,6 +1654,8 @@ def _compute_ratio_determinant_part_split_spin(
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.split(
         geminal_data.lambda_matrix, indices_or_sections=[geminal_data.orb_num_dn], axis=1
     )
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     # Precompute old AO matrices once.
     orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts)
@@ -1634,6 +1703,12 @@ def _compute_ratio_determinant_part_debug(
     new_r_dn_carts_arr: npt.NDArray[np.float64],
 ) -> npt.NDArray:
     """See _api method."""
+    dtype = get_dtype("determinant")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    old_r_up_carts = np.asarray(old_r_up_carts, dtype=dtype_np)
+    old_r_dn_carts = np.asarray(old_r_dn_carts, dtype=dtype_np)
+    new_r_up_carts_arr = np.asarray(new_r_up_carts_arr, dtype=dtype_np)
+    new_r_dn_carts_arr = np.asarray(new_r_dn_carts_arr, dtype=dtype_np)
     return np.array(
         [
             compute_det_geminal_all_elements(geminal_data, new_r_up_carts, new_r_dn_carts)
@@ -1710,18 +1785,25 @@ def compute_grads_and_laplacian_ln_Det(
             - Laplacians for spin-up electrons with shape ``(N_up,)``.
             - Laplacians for spin-down electrons with shape ``(N_dn,)``.
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     # Compute G_inv via SVD pseudoinverse (numerically stable, avoids LU NaN).
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
     _U, _s, _Vt = jnp.linalg.svd(G, full_matrices=False)
     # Use conservative threshold to prevent G^{-2} and G^{-3} terms in the
     # backward pass from diverging. Standard numpy.linalg.pinv uses max(M,N)*eps,
     # but for de_L/dc (which involves G_inv^2 in the chain rule) we need a larger
     # safety margin to avoid Inf/NaN in the gradient. EPS_rcond_SVD is set in setting.py
     # to handle near-singular G while preserving well-conditioned singular values.
-    _s_inv = jnp.where(_s > EPS_rcond_SVD * _s[0], 1.0 / _s, 0.0)
+    eps_rcond = get_eps("rcond_svd", dtype)
+    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype) / _s, jnp.asarray(0.0, dtype=dtype))
     geminal_inverse = (_Vt.T * _s_inv[jnp.newaxis, :]) @ _U.T
 
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
     ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
@@ -1801,7 +1883,13 @@ def _grads_lap_body(
     passed to ``jax.vjp`` inside the custom VJP backward pass without creating
     a dependency on the public fast function.
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    geminal_inverse = jnp.asarray(geminal_inverse, dtype=dtype)
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
     ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
@@ -1874,10 +1962,15 @@ def _grads_lap_fwd(
     r_dn_carts: jax.Array,
 ):
     """Forward pass: compute stable G_inv and primal outputs."""
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
+    G = jnp.asarray(G, dtype=dtype)
     _U, _s, _Vt = jnp.linalg.svd(G, full_matrices=False)
     # Use same conservative threshold as in compute_grads_and_laplacian_ln_Det
-    _s_inv = jnp.where(_s > EPS_rcond_SVD * _s[0], 1.0 / _s, 0.0)
+    eps_rcond = get_eps("rcond_svd", dtype)
+    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype) / _s, jnp.asarray(0.0, dtype=dtype))
     G_inv_stable = (_Vt.T * _s_inv[jnp.newaxis, :]) @ _U.T
     primals = _grads_lap_body(geminal_data, r_up_carts, r_dn_carts, G_inv_stable)
     return primals, (geminal_data, r_up_carts, r_dn_carts, G_inv_stable)
@@ -1909,7 +2002,9 @@ def _grads_lap_bwd(res, g):
         :func:`compute_grads_and_laplacian_ln_Det` for details).  Keep
         ``EPS_rcond_SVD`` very small (e.g. ``1e-20``) to avoid this.
     """
+    dtype = get_dtype("kinetic")
     geminal_data, r_up_carts, r_dn_carts, G_inv_stable = res
+    G_inv_stable = jnp.asarray(G_inv_stable, dtype=dtype)
 
     # Step 1: differentiate _grads_lap_body w.r.t. all args.
     # This gives direct gradients (AO path) and G_inv_bar (cotangent for G_inv).
@@ -1973,7 +2068,14 @@ def compute_grads_and_laplacian_ln_Det_fast(
     if geminal_inverse is None:
         raise ValueError("geminal_inverse must be provided for fast evaluation")
 
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    geminal_inverse = jnp.asarray(geminal_inverse, dtype=dtype)
+
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
 
     ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
     ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
@@ -2046,6 +2148,9 @@ def _compute_grads_and_laplacian_ln_Det_fast_debug(
     r_dn_carts: jax.Array,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """Debug helper that uses auto-diff to validate the fast path."""
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     # Use auto-diff as the reference (independent implementation).
     grad_ln_D_up, grad_ln_D_dn, lap_ln_D_up, lap_ln_D_dn = _compute_grads_and_laplacian_ln_Det_auto(
         geminal_data=geminal_data,
@@ -2072,6 +2177,9 @@ def _compute_grads_and_laplacian_ln_Det_auto(
     Uses autodiff on ln|det(G)| to compute gradients w.r.t. electron positions
     and per-electron Laplacians.
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     def ln_det_fn(r_up, r_dn):
         return compute_ln_det_geminal_all_elements(geminal_data, r_up, r_dn)
@@ -2105,6 +2213,10 @@ def _compute_grads_and_laplacian_ln_Det_debug(
     np.ndarray,
 ]:
     """See compute_grads_and_laplacian_ln_Det_api."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
     det_geminal = compute_det_geminal_all_elements(
         geminal_data=geminal_data,
         r_up_carts=r_up_carts,

--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -51,14 +51,13 @@ from typing import TYPE_CHECKING
 # from jax.debug import print as jprint
 import jax
 import jax.numpy as jnp
-import jax.scipy.linalg as jsp_linalg
 import numpy as np
 import numpy.typing as npt
 from flax import struct
 from jax import jit, vmap
 
-from ._precision import get_dtype
-from ._setting import EPS_rcond_SVD, atol_consistency, get_eps, rtol_consistency
+from ._precision import get_dtype_jnp, get_dtype_np
+from ._setting import atol_consistency, get_eps, rtol_consistency
 from .atomic_orbital import (
     AOs_cart_data,
     AOs_sphe_data,
@@ -93,8 +92,8 @@ class Geminal_data:
         num_electron_dn (int): Number of spin-down electrons.
         orb_data_up_spin (AOs_data | MOs_data): Basis/orbitals for spin-up electrons.
         orb_data_dn_spin (AOs_data | MOs_data): Basis/orbitals for spin-down electrons.
-        lambda_matrix (npt.NDArray | jax.Array): Geminal pairing matrix with shape
-            ``(orb_num_up, orb_num_dn + num_electron_up - num_electron_dn)``.
+        lambda_matrix (npt.NDArray[np.float64]): Geminal pairing matrix with shape
+            ``(orb_num_up, orb_num_dn + num_electron_up - num_electron_dn)``. dtype: float64.
 
     Notes:
         - For closed shells, ``orb_num_up == orb_num_dn`` and ``lambda_matrix`` is square.
@@ -109,9 +108,9 @@ class Geminal_data:
     orb_data_dn_spin: AOs_sphe_data | AOs_cart_data | MOs_data = struct.field(
         pytree_node=True, default_factory=lambda: AOs_sphe_data()
     )  #: Orbital data (AOs or MOs) for spin-down electrons.
-    lambda_matrix: npt.NDArray | jax.Array = struct.field(
-        pytree_node=True, default_factory=lambda: np.array([])
-    )  #: Geminal pairing matrix; see class notes for expected shape.
+    lambda_matrix: npt.NDArray[np.float64] = struct.field(
+        pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64)
+    )  #: Geminal pairing matrix; see class notes for expected shape. dtype: float64.
 
     def sanity_check(self) -> None:
         """Check attributes of the class.
@@ -167,42 +166,49 @@ class Geminal_data:
     # --- AO basis property accessors (for basis optimization) ---
 
     @property
+    def _lambda_matrix_jnp(self) -> jax.Array:
+        """Return lambda_matrix as a jax.Array (jnp view of the underlying numpy storage)."""
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        return jnp.asarray(self.lambda_matrix, dtype=jnp.float64)
+
+    @property
     def ao_exponents_up(self) -> jax.Array:
-        """AO Gaussian exponents for spin-up orbitals, regardless of AO/MO representation."""
+        """AO Gaussian exponents for spin-up orbitals (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data_up_spin, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data_up_spin.exponents
+            return self.orb_data_up_spin._exponents_jnp
         elif isinstance(self.orb_data_up_spin, MOs_data):
-            return self.orb_data_up_spin.aos_data.exponents
+            return self.orb_data_up_spin.aos_data._exponents_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data_up_spin)}")
 
     @property
     def ao_exponents_dn(self) -> jax.Array:
-        """AO Gaussian exponents for spin-down orbitals, regardless of AO/MO representation."""
+        """AO Gaussian exponents for spin-down orbitals (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data_dn_spin, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data_dn_spin.exponents
+            return self.orb_data_dn_spin._exponents_jnp
         elif isinstance(self.orb_data_dn_spin, MOs_data):
-            return self.orb_data_dn_spin.aos_data.exponents
+            return self.orb_data_dn_spin.aos_data._exponents_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data_dn_spin)}")
 
     @property
     def ao_coefficients_up(self) -> jax.Array:
-        """AO contraction coefficients for spin-up orbitals, regardless of AO/MO representation."""
+        """AO contraction coefficients for spin-up orbitals (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data_up_spin, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data_up_spin.coefficients
+            return self.orb_data_up_spin._coefficients_jnp
         elif isinstance(self.orb_data_up_spin, MOs_data):
-            return self.orb_data_up_spin.aos_data.coefficients
+            return self.orb_data_up_spin.aos_data._coefficients_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data_up_spin)}")
 
     @property
     def ao_coefficients_dn(self) -> jax.Array:
-        """AO contraction coefficients for spin-down orbitals, regardless of AO/MO representation."""
+        """AO contraction coefficients for spin-down orbitals (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data_dn_spin, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data_dn_spin.coefficients
+            return self.orb_data_dn_spin._coefficients_jnp
         elif isinstance(self.orb_data_dn_spin, MOs_data):
-            return self.orb_data_dn_spin.aos_data.coefficients
+            return self.orb_data_dn_spin.aos_data._coefficients_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data_dn_spin)}")
 
@@ -226,14 +232,18 @@ class Geminal_data:
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(orb_data)}")
 
-    def with_updated_ao_exponents(self, new_exp_up: jax.Array, new_exp_dn: jax.Array) -> "Geminal_data":
+    def with_updated_ao_exponents(
+        self, new_exp_up: npt.NDArray[np.float64], new_exp_dn: npt.NDArray[np.float64]
+    ) -> "Geminal_data":
         """Return a new instance with updated AO exponents for both spins."""
         return self.replace(
             orb_data_up_spin=self._replace_orb_exponents(self.orb_data_up_spin, new_exp_up),
             orb_data_dn_spin=self._replace_orb_exponents(self.orb_data_dn_spin, new_exp_dn),
         )
 
-    def with_updated_ao_coefficients(self, new_coeff_up: jax.Array, new_coeff_dn: jax.Array) -> "Geminal_data":
+    def with_updated_ao_coefficients(
+        self, new_coeff_up: npt.NDArray[np.float64], new_coeff_dn: npt.NDArray[np.float64]
+    ) -> "Geminal_data":
         """Return a new instance with updated AO contraction coefficients for both spins."""
         return self.replace(
             orb_data_up_spin=self._replace_orb_coefficients(self.orb_data_up_spin, new_coeff_up),
@@ -286,14 +296,12 @@ class Geminal_data:
         elif block.name == "lambda_basis_exp":
             vals = np.asarray(block.values, dtype=np.float64)
             vals = self._symmetrize_ao_basis(vals)
-            vals = jnp.asarray(vals, dtype=jnp.float64)
             n_up = len(self.ao_exponents_up)
             new_exp_up, new_exp_dn = vals[:n_up], vals[n_up:]
             return self.with_updated_ao_exponents(new_exp_up, new_exp_dn)
         elif block.name == "lambda_basis_coeff":
             vals = np.asarray(block.values, dtype=np.float64)
             vals = self._symmetrize_ao_basis(vals)
-            vals = jnp.asarray(vals, dtype=jnp.float64)
             n_up = len(self.ao_coefficients_up)
             new_coeff_up, new_coeff_dn = vals[:n_up], vals[n_up:]
             return self.with_updated_ao_coefficients(new_coeff_up, new_coeff_dn)
@@ -1007,9 +1015,9 @@ def compute_ln_det_geminal_all_elements(
     Returns:
         float: Scalar log-determinant of the geminal matrix.
     """
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     G = compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     return jnp.log(jnp.abs(jnp.linalg.det(G)))
 
 
@@ -1026,9 +1034,9 @@ def _ln_det_fwd(geminal_data, r_up_carts, r_dn_carts):
         - primal output: ln|det(G)|
         - residuals: (inputs and SVD factors) for use in backward pass
     """
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     ln_det = jnp.log(jnp.abs(jnp.linalg.det(G)))
     # Compute SVD: G = U_svd @ diag(s) @ Vt
     U_svd, s, Vt = jnp.linalg.svd(G, full_matrices=False)
@@ -1060,9 +1068,9 @@ def _ln_det_bwd(res, g):
 
     # Compute G^{-1} via SVD pseudoinverse with thresholding.
     # Singular values below eps_rcond * s_max are zeroed to avoid NaN from 1/~0.
-    dtype = get_dtype("determinant")
-    eps_rcond = get_eps("rcond_svd", dtype)
-    s_inv = jnp.where(s > eps_rcond * s[0], jnp.asarray(1.0, dtype=dtype) / s, jnp.asarray(0.0, dtype=dtype))
+    dtype_jnp = get_dtype_jnp("det_eval")
+    eps_rcond = get_eps("rcond_svd", dtype_jnp)
+    s_inv = jnp.where(s > eps_rcond * s[0], jnp.asarray(1.0, dtype=dtype_jnp) / s, jnp.asarray(0.0, dtype=dtype_jnp))
     X = (Vt.T * s_inv[jnp.newaxis, :]) @ U_svd.T  # G^{-1}, shape (n, n)
 
     # d ln|det G| / dG = (G^{-1})^T, scaled by incoming cotangent g
@@ -1111,9 +1119,9 @@ def compute_ln_det_geminal_all_elements_fast(
         used in the MCMC loop.  Passing an inverse that corresponds to different
         electron positions silently produces incorrect gradients.
     """
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     return jnp.log(jnp.abs(jnp.linalg.det(G)))
 
 
@@ -1123,18 +1131,18 @@ def _ln_det_fast_fwd(
     r_dn_carts: jax.Array,
     geminal_inv: jax.Array,
 ):
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     val = jnp.log(jnp.abs(jnp.linalg.det(G)))
     # Save inputs for backward (geminal_inv replaces G^{-1} in bwd)
     return val, (geminal_data, r_up_carts, r_dn_carts, geminal_inv)
 
 
 def _ln_det_fast_bwd(res, g):
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     geminal_data, r_up_carts, r_dn_carts, geminal_inv = res
-    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype)
+    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype_jnp)
     # d(ln|det G|)/d(G_{ij}) = (G^{-T})_{ij}
     # Use the pre-computed inverse instead of re-solving.
     G_bar = g * geminal_inv.T  # cotangent w.r.t. G, shape (N_up, N_up)
@@ -1165,9 +1173,9 @@ def compute_det_geminal_all_elements(
     Returns:
         float: Scalar determinant of the geminal matrix.
     """
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     G = compute_geminal_all_elements(geminal_data=geminal_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     return jnp.linalg.det(G)
 
 
@@ -1177,8 +1185,7 @@ def _compute_det_geminal_all_elements_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> np.float64:
     """See compute_det_geminal_all_elements_api."""
-    dtype = get_dtype("determinant")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("det_eval")
     G = _compute_geminal_all_elements_debug(
         geminal_data=geminal_data,
         r_up_carts=r_up_carts,
@@ -1200,9 +1207,9 @@ def compute_AS_regularization_factor_fast_update(
     Returns:
         jax.Array: Scalar AS regularization factor.
     """
-    dtype = get_dtype("determinant")
-    geminal = jnp.asarray(geminal, dtype=dtype)
-    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_ratio")
+    geminal = jnp.asarray(geminal, dtype=dtype_jnp)
+    geminal_inv = jnp.asarray(geminal_inv, dtype=dtype_jnp)
     # compute the AS factor
     theta = 3.0 / 8.0
 
@@ -1232,8 +1239,7 @@ def _compute_AS_regularization_factor_debug(
     geminal_data: Geminal_data, r_up_carts: npt.NDArray[np.float64], r_dn_carts: npt.NDArray[np.float64]
 ) -> npt.NDArray[np.float64]:
     """See compute_AS_regularization_factor_jax."""
-    dtype = get_dtype("determinant")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("det_eval")
     geminal = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
     geminal = np.asarray(geminal, dtype=dtype_np)
 
@@ -1268,19 +1274,19 @@ def compute_AS_regularization_factor(geminal_data: Geminal_data, r_up_carts: jax
     Returns:
         jax.Array: Scalar AS regularization factor.
     """
-    dtype = get_dtype("determinant")
+    dtype_jnp = get_dtype_jnp("det_eval")
     geminal = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    geminal = jnp.asarray(geminal, dtype=dtype)
+    geminal = jnp.asarray(geminal, dtype=dtype_jnp)
 
     # compute the AS factor
     theta = 3.0 / 8.0
 
     # compute F \equiv the square of Frobenius norm of geminal_inv
     # Use SVD with conservative threshold to avoid Inf from 1/sigma^2 for tiny sigma
-    eps_rcond = get_eps("rcond_svd", dtype)
+    eps_rcond = get_eps("rcond_svd", dtype_jnp)
     sigma = jnp.linalg.svd(geminal, compute_uv=False)
     sigma_sq_inv = jnp.where(
-        sigma > eps_rcond * sigma[0], jnp.asarray(1.0, dtype=dtype) / (sigma**2), jnp.asarray(0.0, dtype=dtype)
+        sigma > eps_rcond * sigma[0], jnp.asarray(1.0, dtype=dtype_jnp) / (sigma**2), jnp.asarray(0.0, dtype=dtype_jnp)
     )
     F = jnp.sum(sigma_sq_inv)
 
@@ -1313,9 +1319,13 @@ def compute_geminal_all_elements(geminal_data: Geminal_data, r_up_carts: jax.Arr
     Returns:
         jax.Array: Geminal matrix with shape ``(N_up, N_up)`` combining paired and unpaired blocks.
     """
-    dtype = get_dtype("geminal")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # NOTE: do not pre-cast r_*_carts here. r_*_carts is only forwarded to
+    # ``_compute_geminal_all_elements`` (which in turn calls ``compute_orb_api``
+    # → ``compute_AOs``); the AO kernels reconstruct ``r - R`` in float64
+    # internally to avoid catastrophic cancellation, and a wrapper-level
+    # downcast would defeat that guard. Arithmetic in this function uses
+    # ``ao_matrix_*`` / ``lambda_matrix_*`` which are cast at their own use
+    # sites, so r_*_carts itself does not need casting here.
     if len(r_up_carts) != geminal_data.num_electron_up or len(r_dn_carts) != geminal_data.num_electron_dn:
         logger.info(
             f"Number of up and dn electrons (N_up, N_dn) = ({len(r_up_carts)}, {len(r_dn_carts)}) are not consistent "
@@ -1348,13 +1358,16 @@ def _compute_geminal_all_elements(
     r_dn_carts: jax.Array,
 ) -> jax.Array:
     """See compute_geminal_all_elements_api."""
-    dtype = get_dtype("geminal")
-    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_eval")
+    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    # orb_matrix_* may be produced in the orb_eval zone (potentially float32).
+    # Explicitly upcast to the geminal zone here so the matmul does not rely
+    # on JAX implicit type promotion (fp32 x fp64 -> fp64).
+    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_jnp)
+    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_jnp)
 
     # compute geminal values
     geminal_paired = jnp.dot(orb_matrix_up.T, jnp.dot(lambda_matrix_paired, orb_matrix_dn))
@@ -1370,16 +1383,15 @@ def _compute_geminal_all_elements_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """See compute_geminal_all_elements_api."""
-    dtype = get_dtype("geminal")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("det_eval")
     r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
     r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
     lambda_matrix_paired, lambda_matrix_unpaired = np.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
     lambda_matrix_paired = np.asarray(lambda_matrix_paired, dtype=dtype_np)
     lambda_matrix_unpaired = np.asarray(lambda_matrix_unpaired, dtype=dtype_np)
 
-    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_np)
+    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_np)
 
     # compute geminal values
     geminal_paired = np.dot(orb_matrix_up.T, np.dot(lambda_matrix_paired, orb_matrix_dn))
@@ -1407,24 +1419,27 @@ def compute_geminal_up_one_row_elements(
     Returns:
         jax.Array: Row vector with shape ``(N_dn + N_unpaired,)``.
     """
-    dtype = get_dtype("geminal")
-    r_up_cart = jnp.asarray(r_up_cart, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_cart(s) are only forwarded to ``compute_orb_api``; do not pre-cast
+    # here (would defeat the AO kernels' fp64 ``r - R`` reconstruction).
+    dtype_jnp = get_dtype_jnp("det_ratio")
     # Split lambda into paired/unpaired blocks along columns
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(
-        geminal_data.lambda_matrix, [geminal_data.orb_num_dn]
+        geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn]
     )  # shapes: (n_orb_up, n_orb_dn), (n_orb_up, num_unpaired)
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
     # Orbital values:
     # - up: single position -> 1D vector (n_orb_up,)
     # - dn: batched positions -> (n_orb_dn, N_dn)
-    orb_up_vec = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_cart)
+    # Explicitly upcast to the geminal zone (compute_orb_api may return
+    # orb_eval dtype, e.g. fp32 for AGP) to avoid relying on JAX implicit
+    # type promotion in the lambda matmul below.
+    orb_up_vec = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_cart).astype(dtype_jnp)
     orb_up_vec = jnp.reshape(orb_up_vec, (-1,))  # ensure (n_orb_up,)
-    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    orb_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_jnp)
     # ensure (n_orb_dn, N_dn)
-    orb_matrix_dn = jnp.asarray(orb_matrix_dn)
+    orb_matrix_dn = jnp.asarray(orb_matrix_dn, dtype=dtype_jnp)
 
     # Paired block row:  (n_orb_up,) @ (n_orb_up, N_dn) -> (N_dn,)
     paired_right = lambda_matrix_paired @ orb_matrix_dn  # (n_orb_up, N_dn)
@@ -1456,22 +1471,25 @@ def compute_geminal_dn_one_column_elements(
     Returns:
         jax.Array: Column vector for the paired block with shape ``(N_up,)``.
     """
-    dtype = get_dtype("geminal")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_cart = jnp.asarray(r_dn_cart, dtype=dtype)
+    # r_*_cart(s) are only forwarded to ``compute_orb_api``; do not pre-cast
+    # here (would defeat the AO kernels' fp64 ``r - R`` reconstruction).
+    dtype_jnp = get_dtype_jnp("det_ratio")
     # Split lambda into paired/unpaired blocks along columns
     lambda_matrix_paired, _lambda_matrix_unpaired = jnp.hsplit(
-        geminal_data.lambda_matrix, [geminal_data.orb_num_dn]
+        geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn]
     )  # lambda_matrix_paired: (n_orb_up, n_orb_dn)
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
 
     # Orbital values:
     # - up: batched positions -> (n_orb_up, N_up)
     # - dn: single position -> 1D vector (n_orb_dn,)
-    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    orb_matrix_up = jnp.asarray(orb_matrix_up)  # (n_orb_up, N_up)
+    # Explicitly upcast to the geminal zone (compute_orb_api may return
+    # orb_eval dtype, e.g. fp32 for AGP) to avoid relying on JAX implicit
+    # type promotion in the lambda matmul below.
+    orb_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_jnp)
+    orb_matrix_up = jnp.asarray(orb_matrix_up, dtype=dtype_jnp)  # (n_orb_up, N_up)
 
-    orb_dn_vec = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_cart)
+    orb_dn_vec = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_cart).astype(dtype_jnp)
     orb_dn_vec = jnp.reshape(orb_dn_vec, (-1,))  # (n_orb_dn,)
 
     # Column of paired block:
@@ -1520,12 +1538,11 @@ def _compute_ratio_determinant_part_rank1_update(
         grid generated by the MCMC loop, where exactly one electron is displaced
         per grid point by construction.
     """
-    dtype = get_dtype("geminal")
-    A_old_inv = jnp.asarray(A_old_inv, dtype=dtype)
-    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
-    new_r_up_carts_arr = jnp.asarray(new_r_up_carts_arr, dtype=dtype)
-    new_r_dn_carts_arr = jnp.asarray(new_r_dn_carts_arr, dtype=dtype)
+    # Forward A_old_inv and old/new r_up/dn_carts as-is (Principle 3a — no
+    # parameter rebind). Module-level forwards (compute_det_geminal_all_elements,
+    # compute_orb_api) handle their own use-site casts. Inline arithmetic below
+    # casts at the use site (Principle 3b) — see jnp.dot with A_old_inv.
+    dtype_jnp = get_dtype_jnp("det_ratio")
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
 
@@ -1558,24 +1575,30 @@ def _compute_ratio_determinant_part_rank1_update(
 
     # lambda split
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.split(
-        geminal_data.lambda_matrix, indices_or_sections=[geminal_data.orb_num_dn], axis=1
+        geminal_data._lambda_matrix_jnp, indices_or_sections=[geminal_data.orb_num_dn], axis=1
     )
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    # Precompute old AO matrices once.
-    orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts)
-    orb_matrix_dn_old = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, old_r_dn_carts)
+    # Precompute old AO matrices once. Explicitly upcast to the geminal zone
+    # (compute_orb_api may return orb_eval dtype, e.g. fp32 for AGP) to avoid
+    # relying on JAX implicit type promotion in the lambda matmuls below.
+    orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts).astype(dtype_jnp)
+    orb_matrix_dn_old = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, old_r_dn_carts).astype(dtype_jnp)
 
     # Batched AO for moved electrons (up) -> rows
-    orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat)  # (n_orb_up, G)
+    orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat).astype(
+        dtype_jnp
+    )  # (n_orb_up, G)
     tmp_up = jnp.dot(orb_up_new_batch.T, lambda_matrix_paired)  # (G, n_orb_dn)
     row_paired = jnp.dot(tmp_up, orb_matrix_dn_old)  # (G, N_dn)
     row_unpaired = jnp.dot(orb_up_new_batch.T, lambda_matrix_unpaired)  # (G, num_unpaired)
     new_rows_up = jnp.hstack([row_paired, row_unpaired])  # (G, N_up)
 
     # Batched AO for moved electrons (dn) -> columns
-    orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat)  # (n_orb_dn, G)
+    orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat).astype(
+        dtype_jnp
+    )  # (n_orb_dn, G)
     w_batch = jnp.dot(lambda_matrix_paired, orb_dn_new_batch)  # (n_orb_up, G)
     cols = jnp.dot(orb_matrix_up_old.T, w_batch)  # (N_up, G)
     new_cols_dn = cols.T  # (G, N_up)
@@ -1583,10 +1606,12 @@ def _compute_ratio_determinant_part_rank1_update(
     # rank-1 determinant ratios for up-move grids and dn-move grids.
     # Use matrix-matrix contractions first to maximize BLAS/TensorCore utilization,
     # then extract the moved-electron component per grid.
-    up_all_cols = jnp.dot(new_rows_up, A_old_inv)  # (N_grid, N_up)
+    # Cast A_old_inv to the det_ratio zone at the use site (Principle 3b).
+    A_old_inv_z = A_old_inv.astype(dtype_jnp)
+    up_all_cols = jnp.dot(new_rows_up, A_old_inv_z)  # (N_grid, N_up)
     det_ratio_up = jnp.take_along_axis(up_all_cols, idx_up[:, None], axis=1).reshape(-1)
 
-    dn_all_rows = jnp.dot(A_old_inv, new_cols_dn.T).T  # (N_grid, N_up)
+    dn_all_rows = jnp.dot(A_old_inv_z, new_cols_dn.T).T  # (N_grid, N_up)
     det_ratio_dn = jnp.take_along_axis(dn_all_rows, idx_dn[:, None], axis=1).reshape(-1)
 
     # Select per grid based on which spin moved.
@@ -1632,12 +1657,11 @@ def _compute_ratio_determinant_part_split_spin(
         exclusively for the block-structured non-local ECP grids produced by
         the MCMC loop.
     """
-    dtype = get_dtype("geminal")
-    A_old_inv = jnp.asarray(A_old_inv, dtype=dtype)
-    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
-    new_r_up_shifted = jnp.asarray(new_r_up_shifted, dtype=dtype)
-    new_r_dn_shifted = jnp.asarray(new_r_dn_shifted, dtype=dtype)
+    # Forward A_old_inv and old/new r_up/dn coords as-is (Principle 3a — no
+    # parameter rebind). Module-level forwards (compute_orb_api,
+    # _compute_ratio_determinant_part_rank1_update) handle their own use-site
+    # casts. A_old_inv is cast at the use site (Principle 3b) below.
+    dtype_jnp = get_dtype_jnp("det_ratio")
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
 
@@ -1656,30 +1680,35 @@ def _compute_ratio_determinant_part_split_spin(
         )
 
     lambda_matrix_paired, lambda_matrix_unpaired = jnp.split(
-        geminal_data.lambda_matrix, indices_or_sections=[geminal_data.orb_num_dn], axis=1
+        geminal_data._lambda_matrix_jnp, indices_or_sections=[geminal_data.orb_num_dn], axis=1
     )
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    # Precompute old AO matrices once.
-    orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts)
-    orb_matrix_dn_old = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, old_r_dn_carts)
+    # Precompute old AO matrices once. Explicitly upcast to the geminal zone
+    # (compute_orb_api may return orb_eval dtype, e.g. fp32 for AGP) to avoid
+    # relying on JAX implicit type promotion in the lambda matmuls below.
+    orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts).astype(dtype_jnp)
+    orb_matrix_dn_old = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, old_r_dn_carts).astype(dtype_jnp)
 
     # ── UP BLOCK: up electron moved, dn unchanged ──────────────────────────────
-    g_up = new_r_up_shifted.shape[0]
     delta_up = new_r_up_shifted - old_r_up_carts  # (G_up, N_up, 3)
     moved_up_mask = jnp.any(delta_up != 0.0, axis=2)  # (G_up, N_up)
     idx_up = jnp.argmax(moved_up_mask.astype(jnp.int32), axis=1)  # (G_up,)
     r_up_new_flat = jnp.take_along_axis(new_r_up_shifted, idx_up[:, None, None], axis=1).reshape(-1, 3)
 
     # Only evaluate up-spin MOs for the moved electron positions.
-    orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat)  # (n_orb_up, G_up)
+    orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat).astype(
+        dtype_jnp
+    )  # (n_orb_up, G_up)
     tmp_up = jnp.dot(orb_up_new_batch.T, lambda_matrix_paired)  # (G_up, n_orb_dn)
     row_paired = jnp.dot(tmp_up, orb_matrix_dn_old)  # (G_up, N_dn)
     row_unpaired = jnp.dot(orb_up_new_batch.T, lambda_matrix_unpaired)  # (G_up, num_unpaired)
     new_rows_up = jnp.hstack([row_paired, row_unpaired])  # (G_up, N_up)
 
-    A_col_for_up = jnp.take(A_old_inv, idx_up, axis=1).T  # (G_up, N_up)
+    # Cast A_old_inv to the det_ratio zone at the use site (Principle 3b).
+    A_old_inv_z = A_old_inv.astype(dtype_jnp)
+    A_col_for_up = jnp.take(A_old_inv_z, idx_up, axis=1).T  # (G_up, N_up)
     det_ratio_up_block = jnp.sum(new_rows_up * A_col_for_up, axis=1)  # (G_up,)
 
     # ── DN BLOCK: dn electron moved, up unchanged ──────────────────────────────
@@ -1689,11 +1718,13 @@ def _compute_ratio_determinant_part_split_spin(
     r_dn_new_flat = jnp.take_along_axis(new_r_dn_shifted, idx_dn[:, None, None], axis=1).reshape(-1, 3)
 
     # Only evaluate dn-spin MOs for the moved electron positions.
-    orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat)  # (n_orb_dn, G_dn)
+    orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat).astype(
+        dtype_jnp
+    )  # (n_orb_dn, G_dn)
     w_batch = jnp.dot(lambda_matrix_paired, orb_dn_new_batch)  # (n_orb_up, G_dn)
     new_cols_dn = jnp.dot(orb_matrix_up_old.T, w_batch).T  # (G_dn, N_up)
 
-    A_row_for_dn = jnp.take(A_old_inv, idx_dn, axis=0)  # (G_dn, N_up)
+    A_row_for_dn = jnp.take(A_old_inv_z, idx_dn, axis=0)  # (G_dn, N_up)
     det_ratio_dn_block = jnp.sum(A_row_for_dn * new_cols_dn, axis=1)  # (G_dn,)
 
     return jnp.concatenate([det_ratio_up_block, det_ratio_dn_block])
@@ -1707,8 +1738,7 @@ def _compute_ratio_determinant_part_debug(
     new_r_dn_carts_arr: npt.NDArray[np.float64],
 ) -> npt.NDArray:
     """See _api method."""
-    dtype = get_dtype("determinant")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("det_ratio")
     old_r_up_carts = np.asarray(old_r_up_carts, dtype=dtype_np)
     old_r_dn_carts = np.asarray(old_r_dn_carts, dtype=dtype_np)
     new_r_up_carts_arr = np.asarray(new_r_up_carts_arr, dtype=dtype_np)
@@ -1789,28 +1819,34 @@ def compute_grads_and_laplacian_ln_Det(
             - Laplacians for spin-up electrons with shape ``(N_up,)``.
             - Laplacians for spin-down electrons with shape ``(N_dn,)``.
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
+    # NOTE: do not pre-cast r_*_carts. They are forwarded to
+    # ``compute_geminal_all_elements`` and ``compute_orb_*_api``; the AO
+    # kernels reconstruct ``r - R`` in float64 internally and a wrapper-level
+    # downcast would defeat that guard. Arithmetic in this function uses
+    # ``ao_matrix_*`` / ``lambda_matrix_*`` (cast at their own use sites).
     # Compute G_inv via SVD pseudoinverse (numerically stable, avoids LU NaN).
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     _U, _s, _Vt = jnp.linalg.svd(G, full_matrices=False)
     # Use conservative threshold to prevent G^{-2} and G^{-3} terms in the
     # backward pass from diverging. Standard numpy.linalg.pinv uses max(M,N)*eps,
     # but for de_L/dc (which involves G_inv^2 in the chain rule) we need a larger
     # safety margin to avoid Inf/NaN in the gradient. EPS_rcond_SVD is set in setting.py
     # to handle near-singular G while preserving well-conditioned singular values.
-    eps_rcond = get_eps("rcond_svd", dtype)
-    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype) / _s, jnp.asarray(0.0, dtype=dtype))
+    eps_rcond = get_eps("rcond_svd", dtype_jnp)
+    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype_jnp) / _s, jnp.asarray(0.0, dtype=dtype_jnp))
     geminal_inverse = (_Vt.T * _s_inv[jnp.newaxis, :]) @ _U.T
 
-    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    # Explicitly upcast AO/MO forward values to the kinetic zone
+    # (compute_orb_api may return orb_eval dtype, e.g. fp32 for AGP) to avoid
+    # relying on JAX implicit type promotion in the lambda/gradient matmuls below.
+    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_jnp)
+    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_jnp)
 
     ao_matrix_up_grad_x, ao_matrix_up_grad_y, ao_matrix_up_grad_z = geminal_data.compute_orb_grad_api(
         geminal_data.orb_data_up_spin, r_up_carts
@@ -1834,7 +1870,7 @@ def compute_grads_and_laplacian_ln_Det(
     geminal_grad_dn_paired = jnp.einsum("ia,gaj->gij", ao_matrix_up.T, paired_dn_grads)
     geminal_grad_dn_unpaired = jnp.zeros(
         (3, geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn),
-        dtype=geminal_grad_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_grad_dn = jnp.concatenate([geminal_grad_dn_paired, geminal_grad_dn_unpaired], axis=2)
 
@@ -1845,7 +1881,7 @@ def compute_grads_and_laplacian_ln_Det(
     geminal_laplacian_dn_paired = jnp.dot(ao_matrix_up.T, jnp.dot(lambda_matrix_paired, ao_matrix_laplacian_dn))
     geminal_laplacian_dn_unpaired = jnp.zeros(
         [geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn],
-        dtype=geminal_laplacian_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_laplacian_dn = jnp.hstack([geminal_laplacian_dn_paired, geminal_laplacian_dn_unpaired])
 
@@ -1887,16 +1923,19 @@ def _grads_lap_body(
     passed to ``jax.vjp`` inside the custom VJP backward pass without creating
     a dependency on the public fast function.
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    geminal_inverse = jnp.asarray(geminal_inverse, dtype=dtype)
-    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
+    # r_*_carts are only forwarded; do not pre-cast (see the public function
+    # ``compute_grads_and_laplacian_ln_Det`` for the rationale).
+    geminal_inverse = jnp.asarray(geminal_inverse, dtype=dtype_jnp)
+    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    # Explicitly upcast AO/MO forward values to the kinetic zone
+    # (compute_orb_api may return orb_eval dtype, e.g. fp32 for AGP) to avoid
+    # relying on JAX implicit type promotion in the lambda/gradient matmuls below.
+    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_jnp)
+    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_jnp)
 
     ao_matrix_up_grad_x, ao_matrix_up_grad_y, ao_matrix_up_grad_z = geminal_data.compute_orb_grad_api(
         geminal_data.orb_data_up_spin, r_up_carts
@@ -1920,7 +1959,7 @@ def _grads_lap_body(
     geminal_grad_dn_paired = jnp.einsum("ia,gaj->gij", ao_matrix_up.T, paired_dn_grads)
     geminal_grad_dn_unpaired = jnp.zeros(
         (3, geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn),
-        dtype=geminal_grad_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_grad_dn = jnp.concatenate([geminal_grad_dn_paired, geminal_grad_dn_unpaired], axis=2)
 
@@ -1931,7 +1970,7 @@ def _grads_lap_body(
     geminal_laplacian_dn_paired = jnp.dot(ao_matrix_up.T, jnp.dot(lambda_matrix_paired, ao_matrix_laplacian_dn))
     geminal_laplacian_dn_unpaired = jnp.zeros(
         [geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn],
-        dtype=geminal_laplacian_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_laplacian_dn = jnp.hstack([geminal_laplacian_dn_paired, geminal_laplacian_dn_unpaired])
 
@@ -1966,15 +2005,15 @@ def _grads_lap_fwd(
     r_dn_carts: jax.Array,
 ):
     """Forward pass: compute stable G_inv and primal outputs."""
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
+    # r_*_carts are only forwarded; do not pre-cast (see
+    # ``compute_grads_and_laplacian_ln_Det`` for the rationale).
     G = compute_geminal_all_elements(geminal_data, r_up_carts, r_dn_carts)
-    G = jnp.asarray(G, dtype=dtype)
+    G = jnp.asarray(G, dtype=dtype_jnp)
     _U, _s, _Vt = jnp.linalg.svd(G, full_matrices=False)
     # Use same conservative threshold as in compute_grads_and_laplacian_ln_Det
-    eps_rcond = get_eps("rcond_svd", dtype)
-    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype) / _s, jnp.asarray(0.0, dtype=dtype))
+    eps_rcond = get_eps("rcond_svd", dtype_jnp)
+    _s_inv = jnp.where(_s > eps_rcond * _s[0], jnp.asarray(1.0, dtype=dtype_jnp) / _s, jnp.asarray(0.0, dtype=dtype_jnp))
     G_inv_stable = (_Vt.T * _s_inv[jnp.newaxis, :]) @ _U.T
     primals = _grads_lap_body(geminal_data, r_up_carts, r_dn_carts, G_inv_stable)
     return primals, (geminal_data, r_up_carts, r_dn_carts, G_inv_stable)
@@ -2006,9 +2045,9 @@ def _grads_lap_bwd(res, g):
         :func:`compute_grads_and_laplacian_ln_Det` for details).  Keep
         ``EPS_rcond_SVD`` very small (e.g. ``1e-20``) to avoid this.
     """
-    dtype = get_dtype("kinetic")
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
     geminal_data, r_up_carts, r_dn_carts, G_inv_stable = res
-    G_inv_stable = jnp.asarray(G_inv_stable, dtype=dtype)
+    G_inv_stable = jnp.asarray(G_inv_stable, dtype=dtype_jnp)
 
     # Step 1: differentiate _grads_lap_body w.r.t. all args.
     # This gives direct gradients (AO path) and G_inv_bar (cotangent for G_inv).
@@ -2030,8 +2069,12 @@ def _grads_lap_bwd(res, g):
     # determined by (r_up_carts, r_dn_carts) (kinetic zone). In mixed precision the
     # G_inv_bar / G_inv_stable arithmetic can promote ``G_bar_from_inv`` to a wider
     # dtype, so cast back to the primal output dtype before invoking ``vjp_fn2``.
-    geminal_primal_out, vjp_fn2 = jax.vjp(compute_geminal_all_elements, geminal_data, r_up_carts, r_dn_carts)
-    G_bar_from_inv = jnp.asarray(G_bar_from_inv, dtype=geminal_primal_out.dtype)
+    # The vjp_fn2 cotangent dtype must match the primal output dtype of
+    # compute_geminal_all_elements (det_eval zone). Use get_dtype_jnp("det_eval")
+    # explicitly rather than borrowing geminal_primal_out.dtype, to keep the
+    # cast target source-visible per the consumer-zone principle.
+    _, vjp_fn2 = jax.vjp(compute_geminal_all_elements, geminal_data, r_up_carts, r_dn_carts)
+    G_bar_from_inv = jnp.asarray(G_bar_from_inv, dtype=get_dtype_jnp("det_eval"))
     d_geminal_inv, d_r_up_inv, d_r_dn_inv = vjp_fn2(G_bar_from_inv)
 
     # Total: sum both contributions.
@@ -2077,17 +2120,20 @@ def compute_grads_and_laplacian_ln_Det_fast(
     if geminal_inverse is None:
         raise ValueError("geminal_inverse must be provided for fast evaluation")
 
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    geminal_inverse = jnp.asarray(geminal_inverse, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
+    # r_*_carts and geminal_inverse are only forwarded; do not pre-cast
+    # (Principle 3a — no parameter rebind). geminal_inverse is cast to the
+    # det_grad_lap zone at each einsum use site below (Principle 3b).
 
-    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data.lambda_matrix, [geminal_data.orb_num_dn])
-    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype)
-    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype)
+    lambda_matrix_paired, lambda_matrix_unpaired = jnp.hsplit(geminal_data._lambda_matrix_jnp, [geminal_data.orb_num_dn])
+    lambda_matrix_paired = jnp.asarray(lambda_matrix_paired, dtype=dtype_jnp)
+    lambda_matrix_unpaired = jnp.asarray(lambda_matrix_unpaired, dtype=dtype_jnp)
 
-    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts)
-    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts)
+    # Explicitly upcast AO/MO forward values to the kinetic zone
+    # (compute_orb_api may return orb_eval dtype, e.g. fp32 for AGP) to avoid
+    # relying on JAX implicit type promotion in the lambda/gradient matmuls below.
+    ao_matrix_up = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_carts).astype(dtype_jnp)
+    ao_matrix_dn = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_carts).astype(dtype_jnp)
 
     ao_matrix_up_grad_x, ao_matrix_up_grad_y, ao_matrix_up_grad_z = geminal_data.compute_orb_grad_api(
         geminal_data.orb_data_up_spin, r_up_carts
@@ -2111,7 +2157,7 @@ def compute_grads_and_laplacian_ln_Det_fast(
     geminal_grad_dn_paired = jnp.einsum("ia,gaj->gij", ao_matrix_up.T, paired_dn_grads)
     geminal_grad_dn_unpaired = jnp.zeros(
         (3, geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn),
-        dtype=geminal_grad_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_grad_dn = jnp.concatenate([geminal_grad_dn_paired, geminal_grad_dn_unpaired], axis=2)
 
@@ -2122,12 +2168,14 @@ def compute_grads_and_laplacian_ln_Det_fast(
     geminal_laplacian_dn_paired = jnp.dot(ao_matrix_up.T, jnp.dot(lambda_matrix_paired, ao_matrix_laplacian_dn))
     geminal_laplacian_dn_unpaired = jnp.zeros(
         [geminal_data.num_electron_up, geminal_data.num_electron_up - geminal_data.num_electron_dn],
-        dtype=geminal_laplacian_dn_paired.dtype,
+        dtype=dtype_jnp,
     )
     geminal_laplacian_dn = jnp.hstack([geminal_laplacian_dn_paired, geminal_laplacian_dn_unpaired])
 
-    grad_ln_D_up_stack = jnp.einsum("gij,ji->gi", geminal_grad_up, geminal_inverse)
-    grad_ln_D_dn_stack = jnp.einsum("ij,gji->gi", geminal_inverse, geminal_grad_dn)
+    # Cast geminal_inverse to the det_grad_lap zone at the use site (Principle 3b).
+    G_inv = geminal_inverse.astype(dtype_jnp)
+    grad_ln_D_up_stack = jnp.einsum("gij,ji->gi", geminal_grad_up, G_inv)
+    grad_ln_D_dn_stack = jnp.einsum("ij,gji->gi", G_inv, geminal_grad_dn)
 
     grad_ln_D_up = grad_ln_D_up_stack.T
     grad_ln_D_dn = grad_ln_D_dn_stack.T
@@ -2137,11 +2185,11 @@ def compute_grads_and_laplacian_ln_Det_fast(
 
     lap_ln_D_up = -(
         grad_ln_D_up_x * grad_ln_D_up_x + grad_ln_D_up_y * grad_ln_D_up_y + grad_ln_D_up_z * grad_ln_D_up_z
-    ) + jnp.einsum("ij,ji->i", geminal_laplacian_up, geminal_inverse)
+    ) + jnp.einsum("ij,ji->i", geminal_laplacian_up, G_inv)
 
     lap_ln_D_dn = -(
         grad_ln_D_dn_x * grad_ln_D_dn_x + grad_ln_D_dn_y * grad_ln_D_dn_y + grad_ln_D_dn_z * grad_ln_D_dn_z
-    ) + jnp.einsum("ij,ji->i", geminal_inverse, geminal_laplacian_dn)
+    ) + jnp.einsum("ij,ji->i", G_inv, geminal_laplacian_dn)
 
     # Trim to n_dn for open-shell (N_up > N_dn) systems
     n_dn = geminal_data.num_electron_dn
@@ -2157,9 +2205,8 @@ def _compute_grads_and_laplacian_ln_Det_fast_debug(
     r_dn_carts: jax.Array,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     """Debug helper that uses auto-diff to validate the fast path."""
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # Pure delegation to ``_compute_grads_and_laplacian_ln_Det_auto``;
+    # no cast needed at this wrapper.
     # Use auto-diff as the reference (independent implementation).
     grad_ln_D_up, grad_ln_D_dn, lap_ln_D_up, lap_ln_D_dn = _compute_grads_and_laplacian_ln_Det_auto(
         geminal_data=geminal_data,
@@ -2186,24 +2233,27 @@ def _compute_grads_and_laplacian_ln_Det_auto(
     Uses autodiff on ln|det(G)| to compute gradients w.r.t. electron positions
     and per-electron Laplacians.
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). Cast
+    # to the det_grad_lap zone at the use site before passing as the
+    # differentiation operand to grad/jacfwd (Principle 3b).
+    dtype_jnp = get_dtype_jnp("det_grad_lap")
+    r_up_z = r_up_carts.astype(dtype_jnp)
+    r_dn_z = r_dn_carts.astype(dtype_jnp)
 
     def ln_det_fn(r_up, r_dn):
         return compute_ln_det_geminal_all_elements(geminal_data, r_up, r_dn)
 
-    grad_ln_D_up = jax.grad(ln_det_fn, argnums=0)(r_up_carts, r_dn_carts)
-    grad_ln_D_dn = jax.grad(ln_det_fn, argnums=1)(r_up_carts, r_dn_carts)
+    grad_ln_D_up = jax.grad(ln_det_fn, argnums=0)(r_up_z, r_dn_z)
+    grad_ln_D_dn = jax.grad(ln_det_fn, argnums=1)(r_up_z, r_dn_z)
 
     def grad_up_fn(r_up):
-        return jax.grad(ln_det_fn, argnums=0)(r_up, r_dn_carts)
+        return jax.grad(ln_det_fn, argnums=0)(r_up, r_dn_z)
 
     def grad_dn_fn(r_dn):
-        return jax.grad(ln_det_fn, argnums=1)(r_up_carts, r_dn)
+        return jax.grad(ln_det_fn, argnums=1)(r_up_z, r_dn)
 
-    jac_up = jax.jacfwd(grad_up_fn)(r_up_carts)
-    jac_dn = jax.jacfwd(grad_dn_fn)(r_dn_carts)
+    jac_up = jax.jacfwd(grad_up_fn)(r_up_z)
+    jac_dn = jax.jacfwd(grad_dn_fn)(r_dn_z)
 
     laplacian_ln_D_up = jnp.einsum("ijij->i", jac_up)
     laplacian_ln_D_dn = jnp.einsum("ijij->i", jac_dn)
@@ -2222,8 +2272,7 @@ def _compute_grads_and_laplacian_ln_Det_debug(
     np.ndarray,
 ]:
     """See compute_grads_and_laplacian_ln_Det_api."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("det_grad_lap")
     r_up_carts = np.asarray(r_up_carts, dtype=dtype_np)
     r_dn_carts = np.asarray(r_dn_carts, dtype=dtype_np)
     det_geminal = compute_det_geminal_all_elements(

--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -2026,7 +2026,12 @@ def _grads_lap_bwd(res, g):
     G_bar_from_inv = -(G_inv_stable.T @ G_inv_bar @ G_inv_stable.T)
 
     # Step 3: propagate G_bar back through G = compute_geminal_all_elements(...).
-    _, vjp_fn2 = jax.vjp(compute_geminal_all_elements, geminal_data, r_up_carts, r_dn_carts)
+    # ``vjp_fn2`` is built around the un-cast call, whose primal output dtype is
+    # determined by (r_up_carts, r_dn_carts) (kinetic zone). In mixed precision the
+    # G_inv_bar / G_inv_stable arithmetic can promote ``G_bar_from_inv`` to a wider
+    # dtype, so cast back to the primal output dtype before invoking ``vjp_fn2``.
+    geminal_primal_out, vjp_fn2 = jax.vjp(compute_geminal_all_elements, geminal_data, r_up_carts, r_dn_carts)
+    G_bar_from_inv = jnp.asarray(G_bar_from_inv, dtype=geminal_primal_out.dtype)
     d_geminal_inv, d_r_up_inv, d_r_dn_inv = vjp_fn2(G_bar_from_inv)
 
     # Total: sum both contributions.

--- a/jqmc/hamiltonians.py
+++ b/jqmc/hamiltonians.py
@@ -1,4 +1,11 @@
-"""Hamiltonian module."""
+"""Hamiltonian module.
+
+Precision Zones:
+    Zone-boundary aggregation -- combines ``kinetic`` (T) and ``coulomb`` (V)
+    results, cast to ``kinetic`` zone dtype.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -49,6 +56,7 @@ from flax import struct
 from jax import jit
 from jax import typing as jnpt
 
+from ._precision import get_dtype
 from .coulomb_potential import Coulomb_potential_data, compute_coulomb_potential, compute_coulomb_potential_fast
 from .structure import Structure_data
 from .wavefunction import (
@@ -191,6 +199,10 @@ def compute_local_energy(
     Returns:
         float: The value of local energy (e_L) with the given wavefunction (float)
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     T = compute_kinetic_energy(
         wavefunction_data=hamiltonian_data.wavefunction_data,
         r_up_carts=r_up_carts,
@@ -205,7 +217,7 @@ def compute_local_energy(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return T + V
+    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
 
 
 def compute_local_energy_fast(
@@ -251,6 +263,10 @@ def compute_local_energy_fast(
         Passing an inverse from a different configuration silently produces
         incorrect kinetic energy.
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     T_up_elements, T_dn_elements = compute_kinetic_energy_all_elements_fast_update(
         wavefunction_data=hamiltonian_data.wavefunction_data,
         r_up_carts=r_up_carts,
@@ -268,7 +284,7 @@ def compute_local_energy_fast(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return T + V
+    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
 
 
 @jit
@@ -295,6 +311,10 @@ def _compute_local_energy_auto(
     Returns:
         float: The value of local energy (e_L) with the given wavefunction (float)
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     T = _compute_kinetic_energy_auto(
         wavefunction_data=hamiltonian_data.wavefunction_data,
         r_up_carts=r_up_carts,
@@ -309,7 +329,7 @@ def _compute_local_energy_auto(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return T + V
+    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
 
 
 def _reconstruct_dataclass(cls, obj):
@@ -496,7 +516,7 @@ def _load_dataclass_from_hdf5(cls: Type[T], group: h5py.Group) -> T:
                 and "list" not in str(field.type)
                 and "tuple" not in str(field.type)
             ):
-                val = jnp.asarray(val, dtype=jnp.float64)
+                val = jnp.asarray(val, dtype=get_dtype("io"))
 
             init_args[field.name] = val
         elif field.name in group.attrs:

--- a/jqmc/hamiltonians.py
+++ b/jqmc/hamiltonians.py
@@ -56,7 +56,7 @@ from flax import struct
 from jax import jit
 from jax import typing as jnpt
 
-from ._precision import get_dtype
+from ._precision import get_dtype_jnp
 from .coulomb_potential import Coulomb_potential_data, compute_coulomb_potential, compute_coulomb_potential_fast
 from .structure import Structure_data
 from .wavefunction import (
@@ -199,9 +199,10 @@ def compute_local_energy(
     Returns:
         float: The value of local energy (e_L) with the given wavefunction (float)
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("local_energy")
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). Each
+    # downstream consumer (compute_kinetic_energy, compute_coulomb_potential)
+    # casts to its own zone at the use site.
 
     T = compute_kinetic_energy(
         wavefunction_data=hamiltonian_data.wavefunction_data,
@@ -217,7 +218,8 @@ def compute_local_energy(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
+    # Cast scalar zone outputs to local_energy zone at the sum (Principle 3b).
+    return T.astype(dtype_jnp) + V.astype(dtype_jnp)
 
 
 def compute_local_energy_fast(
@@ -263,9 +265,9 @@ def compute_local_energy_fast(
         Passing an inverse from a different configuration silently produces
         incorrect kinetic energy.
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("local_energy")
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). Each
+    # downstream consumer casts to its own zone at the use site.
 
     T_up_elements, T_dn_elements = compute_kinetic_energy_all_elements_fast_update(
         wavefunction_data=hamiltonian_data.wavefunction_data,
@@ -284,7 +286,8 @@ def compute_local_energy_fast(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
+    # Cast scalar zone outputs to local_energy zone at the sum (Principle 3b).
+    return T.astype(dtype_jnp) + V.astype(dtype_jnp)
 
 
 @jit
@@ -311,9 +314,9 @@ def _compute_local_energy_auto(
     Returns:
         float: The value of local energy (e_L) with the given wavefunction (float)
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("local_energy")
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). Each
+    # downstream consumer casts to its own zone at the use site.
 
     T = _compute_kinetic_energy_auto(
         wavefunction_data=hamiltonian_data.wavefunction_data,
@@ -329,7 +332,8 @@ def _compute_local_energy_auto(
         wavefunction_data=hamiltonian_data.wavefunction_data,
     )
 
-    return jnp.asarray(T, dtype=dtype) + jnp.asarray(V, dtype=dtype)
+    # Cast scalar zone outputs to local_energy zone at the sum (Principle 3b).
+    return T.astype(dtype_jnp) + V.astype(dtype_jnp)
 
 
 def _reconstruct_dataclass(cls, obj):
@@ -508,15 +512,19 @@ def _load_dataclass_from_hdf5(cls: Type[T], group: h5py.Group) -> T:
             elif isinstance(val, list) and (field.type is tuple or "tuple" in str(field.type)):
                 val = tuple(val)
 
-            # Convert np.ndarray or list/tuple to jax.Array for fields typed as jax.Array
+            # Convert np.ndarray or list/tuple to jax.Array for fields typed as jax.Array.
+            # Note: fields typed `npt.NDArray[np.float64]` (string-form annotation) must
+            # NOT trigger this branch — they are stored as numpy arrays. Exclude both
+            # "ndarray" (resolved form) and "NDArray" (npt alias form).
             if (
                 isinstance(val, (np.ndarray, list, tuple))
                 and "Array" in str(field.type)
                 and "ndarray" not in str(field.type)
+                and "NDArray" not in str(field.type)
                 and "list" not in str(field.type)
                 and "tuple" not in str(field.type)
             ):
-                val = jnp.asarray(val, dtype=get_dtype("io"))
+                val = jnp.asarray(val, dtype=jnp.float64)
 
             init_args[field.name] = val
         elif field.name in group.attrs:

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -436,7 +436,9 @@ class NNJastrow(nn.Module):
         dtype_j = get_dtype("jastrow")
         if A.shape[0] == 0 or B.shape[0] == 0:
             return jnp.zeros((A.shape[0], B.shape[0]), dtype=dtype_j)
-        diff = A[:, None, :] - B[None, :, :]
+        # Compute differences in float64 to avoid catastrophic cancellation
+        # under float32 jastrow zone, then downcast.
+        diff = (A.astype(jnp.float64)[:, None, :] - B.astype(jnp.float64)[None, :, :]).astype(dtype_j)
         return jnp.sqrt(jnp.sum(diff**2, axis=-1) + EPS_safe_distance)
 
     def _nuclear_embeddings(self, Z_n: jnp.ndarray) -> jnp.ndarray:
@@ -676,7 +678,9 @@ def compute_Jastrow_one_body(
             R_cart: jnpt.ArrayLike,
         ) -> float:
             """Exponential form of J1."""
-            return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * coeff * jnp.linalg.norm(r_cart - R_cart)))
+            # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+            diff = (r_cart.astype(jnp.float64) - R_cart.astype(jnp.float64)).astype(r_cart.dtype)
+            return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * coeff * jnp.linalg.norm(diff)))
 
         def atom_contrib(r_cart, R_cart, Z_eff):
             coeff = (2.0 * Z_eff) ** (1.0 / 4.0)
@@ -686,7 +690,9 @@ def compute_Jastrow_one_body(
 
         def atom_contrib(r_cart, R_cart, Z_eff):
             """Pade form of J1: -Z_eff^{3/4} * r_eN / (2*(1 + a * Z_eff^{1/4} * r_eN))."""
-            r_eN = jnp.linalg.norm(r_cart - R_cart)
+            # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
+            diff = (r_cart.astype(jnp.float64) - R_cart.astype(jnp.float64)).astype(r_cart.dtype)
+            r_eN = jnp.linalg.norm(diff)
             coeff = (2.0 * Z_eff) ** (1.0 / 4.0)
             return -((2.0 * Z_eff) ** (3.0 / 4.0)) * r_eN / (2.0 * (1.0 + j1b * coeff * r_eN))
 
@@ -1114,11 +1120,16 @@ def compute_Jastrow_two_body(
 
     def two_body_jastrow_exp(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Exponential form of J2."""
-        return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * jnp.linalg.norm(r_cart_i - r_cart_j)))
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_cart_i.astype(jnp.float64) - r_cart_j.astype(jnp.float64)).astype(r_cart_i.dtype)
+        return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * jnp.linalg.norm(diff)))
 
     def two_body_jastrow_pade(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Pade form of J2."""
-        return jnp.linalg.norm(r_cart_i - r_cart_j) / 2.0 * (1.0 + param * jnp.linalg.norm(r_cart_i - r_cart_j)) ** (-1.0)
+        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
+        diff = (r_cart_i.astype(jnp.float64) - r_cart_j.astype(jnp.float64)).astype(r_cart_i.dtype)
+        r_ij = jnp.linalg.norm(diff)
+        return r_ij / 2.0 * (1.0 + param * r_ij) ** (-1.0)
 
     if j2b_type == "pade":
         two_body_jastrow_anti_parallel = two_body_jastrow_pade

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -656,11 +656,14 @@ def compute_Jastrow_one_body(
         float: One-body Jastrow value (before exponentiation).
     """
     dtype = get_dtype("jastrow")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
     # Retrieve structure data and convert to JAX arrays
     R_carts = jnp.array(jastrow_one_body_data.structure_data.positions, dtype=dtype)
     atomic_numbers = jnp.array(jastrow_one_body_data.structure_data.atomic_numbers, dtype=dtype)
     core_electrons = jnp.array(jastrow_one_body_data.core_electrons, dtype=dtype)
     effective_charges = atomic_numbers - core_electrons
+    j1b = jnp.asarray(jastrow_one_body_data.jastrow_1b_param, dtype=dtype)
 
     j1b_type = jastrow_one_body_data.jastrow_1b_type
 
@@ -676,7 +679,6 @@ def compute_Jastrow_one_body(
             return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * coeff * jnp.linalg.norm(r_cart - R_cart)))
 
         def atom_contrib(r_cart, R_cart, Z_eff):
-            j1b = jastrow_one_body_data.jastrow_1b_param
             coeff = (2.0 * Z_eff) ** (1.0 / 4.0)
             return -((2.0 * Z_eff) ** (3.0 / 4.0)) * one_body_jastrow_kernel(j1b, coeff, r_cart, R_cart)
 
@@ -684,7 +686,6 @@ def compute_Jastrow_one_body(
 
         def atom_contrib(r_cart, R_cart, Z_eff):
             """Pade form of J1: -Z_eff^{3/4} * r_eN / (2*(1 + a * Z_eff^{1/4} * r_eN))."""
-            j1b = jastrow_one_body_data.jastrow_1b_param
             r_eN = jnp.linalg.norm(r_cart - R_cart)
             coeff = (2.0 * Z_eff) ** (1.0 / 4.0)
             return -((2.0 * Z_eff) ** (3.0 / 4.0)) * r_eN / (2.0 * (1.0 + j1b * coeff * r_eN))
@@ -1105,6 +1106,10 @@ def compute_Jastrow_two_body(
     Returns:
         float: Two-body Jastrow value (before exponentiation).
     """
+    dtype_j2 = get_dtype("jastrow")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype_j2)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype_j2)
+    j2b_param = jnp.asarray(jastrow_two_body_data.jastrow_2b_param, dtype=dtype_j2)
     j2b_type = jastrow_two_body_data.jastrow_2b_type
 
     def two_body_jastrow_exp(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
@@ -1128,18 +1133,14 @@ def compute_Jastrow_two_body(
         vmap(two_body_jastrow_anti_parallel, in_axes=(None, None, 0)), in_axes=(None, 0, None)
     )
 
-    two_body_jastrow_anti_parallel_val = jnp.sum(
-        vmap_two_body_jastrow_anti_parallel_spins(jastrow_two_body_data.jastrow_2b_param, r_up_carts, r_dn_carts)
-    )
+    two_body_jastrow_anti_parallel_val = jnp.sum(vmap_two_body_jastrow_anti_parallel_spins(j2b_param, r_up_carts, r_dn_carts))
 
     def compute_parallel_sum(r_carts):
         num_particles = r_carts.shape[0]
         idx_i, idx_j = jnp.triu_indices(num_particles, k=1)
         r_i = r_carts[idx_i]
         r_j = r_carts[idx_j]
-        vmap_two_body_jastrow_parallel_spins = vmap(two_body_jastrow_parallel, in_axes=(None, 0, 0))(
-            jastrow_two_body_data.jastrow_2b_param, r_i, r_j
-        )
+        vmap_two_body_jastrow_parallel_spins = vmap(two_body_jastrow_parallel, in_axes=(None, 0, 0))(j2b_param, r_i, r_j)
         return jnp.sum(vmap_two_body_jastrow_parallel_spins)
 
     two_body_jastrow_parallel_up = compute_parallel_sum(r_up_carts)
@@ -1656,6 +1657,9 @@ def compute_Jastrow_three_body(
         float: Three-body Jastrow value (before exponentiation).
     """
     dtype = get_dtype("jastrow")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    j_matrix = jastrow_three_body_data.j_matrix.astype(dtype)
     num_electron_up = len(r_up_carts)
     num_electron_dn = len(r_dn_carts)
 
@@ -1665,11 +1669,11 @@ def compute_Jastrow_three_body(
     K_up = jnp.tril(jnp.ones((num_electron_up, num_electron_up), dtype=dtype), k=-1)
     K_dn = jnp.tril(jnp.ones((num_electron_dn, num_electron_dn), dtype=dtype), k=-1)
 
-    j1_matrix_up = jastrow_three_body_data.j_matrix[:, -1]
-    j1_matrix_dn = jastrow_three_body_data.j_matrix[:, -1]
-    j3_matrix_up_up = jastrow_three_body_data.j_matrix[:, :-1]
-    j3_matrix_dn_dn = jastrow_three_body_data.j_matrix[:, :-1]
-    j3_matrix_up_dn = jastrow_three_body_data.j_matrix[:, :-1]
+    j1_matrix_up = j_matrix[:, -1]
+    j1_matrix_dn = j_matrix[:, -1]
+    j3_matrix_up_up = j_matrix[:, :-1]
+    j3_matrix_dn_dn = j_matrix[:, :-1]
+    j3_matrix_up_dn = j_matrix[:, :-1]
 
     e_up = jnp.ones(num_electron_up, dtype=dtype).T
     e_dn = jnp.ones(num_electron_dn, dtype=dtype).T
@@ -2060,8 +2064,11 @@ def compute_Jastrow_part(jastrow_data: Jastrow_data, r_up_carts: jax.Array, r_dn
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
         R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
-        J3_nn = nn3.nn_def.apply({"params": nn3.params}, r_up_carts, r_dn_carts, R_n, Z_n)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
+        nn_params = jax.tree_util.tree_map(
+            lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+        )
+        J3_nn = nn3.nn_def.apply({"params": nn_params}, r_up_carts, r_dn_carts, R_n, Z_n)
         J3 = J3 + J3_nn
 
     J = J1 + J2 + J3
@@ -2101,8 +2108,11 @@ def _compute_Jastrow_part_debug(
         Z_n = np.asarray(nn3.structure_data.atomic_numbers, dtype=dtype_np)
 
         # Use JAX NN for debug as well; convert inputs to jnp and back to float
+        nn_params = jax.tree_util.tree_map(
+            lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+        )
         J3_nn = nn3.nn_def.apply(
-            {"params": nn3.params},
+            {"params": nn_params},
             jnp.asarray(r_up_carts, dtype=dtype),
             jnp.asarray(r_dn_carts, dtype=dtype),
             jnp.asarray(R_n, dtype=dtype),
@@ -2854,10 +2864,13 @@ def compute_grads_and_laplacian_Jastrow_part(
         r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
         r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
         R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
-            return nn3.nn_def.apply({"params": nn3.params}, r_up, r_dn, R_n, Z_n)
+            nn_params = jax.tree_util.tree_map(
+                lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+            )
+            return nn3.nn_def.apply({"params": nn_params}, r_up, r_dn, R_n, Z_n)
 
         grad_JNN_up = grad(_compute_Jastrow_nn_only, argnums=0)(r_up_carts_jnp, r_dn_carts_jnp)
         grad_JNN_dn = grad(_compute_Jastrow_nn_only, argnums=1)(r_up_carts_jnp, r_dn_carts_jnp)
@@ -2962,10 +2975,13 @@ def _compute_grads_and_laplacian_Jastrow_part_auto(
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
         R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
-            return nn3.nn_def.apply({"params": nn3.params}, r_up, r_dn, R_n, Z_n)
+            nn_params = jax.tree_util.tree_map(
+                lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+            )
+            return nn3.nn_def.apply({"params": nn_params}, r_up, r_dn, R_n, Z_n)
 
         grad_JNN_up = grad(_compute_Jastrow_nn_only, argnums=0)(r_up_carts_jnp, r_dn_carts_jnp)
         grad_JNN_dn = grad(_compute_Jastrow_nn_only, argnums=1)(r_up_carts_jnp, r_dn_carts_jnp)

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -1,4 +1,12 @@
-"""Jastrow module."""
+"""Jastrow module.
+
+Precision Zones:
+    - ``jastrow``: forward Jastrow evaluation (compute_Jastrow_part, J1/J2/J3).
+    - ``kinetic``: Jastrow derivatives (compute_grads_and_laplacian_Jastrow_*).
+    - ``mcmc``: ratio and update functions.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -53,6 +61,7 @@ from jax import grad, hessian, jit, vmap
 from jax import typing as jnpt
 from jax.tree_util import tree_flatten, tree_unflatten
 
+from ._precision import get_dtype
 from ._setting import EPS_safe_distance, atol_consistency
 from .atomic_orbital import (
     AOs_cart_data,
@@ -347,7 +356,7 @@ class NNJastrow(nn.Module):
                 jnp.ndarray: ``(n_e, hidden_dim)`` messages summarizing nuclear influence.
             """
             if nuclear_embeddings.shape[0] == 0:
-                return jnp.zeros((radial_features.shape[0], self.hidden_dim))
+                return jnp.zeros((radial_features.shape[0], self.hidden_dim), dtype=radial_features.dtype)
             weights = weights_net(radial_features)
             messages = weights * nuclear_embeddings[None, :, :]
             return jnp.sum(messages, axis=1)
@@ -424,8 +433,9 @@ class NNJastrow(nn.Module):
             jnp.ndarray: ``(n_a, n_b)`` matrix with a small epsilon added before the square
             root to keep gradients finite when particles coincide.
         """
+        dtype_j = get_dtype("jastrow")
         if A.shape[0] == 0 or B.shape[0] == 0:
-            return jnp.zeros((A.shape[0], B.shape[0]))
+            return jnp.zeros((A.shape[0], B.shape[0]), dtype=dtype_j)
         diff = A[:, None, :] - B[None, :, :]
         return jnp.sqrt(jnp.sum(diff**2, axis=-1) + EPS_safe_distance)
 
@@ -439,9 +449,10 @@ class NNJastrow(nn.Module):
             jnp.ndarray: ``(n_nuc, hidden_dim)`` embeddings looked up through
             ``species_lookup``. Returns an empty array when no nuclei are present.
         """
+        dtype = get_dtype("jastrow")
         n_nuc = Z_n.shape[0]
         if n_nuc == 0:
-            return jnp.zeros((0, self.hidden_dim))
+            return jnp.zeros((0, self.hidden_dim), dtype=dtype)
 
         lookup = jnp.asarray(self.species_lookup)
         species_ids = jnp.take(lookup, Z_n.astype(jnp.int32), mode="clip")
@@ -500,9 +511,10 @@ class NNJastrow(nn.Module):
             The network is permutation equivariant within each spin channel and rotation
             invariant by construction of the PhysNet radial features.
         """
-        r_up = jnp.asarray(r_up)
-        r_dn = jnp.asarray(r_dn)
-        R_n = jnp.asarray(R_n)
+        dtype = get_dtype("jastrow")
+        r_up = jnp.asarray(r_up, dtype=dtype)
+        r_dn = jnp.asarray(r_dn, dtype=dtype)
+        R_n = jnp.asarray(R_n, dtype=dtype)
         Z_n = jnp.asarray(Z_n)
 
         n_up = r_up.shape[0]
@@ -613,8 +625,10 @@ class Jastrow_one_body_data:
     @classmethod
     def init_jastrow_one_body_data(cls, jastrow_1b_param, structure_data, core_electrons, jastrow_1b_type="exp"):
         """Initialization."""
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
         jastrow_one_body_data = cls(
-            jastrow_1b_param=np.asarray(jastrow_1b_param, dtype=np.float64).reshape(()),
+            jastrow_1b_param=np.asarray(jastrow_1b_param, dtype=dtype_np).reshape(()),
             jastrow_1b_type=jastrow_1b_type,
             structure_data=structure_data,
             core_electrons=core_electrons,
@@ -641,10 +655,11 @@ def compute_Jastrow_one_body(
     Returns:
         float: One-body Jastrow value (before exponentiation).
     """
+    dtype = get_dtype("jastrow")
     # Retrieve structure data and convert to JAX arrays
-    R_carts = jnp.array(jastrow_one_body_data.structure_data.positions)
-    atomic_numbers = jnp.array(jastrow_one_body_data.structure_data.atomic_numbers)
-    core_electrons = jnp.array(jastrow_one_body_data.core_electrons)
+    R_carts = jnp.array(jastrow_one_body_data.structure_data.positions, dtype=dtype)
+    atomic_numbers = jnp.array(jastrow_one_body_data.structure_data.atomic_numbers, dtype=dtype)
+    core_electrons = jnp.array(jastrow_one_body_data.core_electrons, dtype=dtype)
     effective_charges = atomic_numbers - core_electrons
 
     j1b_type = jastrow_one_body_data.jastrow_1b_type
@@ -696,10 +711,12 @@ def _compute_Jastrow_one_body_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See compute_Jastrow_one_body_api."""
+    dtype = get_dtype("jastrow")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     positions = jastrow_one_body_data.structure_data.positions
     atomic_numbers = jastrow_one_body_data.structure_data.atomic_numbers
     core_electrons = jastrow_one_body_data.core_electrons
-    effective_charges = np.array(atomic_numbers) - np.array(core_electrons)
+    effective_charges = np.array(atomic_numbers, dtype=dtype_np) - np.array(core_electrons, dtype=dtype_np)
 
     j1b_type = jastrow_one_body_data.jastrow_1b_type
 
@@ -751,9 +768,11 @@ def _compute_grads_and_laplacian_Jastrow_one_body_debug(
     np.ndarray,
 ]:
     """Numerical gradients and Laplacian for one-body Jastrow (debug)."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     diff_h = 1.0e-5
-    r_up_carts = np.array(r_up_carts, dtype=float)
-    r_dn_carts = np.array(r_dn_carts, dtype=float)
+    r_up_carts = np.array(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.array(r_dn_carts, dtype=dtype_np)
 
     # grad up
     grad_x_up = []
@@ -817,14 +836,14 @@ def _compute_grads_and_laplacian_Jastrow_one_body_debug(
         grad_y_dn.append((J_p_y_dn - J_m_y_dn) / (2.0 * diff_h))
         grad_z_dn.append((J_p_z_dn - J_m_z_dn) / (2.0 * diff_h))
 
-    grad_J1_up = np.array([grad_x_up, grad_y_up, grad_z_up]).T
-    grad_J1_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn]).T
+    grad_J1_up = np.array([grad_x_up, grad_y_up, grad_z_up], dtype=dtype_np).T
+    grad_J1_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn], dtype=dtype_np).T
 
     # laplacian
     diff_h2 = 1.0e-3
     J_ref = _compute_Jastrow_one_body_debug(jastrow_one_body_data, r_up_carts, r_dn_carts)
 
-    lap_J1_up = np.zeros(len(r_up_carts), dtype=float)
+    lap_J1_up = np.zeros(len(r_up_carts), dtype=dtype_np)
 
     # laplacians up
     for r_i, _ in enumerate(r_up_carts):
@@ -856,7 +875,7 @@ def _compute_grads_and_laplacian_Jastrow_one_body_debug(
 
         lap_J1_up[r_i] = gradgrad_x_up + gradgrad_y_up + gradgrad_z_up
 
-    lap_J1_dn = np.zeros(len(r_dn_carts), dtype=float)
+    lap_J1_dn = np.zeros(len(r_dn_carts), dtype=dtype_np)
 
     # laplacians dn
     for r_i, _ in enumerate(r_dn_carts):
@@ -903,8 +922,9 @@ def _compute_grads_and_laplacian_Jastrow_one_body_auto(
     jax.Array,
 ]:
     """Auto-diff gradients and Laplacian for one-body Jastrow."""
-    r_up_carts = jnp.array(r_up_carts)
-    r_dn_carts = jnp.array(r_dn_carts)
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.array(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype)
 
     grad_J1_up = grad(compute_Jastrow_one_body, argnums=1)(jastrow_one_body_data, r_up_carts, r_dn_carts)
     grad_J1_dn = grad(compute_Jastrow_one_body, argnums=2)(jastrow_one_body_data, r_up_carts, r_dn_carts)
@@ -936,7 +956,8 @@ def compute_grads_and_laplacian_Jastrow_one_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    positions = jnp.asarray(jastrow_one_body_data.structure_data.positions)
+    dtype = get_dtype("kinetic")
+    positions = jnp.asarray(jastrow_one_body_data.structure_data.positions, dtype=dtype)
     atomic_numbers = jnp.asarray(jastrow_one_body_data.structure_data.atomic_numbers)
     core_electrons = jnp.asarray(jastrow_one_body_data.core_electrons)
     z_eff = atomic_numbers - core_electrons
@@ -988,8 +1009,8 @@ def compute_grads_and_laplacian_Jastrow_one_body(
     else:
         raise ValueError(f"Unknown jastrow_1b_type: {j1b_type}")
 
-    grad_up, lap_up = _grad_lap_one_spin(jnp.asarray(r_up_carts))
-    grad_dn, lap_dn = _grad_lap_one_spin(jnp.asarray(r_dn_carts))
+    grad_up, lap_up = _grad_lap_one_spin(jnp.asarray(r_up_carts, dtype=dtype))
+    grad_dn, lap_dn = _grad_lap_one_spin(jnp.asarray(r_dn_carts, dtype=dtype))
 
     return grad_up, grad_dn, lap_up, lap_dn
 
@@ -1056,8 +1077,10 @@ class Jastrow_two_body_data:
     @classmethod
     def init_jastrow_two_body_data(cls, jastrow_2b_param=1.0, jastrow_2b_type="pade"):
         """Initialization."""
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
         jastrow_two_body_data = cls(
-            jastrow_2b_param=np.asarray(jastrow_2b_param, dtype=np.float64).reshape(()),
+            jastrow_2b_param=np.asarray(jastrow_2b_param, dtype=dtype_np).reshape(()),
             jastrow_2b_type=jastrow_2b_type,
         )
         return jastrow_two_body_data
@@ -1332,11 +1355,13 @@ class Jastrow_three_body_data:
             random_scale: Upper bound of uniform sampler when random_init is True (default 0.01).
             seed: Optional seed for deterministic initialization when random_init is True.
         """
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
         if random_init:
             rng = np.random.default_rng(seed)
-            j_matrix = rng.uniform(0.0, random_scale, size=(orb_data._num_orb, orb_data._num_orb + 1))
+            j_matrix = rng.uniform(0.0, random_scale, size=(orb_data._num_orb, orb_data._num_orb + 1)).astype(dtype_np)
         else:
-            j_matrix = np.zeros((orb_data._num_orb, orb_data._num_orb + 1))
+            j_matrix = np.zeros((orb_data._num_orb, orb_data._num_orb + 1), dtype=dtype_np)
 
         jastrow_three_body_data = cls(
             orb_data=orb_data,
@@ -1359,8 +1384,10 @@ class Jastrow_three_body_data:
 
         aos_cart, transform_matrix = _aos_sphe_to_cart(self.orb_data)
 
-        square_sph = np.asarray(self.j_matrix[:, :-1], dtype=np.float64)
-        j1_sph = np.asarray(self.j_matrix[:, -1], dtype=np.float64)
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        square_sph = np.asarray(self.j_matrix[:, :-1], dtype=dtype_np)
+        j1_sph = np.asarray(self.j_matrix[:, -1], dtype=dtype_np)
         square_cart = transform_matrix.T @ square_sph @ transform_matrix
         j1_cart = transform_matrix.T @ j1_sph
 
@@ -1385,8 +1412,10 @@ class Jastrow_three_body_data:
 
         aos_sphe, transform_pinv = _aos_cart_to_sphe(self.orb_data)
 
-        square_cart = np.asarray(self.j_matrix[:, :-1], dtype=np.float64)
-        j1_cart = np.asarray(self.j_matrix[:, -1], dtype=np.float64)
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        square_cart = np.asarray(self.j_matrix[:, :-1], dtype=dtype_np)
+        j1_cart = np.asarray(self.j_matrix[:, -1], dtype=dtype_np)
         square_sph = transform_pinv.T @ square_cart @ transform_pinv
         j1_sph = transform_pinv.T @ j1_cart
 
@@ -1550,9 +1579,10 @@ class Jastrow_NN_data:
         # Dummy electron positions for parameter initialization:
         # use one spin-up and one spin-down electron at the origin so that
         # both PauliNet channels are initialized with valid shapes.
-        r_up_init = jnp.zeros((1, 3))
-        r_dn_init = jnp.zeros((1, 3))
-        R_n = jnp.asarray(structure_data.positions)  # (n_nuc, 3)
+        dtype = get_dtype("jastrow")
+        r_up_init = jnp.zeros((1, 3), dtype=dtype)
+        r_dn_init = jnp.zeros((1, 3), dtype=dtype)
+        R_n = jnp.asarray(structure_data.positions, dtype=dtype)  # (n_nuc, 3)
         Z_n = jnp.asarray(structure_data.atomic_numbers)  # (n_nuc,)
 
         rngs = {"params": key}
@@ -1625,14 +1655,15 @@ def compute_Jastrow_three_body(
     Returns:
         float: Three-body Jastrow value (before exponentiation).
     """
+    dtype = get_dtype("jastrow")
     num_electron_up = len(r_up_carts)
     num_electron_dn = len(r_dn_carts)
 
-    aos_up = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts))
-    aos_dn = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts))
+    aos_up = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts), dtype=dtype)
+    aos_dn = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts), dtype=dtype)
 
-    K_up = jnp.tril(jnp.ones((num_electron_up, num_electron_up)), k=-1)
-    K_dn = jnp.tril(jnp.ones((num_electron_dn, num_electron_dn)), k=-1)
+    K_up = jnp.tril(jnp.ones((num_electron_up, num_electron_up), dtype=dtype), k=-1)
+    K_dn = jnp.tril(jnp.ones((num_electron_dn, num_electron_dn), dtype=dtype), k=-1)
 
     j1_matrix_up = jastrow_three_body_data.j_matrix[:, -1]
     j1_matrix_dn = jastrow_three_body_data.j_matrix[:, -1]
@@ -1640,8 +1671,8 @@ def compute_Jastrow_three_body(
     j3_matrix_dn_dn = jastrow_three_body_data.j_matrix[:, :-1]
     j3_matrix_up_dn = jastrow_three_body_data.j_matrix[:, :-1]
 
-    e_up = jnp.ones(num_electron_up).T
-    e_dn = jnp.ones(num_electron_dn).T
+    e_up = jnp.ones(num_electron_up, dtype=dtype).T
+    e_dn = jnp.ones(num_electron_dn, dtype=dtype).T
 
     # print(f"aos_up.shape={aos_up.shape}")
     # print(f"aos_dn.shape={aos_dn.shape}")
@@ -1668,6 +1699,8 @@ def _compute_Jastrow_three_body_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See _api method."""
+    dtype = get_dtype("jastrow")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_up = jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts)
     aos_dn = jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts)
 
@@ -1852,13 +1885,15 @@ class Jastrow_data:
         in ``Wavefunction_data.get_variational_blocks`` and add the
         corresponding handling here, without touching the SR/MCMC driver.
         """
+        dtype = get_dtype("jastrow")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
         j1 = self.jastrow_one_body_data
         j2 = self.jastrow_two_body_data
         j3 = self.jastrow_three_body_data
         nn3 = self.jastrow_nn_data
 
         if block.name == "j1_param" and j1 is not None:
-            new_param = np.asarray(block.values, dtype=np.float64).reshape(())
+            new_param = np.asarray(block.values, dtype=dtype_np).reshape(())
             j1 = Jastrow_one_body_data(
                 jastrow_1b_param=new_param,
                 structure_data=j1.structure_data,
@@ -1866,26 +1901,26 @@ class Jastrow_data:
                 jastrow_1b_type=j1.jastrow_1b_type,
             )
         elif block.name == "j2_param" and j2 is not None:
-            new_param = np.asarray(block.values, dtype=np.float64).reshape(())
+            new_param = np.asarray(block.values, dtype=dtype_np).reshape(())
             j2 = Jastrow_two_body_data(jastrow_2b_param=new_param, jastrow_2b_type=j2.jastrow_2b_type)
         elif block.name == "j3_matrix" and j3 is not None:
-            j3_new = np.array(block.values)
+            j3_new = np.array(block.values, dtype=dtype_np)
 
             # Symmetrize unconditionally — the method is a no-op for non-symmetric matrices.
             j3_new = self.symmetrize_j3(j3_new)
 
             j3 = Jastrow_three_body_data(orb_data=j3.orb_data, j_matrix=j3_new)
         elif block.name == "j3_basis_exp" and j3 is not None:
-            new_exp = np.asarray(block.values, dtype=np.float64)
-            new_exp = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_exp), dtype=jnp.float64)
+            new_exp = np.asarray(block.values, dtype=dtype_np)
+            new_exp = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_exp), dtype=dtype)
             j3 = j3.with_updated_ao_exponents(new_exp)
         elif block.name == "j3_basis_coeff" and j3 is not None:
-            new_coeff = np.asarray(block.values, dtype=np.float64)
-            new_coeff = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_coeff), dtype=jnp.float64)
+            new_coeff = np.asarray(block.values, dtype=dtype_np)
+            new_coeff = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_coeff), dtype=dtype)
             j3 = j3.with_updated_ao_coefficients(new_coeff)
         elif block.name == "jastrow_nn_params" and nn3 is not None:
             # Update NN Jastrow parameters: block.values is the flattened parameter vector.
-            flat = jnp.asarray(block.values).reshape(-1)
+            flat = jnp.asarray(block.values, dtype=dtype).reshape(-1)
             params_new = nn3.unflatten_fn(flat)
             nn3 = nn3.replace(params=params_new)
 
@@ -1998,8 +2033,9 @@ def compute_Jastrow_part(jastrow_data: Jastrow_data, r_up_carts: jax.Array, r_dn
     Returns:
         float: Total Jastrow value before exponentiation.
     """
-    r_up_carts = jnp.asarray(r_up_carts)
-    r_dn_carts = jnp.asarray(r_dn_carts)
+    dtype = get_dtype("jastrow")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
 
     J1 = 0.0
     J2 = 0.0
@@ -2023,7 +2059,7 @@ def compute_Jastrow_part(jastrow_data: Jastrow_data, r_up_carts: jax.Array, r_dn
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn3.structure_data.positions)
+        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
         Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
         J3_nn = nn3.nn_def.apply({"params": nn3.params}, r_up_carts, r_dn_carts, R_n, Z_n)
         J3 = J3 + J3_nn
@@ -2037,6 +2073,8 @@ def _compute_Jastrow_part_debug(
     jastrow_data: Jastrow_data, r_up_carts: npt.NDArray[np.float64], r_dn_carts: npt.NDArray[np.float64]
 ) -> float:
     """See compute_Jastrow_part_jax for more details."""
+    dtype = get_dtype("jastrow")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     J1 = 0.0
     J2 = 0.0
     J3 = 0.0
@@ -2059,12 +2097,16 @@ def _compute_Jastrow_part_debug(
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3 (debug).")
 
-        R_n = np.asarray(nn3.structure_data.positions, dtype=float)
-        Z_n = np.asarray(nn3.structure_data.atomic_numbers, dtype=float)
+        R_n = np.asarray(nn3.structure_data.positions, dtype=dtype_np)
+        Z_n = np.asarray(nn3.structure_data.atomic_numbers, dtype=dtype_np)
 
         # Use JAX NN for debug as well; convert inputs to jnp and back to float
         J3_nn = nn3.nn_def.apply(
-            {"params": nn3.params}, jnp.asarray(r_up_carts), jnp.asarray(r_dn_carts), jnp.asarray(R_n), jnp.asarray(Z_n)
+            {"params": nn3.params},
+            jnp.asarray(r_up_carts, dtype=dtype),
+            jnp.asarray(r_dn_carts, dtype=dtype),
+            jnp.asarray(R_n, dtype=dtype),
+            jnp.asarray(Z_n, dtype=dtype),
         )
         J3 += float(J3_nn)
 
@@ -2106,10 +2148,11 @@ def _compute_ratio_Jastrow_part_rank1_update(
         grid generated by the MCMC loop, where exactly one electron is displaced
         per grid point by construction.
     """
-    old_r_up_carts = jnp.asarray(old_r_up_carts)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts)
-    new_r_up_carts_arr = jnp.asarray(new_r_up_carts_arr)
-    new_r_dn_carts_arr = jnp.asarray(new_r_dn_carts_arr)
+    dtype = get_dtype("mcmc")
+    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
+    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
+    new_r_up_carts_arr = jnp.asarray(new_r_up_carts_arr, dtype=dtype)
+    new_r_dn_carts_arr = jnp.asarray(new_r_dn_carts_arr, dtype=dtype)
 
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
@@ -2119,7 +2162,7 @@ def _compute_ratio_Jastrow_part_rank1_update(
         jastrow_xp = vmap(compute_Jastrow_part, in_axes=(None, 0, 0))(jastrow_data, new_r_up_carts_arr, new_r_dn_carts_arr)
         return jnp.exp(jastrow_xp - jastrow_x)
 
-    J_ratio = jnp.ones(n_grid)
+    J_ratio = jnp.ones(n_grid, dtype=dtype)
 
     # J1 part
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2133,8 +2176,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
                 idx_dn = jnp.argmax(nonzero_dn)
                 r_dn_new = new_r_dn_carts[idx_dn]
                 r_dn_old = old_r_dn_carts[idx_dn]
-                j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_new, axis=0))
-                j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_old, axis=0))
+                j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0))
+                j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0))
                 return jnp.exp(j1_new - j1_old)
 
         elif num_dn == 0:
@@ -2145,8 +2188,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
                 idx_up = jnp.argmax(nonzero_up)
                 r_up_new = new_r_up_carts[idx_up]
                 r_up_old = old_r_up_carts[idx_up]
-                j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3)))
-                j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3)))
+                j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype))
+                j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype))
                 return jnp.exp(j1_new - j1_old)
 
         else:
@@ -2165,16 +2208,24 @@ def _compute_ratio_Jastrow_part_rank1_update(
                     j1_data, new_r_up_carts, new_r_dn_carts, old_r_up_carts, old_r_dn_carts = args
                     r_up_new = new_r_up_carts[idx_up]
                     r_up_old = old_r_up_carts[idx_up]
-                    j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3)))
-                    j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3)))
+                    j1_new = compute_Jastrow_one_body(
+                        j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype)
+                    )
+                    j1_old = compute_Jastrow_one_body(
+                        j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype)
+                    )
                     return jnp.exp(j1_new - j1_old)
 
                 def dn_case(args):
                     j1_data, new_r_up_carts, new_r_dn_carts, old_r_up_carts, old_r_dn_carts = args
                     r_dn_new = new_r_dn_carts[idx_dn]
                     r_dn_old = old_r_dn_carts[idx_dn]
-                    j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_new, axis=0))
-                    j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_old, axis=0))
+                    j1_new = compute_Jastrow_one_body(
+                        j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0)
+                    )
+                    j1_old = compute_Jastrow_one_body(
+                        j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0)
+                    )
                     return jnp.exp(j1_new - j1_old)
 
                 return jax.lax.cond(
@@ -2316,7 +2367,7 @@ def _compute_ratio_Jastrow_part_rank1_update(
 
         def compute_pairwise_sums(pos1, pos2):
             if pos1.shape[0] == 0 or pos2.shape[0] == 0:
-                return jnp.zeros(pos1.shape[0])
+                return jnp.zeros(pos1.shape[0], dtype=dtype)
             dists = _safe_norm(pos1[:, None, :] - pos2[None, :, :])
             vals = _j2_from_dist(dists, j2_param)
             return jnp.sum(vals, axis=1)
@@ -2380,8 +2431,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         j1_vec = j3d.j_matrix[:, -1]  # (n_ao,)
 
         # Old AOs evaluated once
-        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts))  # (n_ao, N_up)
-        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts))  # (n_ao, N_dn)
+        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype)  # (n_ao, N_up)
+        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype)  # (n_ao, N_dn)
 
         N_batch = new_r_up_carts_arr.shape[0]
 
@@ -2401,8 +2452,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         r_old_moved = jnp.where(up_moved_batch[:, None], r_old_up_moved, r_old_dn_moved)  # (N, 3)
 
         # Single batched AO evaluation for all N configs (replaces N per-config calls inside vmap)
-        aos_new_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_new_moved))  # (n_ao, N)
-        aos_old_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_old_moved))  # (n_ao, N)
+        aos_new_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_new_moved), dtype=dtype)  # (n_ao, N)
+        aos_old_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_old_moved), dtype=dtype)  # (n_ao, N)
         aos_p_batch = aos_new_batch - aos_old_batch  # (n_ao, N)
 
         # Precompute constant products (independent of config)
@@ -2422,8 +2473,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         # UP formula  -----------------------------------------------------------
         V_up = jnp.dot(aos_p_batch.T, W_up)  # (N, N_up)
         P_up = jnp.dot(U_up, aos_p_batch)  # (N_up, N)
-        Q_up_c = (idx_for_Q[:, None] < jnp.arange(num_up)[None, :]).astype(jnp.float64)  # (N, N_up)
-        Q_up_r = (idx_for_Q[:, None] > jnp.arange(num_up)[None, :]).astype(jnp.float64)  # (N, N_up)
+        Q_up_c = (idx_for_Q[:, None] < jnp.arange(num_up)[None, :]).astype(dtype)  # (N, N_up)
+        Q_up_r = (idx_for_Q[:, None] > jnp.arange(num_up)[None, :]).astype(dtype)  # (N, N_up)
         term2_up = jnp.sum(V_up * Q_up_c, axis=1)  # (N,)
         term3_up = jnp.sum(P_up.T * Q_up_r, axis=1)  # (N,)
         term4_up = dn_cross_vec @ aos_p_batch  # (N,)
@@ -2432,8 +2483,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         # DN formula  -----------------------------------------------------------
         V_dn = jnp.dot(aos_p_batch.T, W_dn)  # (N, N_dn)
         P_dn = jnp.dot(U_dn, aos_p_batch)  # (N_dn, N)
-        Q_dn_c = (idx_for_Q[:, None] < jnp.arange(num_dn)[None, :]).astype(jnp.float64)  # (N, N_dn)
-        Q_dn_r = (idx_for_Q[:, None] > jnp.arange(num_dn)[None, :]).astype(jnp.float64)  # (N, N_dn)
+        Q_dn_c = (idx_for_Q[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype)  # (N, N_dn)
+        Q_dn_r = (idx_for_Q[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype)  # (N, N_dn)
         term2_dn = jnp.sum(V_dn * Q_dn_c, axis=1)  # (N,)
         term3_dn = jnp.sum(P_dn.T * Q_dn_r, axis=1)  # (N,)
         term4_dn = up_cross_vec @ aos_p_batch  # (N,)
@@ -2455,7 +2506,7 @@ def _compute_ratio_Jastrow_part_rank1_update(
         if nn.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn.structure_data.positions)
+        R_n = jnp.asarray(nn.structure_data.positions, dtype=dtype)
         Z_n = jnp.asarray(nn.structure_data.atomic_numbers)
 
         def compute_one_grid_JNN(new_r_up_carts, new_r_dn_carts):
@@ -2509,10 +2560,11 @@ def _compute_ratio_Jastrow_part_split_spin(
         exclusively for the block-structured non-local ECP grids produced by
         the MCMC loop.
     """
-    old_r_up_carts = jnp.asarray(old_r_up_carts)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts)
-    new_r_up_shifted = jnp.asarray(new_r_up_shifted)
-    new_r_dn_shifted = jnp.asarray(new_r_dn_shifted)
+    dtype = get_dtype("mcmc")
+    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
+    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
+    new_r_up_shifted = jnp.asarray(new_r_up_shifted, dtype=dtype)
+    new_r_dn_shifted = jnp.asarray(new_r_dn_shifted, dtype=dtype)
 
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
@@ -2548,8 +2600,8 @@ def _compute_ratio_Jastrow_part_split_spin(
     r_up_old_moved = old_r_up_carts[idx_up_block]  # (G_up, 3)
     r_dn_old_moved = old_r_dn_carts[idx_dn_block]  # (G_dn, 3)
 
-    J_up = jnp.ones(g_up)
-    J_dn = jnp.ones(g_dn)
+    J_up = jnp.ones(g_up, dtype=dtype)
+    J_dn = jnp.ones(g_dn, dtype=dtype)
 
     # ── J1 part ──────────────────────────────────────────────────────────────
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2557,8 +2609,8 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # UP block: only the moved up electron contributes to the J1 change.
         def compute_J1_up_one(r_up_new: jax.Array, r_up_old: jax.Array) -> jax.Array:
-            j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3)))
-            j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3)))
+            j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype))
+            j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype))
             return jnp.exp(j1_new - j1_old)
 
         J1_up_block = vmap(compute_J1_up_one)(r_up_moved, r_up_old_moved)  # (G_up,)
@@ -2566,8 +2618,8 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # DN block: only the moved dn electron contributes.
         def compute_J1_dn_one(r_dn_new: jax.Array, r_dn_old: jax.Array) -> jax.Array:
-            j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_new, axis=0))
-            j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3)), jnp.expand_dims(r_dn_old, axis=0))
+            j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0))
+            j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0))
             return jnp.exp(j1_new - j1_old)
 
         J1_dn_block = vmap(compute_J1_dn_one)(r_dn_moved, r_dn_old_moved)  # (G_dn,)
@@ -2633,8 +2685,8 @@ def _compute_ratio_Jastrow_part_split_spin(
         j1_vec = j3d.j_matrix[:, -1]  # (n_ao,)
 
         # Old AOs evaluated once; column slices give old AO at each moved position.
-        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts))  # (n_ao, N_up)
-        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts))  # (n_ao, N_dn)
+        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype)  # (n_ao, N_up)
+        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype)  # (n_ao, N_dn)
 
         # Precompute constant products (shared between blocks).
         W_up = jnp.dot(j3_mat, aos_up_old)  # (n_ao, N_up)
@@ -2646,15 +2698,15 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # ── UP BLOCK ─────────────────────────────────────────────────────────
         # New AOs at the moved up-electron positions; old AOs by column-slice.
-        aos_up_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_up_moved))  # (n_ao, G_up)
+        aos_up_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_up_moved), dtype=dtype)  # (n_ao, G_up)
         aos_up_old_moved = aos_up_old[:, idx_up_block]  # (n_ao, G_up)
         aos_p_up = aos_up_new_moved - aos_up_old_moved  # (n_ao, G_up)
 
         term1_up = j1_vec @ aos_p_up  # (G_up,)
         V_up_block = jnp.dot(aos_p_up.T, W_up)  # (G_up, N_up)
         P_up_block = jnp.dot(U_up, aos_p_up)  # (N_up, G_up)
-        Q_up_c = (idx_up_block[:, None] < jnp.arange(num_up)[None, :]).astype(jnp.float64)  # (G_up, N_up)
-        Q_up_r = (idx_up_block[:, None] > jnp.arange(num_up)[None, :]).astype(jnp.float64)  # (G_up, N_up)
+        Q_up_c = (idx_up_block[:, None] < jnp.arange(num_up)[None, :]).astype(dtype)  # (G_up, N_up)
+        Q_up_r = (idx_up_block[:, None] > jnp.arange(num_up)[None, :]).astype(dtype)  # (G_up, N_up)
         term2_up = jnp.sum(V_up_block * Q_up_c, axis=1)  # (G_up,)
         term3_up = jnp.sum(P_up_block.T * Q_up_r, axis=1)  # (G_up,)
         term4_up = dn_cross_vec @ aos_p_up  # (G_up,)
@@ -2662,15 +2714,15 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # ── DN BLOCK ─────────────────────────────────────────────────────────
         # New AOs at the moved dn-electron positions; old AOs by column-slice.
-        aos_dn_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_dn_moved))  # (n_ao, G_dn)
+        aos_dn_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_dn_moved), dtype=dtype)  # (n_ao, G_dn)
         aos_dn_old_moved = aos_dn_old[:, idx_dn_block]  # (n_ao, G_dn)
         aos_p_dn = aos_dn_new_moved - aos_dn_old_moved  # (n_ao, G_dn)
 
         term1_dn = j1_vec @ aos_p_dn  # (G_dn,)
         V_dn_block = jnp.dot(aos_p_dn.T, W_dn)  # (G_dn, N_dn)
         P_dn_block = jnp.dot(U_dn, aos_p_dn)  # (N_dn, G_dn)
-        Q_dn_c = (idx_dn_block[:, None] < jnp.arange(num_dn)[None, :]).astype(jnp.float64)  # (G_dn, N_dn)
-        Q_dn_r = (idx_dn_block[:, None] > jnp.arange(num_dn)[None, :]).astype(jnp.float64)  # (G_dn, N_dn)
+        Q_dn_c = (idx_dn_block[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype)  # (G_dn, N_dn)
+        Q_dn_r = (idx_dn_block[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype)  # (G_dn, N_dn)
         term2_dn = jnp.sum(V_dn_block * Q_dn_c, axis=1)  # (G_dn,)
         term3_dn = jnp.sum(P_dn_block.T * Q_dn_r, axis=1)  # (G_dn,)
         term4_dn = up_cross_vec @ aos_p_dn  # (G_dn,)
@@ -2682,7 +2734,7 @@ def _compute_ratio_Jastrow_part_split_spin(
         if nn.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn.structure_data.positions)
+        R_n = jnp.asarray(nn.structure_data.positions, dtype=dtype)
         Z_n = jnp.asarray(nn.structure_data.atomic_numbers)
 
         def compute_one_grid_JNN_split(r_up: jax.Array, r_dn: jax.Array) -> jax.Array:
@@ -2709,12 +2761,15 @@ def _compute_ratio_Jastrow_part_debug(
     new_r_dn_carts_arr: npt.NDArray[np.float64],
 ) -> npt.NDArray:
     """See _api method."""
+    dtype = get_dtype("mcmc")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     return np.array(
         [
             np.exp(compute_Jastrow_part(jastrow_data, new_r_up_carts, new_r_dn_carts))
             / np.exp(compute_Jastrow_part(jastrow_data, old_r_up_carts, old_r_dn_carts))
             for new_r_up_carts, new_r_dn_carts in zip(new_r_up_carts_arr, new_r_dn_carts_arr, strict=True)
-        ]
+        ],
+        dtype=dtype_np,
     )
 
 
@@ -2745,13 +2800,14 @@ def compute_grads_and_laplacian_Jastrow_part(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``
             and Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    r_up = jnp.asarray(r_up_carts)
-    r_dn = jnp.asarray(r_dn_carts)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     grad_J_up = jnp.zeros_like(r_up)
     grad_J_dn = jnp.zeros_like(r_dn)
-    lap_J_up = jnp.zeros((r_up.shape[0],))
-    lap_J_dn = jnp.zeros((r_dn.shape[0],))
+    lap_J_up = jnp.zeros((r_up.shape[0],), dtype=dtype)
+    lap_J_dn = jnp.zeros((r_dn.shape[0],), dtype=dtype)
 
     # one-body (analytic)
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2795,9 +2851,9 @@ def compute_grads_and_laplacian_Jastrow_part(
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        r_up_carts_jnp = jnp.asarray(r_up_carts)
-        r_dn_carts_jnp = jnp.asarray(r_dn_carts)
-        R_n = jnp.asarray(nn3.structure_data.positions)
+        r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
+        r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
+        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
         Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
@@ -2844,13 +2900,14 @@ def _compute_grads_and_laplacian_Jastrow_part_auto(
     Returns:
         the gradients(x,y,z) of J and the sum of laplacians of J at (r_up_carts, r_dn_carts).
     """
-    r_up_carts_jnp = jnp.array(r_up_carts)
-    r_dn_carts_jnp = jnp.array(r_dn_carts)
+    dtype = get_dtype("kinetic")
+    r_up_carts_jnp = jnp.array(r_up_carts, dtype=dtype)
+    r_dn_carts_jnp = jnp.array(r_dn_carts, dtype=dtype)
 
     grad_J_up = jnp.zeros_like(r_up_carts_jnp)
     grad_J_dn = jnp.zeros_like(r_dn_carts_jnp)
-    lap_J_up = jnp.zeros((r_up_carts_jnp.shape[0],))
-    lap_J_dn = jnp.zeros((r_dn_carts_jnp.shape[0],))
+    lap_J_up = jnp.zeros((r_up_carts_jnp.shape[0],), dtype=dtype)
+    lap_J_dn = jnp.zeros((r_dn_carts_jnp.shape[0],), dtype=dtype)
 
     # one-body
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2904,7 +2961,7 @@ def _compute_grads_and_laplacian_Jastrow_part_auto(
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn3.structure_data.positions)
+        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
         Z_n = jnp.asarray(nn3.structure_data.atomic_numbers)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
@@ -2942,10 +2999,12 @@ def _compute_grads_and_laplacian_Jastrow_part_debug(
     Uses central finite differences to approximate gradients and the
     sum of Laplacians of J at (r_up_carts, r_dn_carts).
     """
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     diff_h = 1.0e-5
 
-    r_up_carts = np.array(r_up_carts, dtype=float)
-    r_dn_carts = np.array(r_dn_carts, dtype=float)
+    r_up_carts = np.array(r_up_carts, dtype=dtype_np)
+    r_dn_carts = np.array(r_dn_carts, dtype=dtype_np)
 
     # grad up
     grad_x_up = []
@@ -3009,14 +3068,14 @@ def _compute_grads_and_laplacian_Jastrow_part_debug(
         grad_y_dn.append((J_p_y_dn - J_m_y_dn) / (2.0 * diff_h))
         grad_z_dn.append((J_p_z_dn - J_m_z_dn) / (2.0 * diff_h))
 
-    grad_J_up = np.array([grad_x_up, grad_y_up, grad_z_up]).T
-    grad_J_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn]).T
+    grad_J_up = np.array([grad_x_up, grad_y_up, grad_z_up], dtype=dtype_np).T
+    grad_J_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn], dtype=dtype_np).T
 
     # laplacian
     diff_h2 = 1.0e-3
     J_ref = compute_Jastrow_part(jastrow_data=jastrow_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
 
-    lap_J_up = np.zeros(len(r_up_carts), dtype=float)
+    lap_J_up = np.zeros(len(r_up_carts), dtype=dtype_np)
 
     # laplacians up
     for r_i, _ in enumerate(r_up_carts):
@@ -3048,7 +3107,7 @@ def _compute_grads_and_laplacian_Jastrow_part_debug(
 
         lap_J_up[r_i] = gradgrad_x_up + gradgrad_y_up + gradgrad_z_up
 
-    lap_J_dn = np.zeros(len(r_dn_carts), dtype=float)
+    lap_J_dn = np.zeros(len(r_dn_carts), dtype=dtype_np)
 
     # laplacians dn
     for r_i, _ in enumerate(r_dn_carts):
@@ -3112,8 +3171,9 @@ def _compute_grads_and_laplacian_Jastrow_two_body_auto(
     #        jastrow_two_body_data, r_up_carts, r_dn_carts
     #    )
     # )
-    r_up_carts = jnp.array(r_up_carts)
-    r_dn_carts = jnp.array(r_dn_carts)
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.array(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype)
 
     # compute grad
     grad_J2_up = grad(compute_Jastrow_two_body, argnums=1)(jastrow_two_body_data, r_up_carts, r_dn_carts)
@@ -3151,19 +3211,20 @@ def compute_grads_and_laplacian_Jastrow_two_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
+    dtype = get_dtype("kinetic")
     a = jastrow_two_body_data.jastrow_2b_param
     eps = EPS_safe_distance
 
-    r_up = jnp.asarray(r_up_carts)
-    r_dn = jnp.asarray(r_dn_carts)
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     num_up = r_up.shape[0]
     num_dn = r_dn.shape[0]
 
     grad_up = jnp.zeros_like(r_up)
     grad_dn = jnp.zeros_like(r_dn)
-    lap_up = jnp.zeros((num_up,))
-    lap_dn = jnp.zeros((num_dn,))
+    lap_up = jnp.zeros((num_up,), dtype=dtype)
+    lap_dn = jnp.zeros((num_dn,), dtype=dtype)
 
     j2b_type = jastrow_two_body_data.jastrow_2b_type
 
@@ -3239,6 +3300,8 @@ def _compute_grads_and_laplacian_Jastrow_two_body_debug(
     np.ndarray,
 ]:
     """See _api method."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     diff_h = 1.0e-5
 
     # grad up
@@ -3351,8 +3414,8 @@ def _compute_grads_and_laplacian_Jastrow_two_body_debug(
         grad_y_dn.append((J2_p_y_dn - J2_m_y_dn) / (2.0 * diff_h))
         grad_z_dn.append((J2_p_z_dn - J2_m_z_dn) / (2.0 * diff_h))
 
-    grad_J2_up = np.array([grad_x_up, grad_y_up, grad_z_up]).T
-    grad_J2_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn]).T
+    grad_J2_up = np.array([grad_x_up, grad_y_up, grad_z_up], dtype=dtype_np).T
+    grad_J2_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn], dtype=dtype_np).T
 
     # laplacian
     diff_h2 = 1.0e-3  # for laplacian
@@ -3363,7 +3426,7 @@ def _compute_grads_and_laplacian_Jastrow_two_body_debug(
         r_dn_carts=r_dn_carts,
     )
 
-    lap_J2_up = np.zeros(len(r_up_carts), dtype=float)
+    lap_J2_up = np.zeros(len(r_up_carts), dtype=dtype_np)
 
     # laplacians up
     for r_i, _ in enumerate(r_up_carts):
@@ -3420,7 +3483,7 @@ def _compute_grads_and_laplacian_Jastrow_two_body_debug(
 
         lap_J2_up[r_i] = gradgrad_x_up + gradgrad_y_up + gradgrad_z_up
 
-    lap_J2_dn = np.zeros(len(r_dn_carts), dtype=float)
+    lap_J2_dn = np.zeros(len(r_dn_carts), dtype=dtype_np)
 
     # laplacians dn
     for r_i, _ in enumerate(r_dn_carts):
@@ -3504,6 +3567,10 @@ def _compute_grads_and_laplacian_Jastrow_three_body_auto(
     Returns:
         the gradients(x,y,z) of J(threebody) and the sum of laplacians of J(threebody) at (r_up_carts, r_dn_carts).
     """
+    dtype = get_dtype("kinetic")
+    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+
     # compute grad
     grad_J3_up = grad(compute_Jastrow_three_body, argnums=1)(jastrow_three_body_data, r_up_carts, r_dn_carts)
 
@@ -3541,6 +3608,7 @@ def compute_grads_and_laplacian_Jastrow_three_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
+    dtype = get_dtype("kinetic")
     orb_data = jastrow_three_body_data.orb_data
 
     if isinstance(orb_data, MOs_data):
@@ -3554,11 +3622,11 @@ def compute_grads_and_laplacian_Jastrow_three_body(
     else:
         raise NotImplementedError
 
-    r_up = jnp.asarray(r_up_carts)
-    r_dn = jnp.asarray(r_dn_carts)
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
-    aos_up = jnp.asarray(compute_orb(orb_data, r_up))  # (n_orb, n_up)
-    aos_dn = jnp.asarray(compute_orb(orb_data, r_dn))  # (n_orb, n_dn)
+    aos_up = jnp.asarray(compute_orb(orb_data, r_up), dtype=dtype)  # (n_orb, n_up)
+    aos_dn = jnp.asarray(compute_orb(orb_data, r_dn), dtype=dtype)  # (n_orb, n_dn)
 
     grad_up_x, grad_up_y, grad_up_z = compute_orb_grad(orb_data, r_up)
     grad_dn_x, grad_dn_y, grad_dn_z = compute_orb_grad(orb_data, r_dn)
@@ -3566,34 +3634,34 @@ def compute_grads_and_laplacian_Jastrow_three_body(
     grad_up = jnp.stack([grad_up_x, grad_up_y, grad_up_z], axis=-1)  # (n_orb, n_up, 3)
     grad_dn = jnp.stack([grad_dn_x, grad_dn_y, grad_dn_z], axis=-1)  # (n_orb, n_dn, 3)
 
-    lap_up = jnp.asarray(compute_orb_lapl(orb_data, r_up))  # (n_orb, n_up)
-    lap_dn = jnp.asarray(compute_orb_lapl(orb_data, r_dn))  # (n_orb, n_dn)
+    lap_up = jnp.asarray(compute_orb_lapl(orb_data, r_up), dtype=dtype)  # (n_orb, n_up)
+    lap_dn = jnp.asarray(compute_orb_lapl(orb_data, r_dn), dtype=dtype)  # (n_orb, n_dn)
 
-    j1_vec = jnp.asarray(jastrow_three_body_data.j_matrix[:, -1])  # (n_orb,)
-    j3_mat = jnp.asarray(jastrow_three_body_data.j_matrix[:, :-1])  # (n_orb, n_orb)
+    j1_vec = jnp.asarray(jastrow_three_body_data.j_matrix[:, -1], dtype=dtype)  # (n_orb,)
+    j3_mat = jnp.asarray(jastrow_three_body_data.j_matrix[:, :-1], dtype=dtype)  # (n_orb, n_orb)
 
     num_up = aos_up.shape[1]
     num_dn = aos_dn.shape[1]
 
     # Precompute pair-accumulation masks
-    upper_up = jnp.triu(jnp.ones((num_up, num_up)), k=1)
-    lower_up = jnp.tril(jnp.ones((num_up, num_up)), k=-1)
-    upper_dn = jnp.triu(jnp.ones((num_dn, num_dn)), k=1)
-    lower_dn = jnp.tril(jnp.ones((num_dn, num_dn)), k=-1)
+    upper_up = jnp.triu(jnp.ones((num_up, num_up), dtype=dtype), k=1)
+    lower_up = jnp.tril(jnp.ones((num_up, num_up), dtype=dtype), k=-1)
+    upper_dn = jnp.triu(jnp.ones((num_dn, num_dn), dtype=dtype), k=1)
+    lower_dn = jnp.tril(jnp.ones((num_dn, num_dn), dtype=dtype), k=-1)
 
     # dJ/dA for each electron (orbital-space coefficients)
     g_up = (
         j1_vec[:, None]
         + jnp.dot(j3_mat, aos_up) @ lower_up
         + jnp.dot(j3_mat.T, aos_up) @ upper_up
-        + jnp.dot(j3_mat, aos_dn) @ jnp.ones((num_dn, 1))
+        + jnp.dot(j3_mat, aos_dn) @ jnp.ones((num_dn, 1), dtype=dtype)
     )  # (n_orb, n_up)
 
     g_dn = (
         j1_vec[:, None]
         + jnp.dot(j3_mat, aos_dn) @ lower_dn
         + jnp.dot(j3_mat.T, aos_dn) @ upper_dn
-        + jnp.dot(j3_mat.T, aos_up) @ jnp.ones((num_up, 1))
+        + jnp.dot(j3_mat.T, aos_up) @ jnp.ones((num_up, 1), dtype=dtype)
     )  # (n_orb, n_dn)
 
     grad_J3_up = jnp.einsum("on,onj->nj", g_up, grad_up)
@@ -3616,6 +3684,8 @@ def _compute_grads_and_laplacian_Jastrow_three_body_debug(
     np.ndarray,
 ]:
     """See _api method."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     diff_h = 1.0e-5
 
     # grad up
@@ -3728,8 +3798,8 @@ def _compute_grads_and_laplacian_Jastrow_three_body_debug(
         grad_y_dn.append((J3_p_y_dn - J3_m_y_dn) / (2.0 * diff_h))
         grad_z_dn.append((J3_p_z_dn - J3_m_z_dn) / (2.0 * diff_h))
 
-    grad_J3_up = np.array([grad_x_up, grad_y_up, grad_z_up]).T
-    grad_J3_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn]).T
+    grad_J3_up = np.array([grad_x_up, grad_y_up, grad_z_up], dtype=dtype_np).T
+    grad_J3_dn = np.array([grad_x_dn, grad_y_dn, grad_z_dn], dtype=dtype_np).T
 
     # laplacian
     diff_h2 = 1.0e-3  # for laplacian
@@ -3740,7 +3810,7 @@ def _compute_grads_and_laplacian_Jastrow_three_body_debug(
         r_dn_carts=r_dn_carts,
     )
 
-    lap_J3_up = np.zeros(len(r_up_carts), dtype=float)
+    lap_J3_up = np.zeros(len(r_up_carts), dtype=dtype_np)
 
     # laplacians up
     for r_i, _ in enumerate(r_up_carts):
@@ -3797,7 +3867,7 @@ def _compute_grads_and_laplacian_Jastrow_three_body_debug(
 
         lap_J3_up[r_i] = gradgrad_x_up + gradgrad_y_up + gradgrad_z_up
 
-    lap_J3_dn = np.zeros(len(r_dn_carts), dtype=float)
+    lap_J3_dn = np.zeros(len(r_dn_carts), dtype=dtype_np)
 
     # laplacians dn
     for r_i, _ in enumerate(r_dn_carts):

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -61,7 +61,7 @@ from jax import grad, hessian, jit, vmap
 from jax import typing as jnpt
 from jax.tree_util import tree_flatten, tree_unflatten
 
-from ._precision import get_dtype
+from ._precision import get_dtype_jnp, get_dtype_np
 from ._setting import EPS_safe_distance, atol_consistency
 from .atomic_orbital import (
     AOs_cart_data,
@@ -433,12 +433,14 @@ class NNJastrow(nn.Module):
             jnp.ndarray: ``(n_a, n_b)`` matrix with a small epsilon added before the square
             root to keep gradients finite when particles coincide.
         """
-        dtype_j = get_dtype("jastrow")
+        dtype_jnp = get_dtype_jnp("jastrow_eval")
         if A.shape[0] == 0 or B.shape[0] == 0:
-            return jnp.zeros((A.shape[0], B.shape[0]), dtype=dtype_j)
-        # Compute differences in float64 to avoid catastrophic cancellation
-        # under float32 jastrow zone, then downcast.
-        diff = (A.astype(jnp.float64)[:, None, :] - B.astype(jnp.float64)[None, :, :]).astype(dtype_j)
+            return jnp.zeros((A.shape[0], B.shape[0]), dtype=dtype_jnp)
+        # Reconstruct differences in caller-supplied precision (fp64 from MCMC
+        # walker state) via JAX promotion when one operand is fp64, then downcast
+        # to the jastrow_eval zone. Avoids catastrophic cancellation without
+        # hardcoding fp64.
+        diff = (A[:, None, :] - B[None, :, :]).astype(dtype_jnp)
         return jnp.sqrt(jnp.sum(diff**2, axis=-1) + EPS_safe_distance)
 
     def _nuclear_embeddings(self, Z_n: jnp.ndarray) -> jnp.ndarray:
@@ -451,10 +453,10 @@ class NNJastrow(nn.Module):
             jnp.ndarray: ``(n_nuc, hidden_dim)`` embeddings looked up through
             ``species_lookup``. Returns an empty array when no nuclei are present.
         """
-        dtype = get_dtype("jastrow")
+        dtype_jnp = get_dtype_jnp("jastrow_eval")
         n_nuc = Z_n.shape[0]
         if n_nuc == 0:
-            return jnp.zeros((0, self.hidden_dim), dtype=dtype)
+            return jnp.zeros((0, self.hidden_dim), dtype=dtype_jnp)
 
         lookup = jnp.asarray(self.species_lookup)
         species_ids = jnp.take(lookup, Z_n.astype(jnp.int32), mode="clip")
@@ -513,10 +515,9 @@ class NNJastrow(nn.Module):
             The network is permutation equivariant within each spin channel and rotation
             invariant by construction of the PhysNet radial features.
         """
-        dtype = get_dtype("jastrow")
-        r_up = jnp.asarray(r_up, dtype=dtype)
-        r_dn = jnp.asarray(r_dn, dtype=dtype)
-        R_n = jnp.asarray(R_n, dtype=dtype)
+        # Forward r_up/r_dn/R_n as-is (Principle 3a — no parameter rebind).
+        # `_pairwise_distances` reconstructs the differences in caller-supplied
+        # precision and downcasts to the jastrow_eval zone at the use site.
         Z_n = jnp.asarray(Z_n)
 
         n_up = r_up.shape[0]
@@ -627,8 +628,7 @@ class Jastrow_one_body_data:
     @classmethod
     def init_jastrow_one_body_data(cls, jastrow_1b_param, structure_data, core_electrons, jastrow_1b_type="exp"):
         """Initialization."""
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = get_dtype_np("jastrow_eval")
         jastrow_one_body_data = cls(
             jastrow_1b_param=np.asarray(jastrow_1b_param, dtype=dtype_np).reshape(()),
             jastrow_1b_type=jastrow_1b_type,
@@ -657,15 +657,16 @@ def compute_Jastrow_one_body(
     Returns:
         float: One-body Jastrow value (before exponentiation).
     """
-    dtype = get_dtype("jastrow")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # NOTE: do not pre-cast r_*_carts. ``one_body_jastrow_kernel`` reconstructs
+    # ``r - R`` in float64 internally to avoid catastrophic cancellation;
+    # a wrapper-level downcast would defeat that guard.
+    dtype_jnp = get_dtype_jnp("jastrow_eval")
     # Retrieve structure data and convert to JAX arrays
-    R_carts = jnp.array(jastrow_one_body_data.structure_data.positions, dtype=dtype)
-    atomic_numbers = jnp.array(jastrow_one_body_data.structure_data.atomic_numbers, dtype=dtype)
-    core_electrons = jnp.array(jastrow_one_body_data.core_electrons, dtype=dtype)
+    R_carts = jastrow_one_body_data.structure_data._positions_cart_jnp.astype(dtype_jnp)
+    atomic_numbers = jnp.array(jastrow_one_body_data.structure_data.atomic_numbers, dtype=dtype_jnp)
+    core_electrons = jnp.array(jastrow_one_body_data.core_electrons, dtype=dtype_jnp)
     effective_charges = atomic_numbers - core_electrons
-    j1b = jnp.asarray(jastrow_one_body_data.jastrow_1b_param, dtype=dtype)
+    j1b = jnp.asarray(jastrow_one_body_data.jastrow_1b_param, dtype=dtype_jnp)
 
     j1b_type = jastrow_one_body_data.jastrow_1b_type
 
@@ -678,8 +679,11 @@ def compute_Jastrow_one_body(
             R_cart: jnpt.ArrayLike,
         ) -> float:
             """Exponential form of J1."""
-            # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-            diff = (r_cart.astype(jnp.float64) - R_cart.astype(jnp.float64)).astype(r_cart.dtype)
+            # Reconstruct r - R in caller-supplied precision (fp64 from MCMC walker
+            # state) via JAX promotion when one operand is fp64, then downcast to
+            # the jastrow_eval zone. Avoids catastrophic cancellation without
+            # hardcoding fp64.
+            diff = (r_cart - R_cart).astype(dtype_jnp)
             return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * coeff * jnp.linalg.norm(diff)))
 
         def atom_contrib(r_cart, R_cart, Z_eff):
@@ -690,8 +694,11 @@ def compute_Jastrow_one_body(
 
         def atom_contrib(r_cart, R_cart, Z_eff):
             """Pade form of J1: -Z_eff^{3/4} * r_eN / (2*(1 + a * Z_eff^{1/4} * r_eN))."""
-            # Compute r-R in float64 to avoid catastrophic cancellation under float32 zones.
-            diff = (r_cart.astype(jnp.float64) - R_cart.astype(jnp.float64)).astype(r_cart.dtype)
+            # Reconstruct r - R in caller-supplied precision (fp64 from MCMC walker
+            # state) via JAX promotion when one operand is fp64, then downcast to
+            # the jastrow_eval zone. Avoids catastrophic cancellation without
+            # hardcoding fp64.
+            diff = (r_cart - R_cart).astype(dtype_jnp)
             r_eN = jnp.linalg.norm(diff)
             coeff = (2.0 * Z_eff) ** (1.0 / 4.0)
             return -((2.0 * Z_eff) ** (3.0 / 4.0)) * r_eN / (2.0 * (1.0 + j1b * coeff * r_eN))
@@ -718,8 +725,7 @@ def _compute_Jastrow_one_body_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See compute_Jastrow_one_body_api."""
-    dtype = get_dtype("jastrow")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_eval")
     positions = jastrow_one_body_data.structure_data.positions
     atomic_numbers = jastrow_one_body_data.structure_data.atomic_numbers
     core_electrons = jastrow_one_body_data.core_electrons
@@ -775,8 +781,7 @@ def _compute_grads_and_laplacian_Jastrow_one_body_debug(
     np.ndarray,
 ]:
     """Numerical gradients and Laplacian for one-body Jastrow (debug)."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_grad_lap")
     diff_h = 1.0e-5
     r_up_carts = np.array(r_up_carts, dtype=dtype_np)
     r_dn_carts = np.array(r_dn_carts, dtype=dtype_np)
@@ -929,9 +934,9 @@ def _compute_grads_and_laplacian_Jastrow_one_body_auto(
     jax.Array,
 ]:
     """Auto-diff gradients and Laplacian for one-body Jastrow."""
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.array(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    r_up_carts = jnp.array(r_up_carts, dtype=dtype_jnp)
+    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype_jnp)
 
     grad_J1_up = grad(compute_Jastrow_one_body, argnums=1)(jastrow_one_body_data, r_up_carts, r_dn_carts)
     grad_J1_dn = grad(compute_Jastrow_one_body, argnums=2)(jastrow_one_body_data, r_up_carts, r_dn_carts)
@@ -963,10 +968,10 @@ def compute_grads_and_laplacian_Jastrow_one_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    dtype = get_dtype("kinetic")
-    positions = jnp.asarray(jastrow_one_body_data.structure_data.positions, dtype=dtype)
-    atomic_numbers = jnp.asarray(jastrow_one_body_data.structure_data.atomic_numbers)
-    core_electrons = jnp.asarray(jastrow_one_body_data.core_electrons)
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    positions = jastrow_one_body_data.structure_data._positions_cart_jnp.astype(dtype_jnp)
+    atomic_numbers = jnp.asarray(jastrow_one_body_data.structure_data.atomic_numbers, dtype=dtype_jnp)
+    core_electrons = jnp.asarray(jastrow_one_body_data.core_electrons, dtype=dtype_jnp)
     z_eff = atomic_numbers - core_electrons
 
     a = jastrow_one_body_data.jastrow_1b_param
@@ -1016,8 +1021,8 @@ def compute_grads_and_laplacian_Jastrow_one_body(
     else:
         raise ValueError(f"Unknown jastrow_1b_type: {j1b_type}")
 
-    grad_up, lap_up = _grad_lap_one_spin(jnp.asarray(r_up_carts, dtype=dtype))
-    grad_dn, lap_dn = _grad_lap_one_spin(jnp.asarray(r_dn_carts, dtype=dtype))
+    grad_up, lap_up = _grad_lap_one_spin(jnp.asarray(r_up_carts, dtype=dtype_jnp))
+    grad_dn, lap_dn = _grad_lap_one_spin(jnp.asarray(r_dn_carts, dtype=dtype_jnp))
 
     return grad_up, grad_dn, lap_up, lap_dn
 
@@ -1084,8 +1089,7 @@ class Jastrow_two_body_data:
     @classmethod
     def init_jastrow_two_body_data(cls, jastrow_2b_param=1.0, jastrow_2b_type="pade"):
         """Initialization."""
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = get_dtype_np("jastrow_eval")
         jastrow_two_body_data = cls(
             jastrow_2b_param=np.asarray(jastrow_2b_param, dtype=dtype_np).reshape(()),
             jastrow_2b_type=jastrow_2b_type,
@@ -1112,22 +1116,27 @@ def compute_Jastrow_two_body(
     Returns:
         float: Two-body Jastrow value (before exponentiation).
     """
-    dtype_j2 = get_dtype("jastrow")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype_j2)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype_j2)
-    j2b_param = jnp.asarray(jastrow_two_body_data.jastrow_2b_param, dtype=dtype_j2)
+    # NOTE: do not pre-cast r_*_carts. ``two_body_jastrow_pade``/``_exp``
+    # reconstruct ``r_i - r_j`` in float64 internally to avoid catastrophic
+    # cancellation; a wrapper-level downcast would defeat that guard.
+    dtype_jnp = get_dtype_jnp("jastrow_eval")
+    j2b_param = jnp.asarray(jastrow_two_body_data.jastrow_2b_param, dtype=dtype_jnp)
     j2b_type = jastrow_two_body_data.jastrow_2b_type
 
     def two_body_jastrow_exp(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Exponential form of J2."""
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_cart_i.astype(jnp.float64) - r_cart_j.astype(jnp.float64)).astype(r_cart_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # jastrow_eval zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_cart_i - r_cart_j).astype(dtype_jnp)
         return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * jnp.linalg.norm(diff)))
 
     def two_body_jastrow_pade(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Pade form of J2."""
-        # Compute r_i - r_j in float64 to avoid catastrophic cancellation under float32 zones.
-        diff = (r_cart_i.astype(jnp.float64) - r_cart_j.astype(jnp.float64)).astype(r_cart_i.dtype)
+        # Reconstruct r_i - r_j in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion when one operand is fp64, then downcast to the
+        # jastrow_eval zone. Avoids catastrophic cancellation without hardcoding fp64.
+        diff = (r_cart_i - r_cart_j).astype(dtype_jnp)
         r_ij = jnp.linalg.norm(diff)
         return r_ij / 2.0 * (1.0 + param * r_ij) ** (-1.0)
 
@@ -1235,15 +1244,15 @@ class Jastrow_three_body_data:
 
     Args:
         orb_data (AOs_sphe_data | AOs_cart_data | MOs_data): Basis/orbital data used for both spins.
-        j_matrix (npt.NDArray | jax.Array): J matrix with shape ``(orb_num, orb_num + 1)``.
+        j_matrix (npt.NDArray[np.float64]): J matrix with shape ``(orb_num, orb_num + 1)``. dtype: float64.
     """
 
     orb_data: AOs_sphe_data | AOs_cart_data | MOs_data = struct.field(
         pytree_node=True, default_factory=AOs_sphe_data
     )  #: Orbital basis (AOs or MOs) shared across spins.
-    j_matrix: npt.NDArray | jax.Array = struct.field(
-        pytree_node=True, default_factory=lambda: np.array([])
-    )  #: J3/J1 matrix; square block plus final column.
+    j_matrix: npt.NDArray[np.float64] = struct.field(
+        pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64)
+    )  #: J3/J1 matrix; square block plus final column. dtype: float64.
 
     def sanity_check(self) -> None:
         """Check attributes of the class.
@@ -1312,26 +1321,33 @@ class Jastrow_three_body_data:
             raise NotImplementedError
 
     @property
+    def _j_matrix_jnp(self) -> jax.Array:
+        """Return j_matrix as a jax.Array (jnp view of the underlying numpy storage)."""
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        return jnp.asarray(self.j_matrix, dtype=jnp.float64)
+
+    @property
     def ao_exponents(self) -> jax.Array:
-        """AO Gaussian exponents, regardless of AO/MO representation."""
+        """AO Gaussian exponents (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data.exponents
+            return self.orb_data._exponents_jnp
         elif isinstance(self.orb_data, MOs_data):
-            return self.orb_data.aos_data.exponents
+            return self.orb_data.aos_data._exponents_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data)}")
 
     @property
     def ao_coefficients(self) -> jax.Array:
-        """AO contraction coefficients, regardless of AO/MO representation."""
+        """AO contraction coefficients (jnp view of underlying numpy storage)."""
         if isinstance(self.orb_data, (AOs_sphe_data, AOs_cart_data)):
-            return self.orb_data.coefficients
+            return self.orb_data._coefficients_jnp
         elif isinstance(self.orb_data, MOs_data):
-            return self.orb_data.aos_data.coefficients
+            return self.orb_data.aos_data._coefficients_jnp
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data)}")
 
-    def with_updated_ao_exponents(self, new_exp: jax.Array) -> "Jastrow_three_body_data":
+    def with_updated_ao_exponents(self, new_exp: npt.NDArray[np.float64]) -> "Jastrow_three_body_data":
         """Return a new instance with updated AO exponents."""
         if isinstance(self.orb_data, (AOs_sphe_data, AOs_cart_data)):
             return self.replace(orb_data=self.orb_data.replace(exponents=new_exp))
@@ -1341,7 +1357,7 @@ class Jastrow_three_body_data:
         else:
             raise NotImplementedError(f"Unsupported orb_data type: {type(self.orb_data)}")
 
-    def with_updated_ao_coefficients(self, new_coeff: jax.Array) -> "Jastrow_three_body_data":
+    def with_updated_ao_coefficients(self, new_coeff: npt.NDArray[np.float64]) -> "Jastrow_three_body_data":
         """Return a new instance with updated AO contraction coefficients."""
         if isinstance(self.orb_data, (AOs_sphe_data, AOs_cart_data)):
             return self.replace(orb_data=self.orb_data.replace(coefficients=new_coeff))
@@ -1367,8 +1383,7 @@ class Jastrow_three_body_data:
             random_scale: Upper bound of uniform sampler when random_init is True (default 0.01).
             seed: Optional seed for deterministic initialization when random_init is True.
         """
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = get_dtype_np("jastrow_eval")
         if random_init:
             rng = np.random.default_rng(seed)
             j_matrix = rng.uniform(0.0, random_scale, size=(orb_data._num_orb, orb_data._num_orb + 1)).astype(dtype_np)
@@ -1396,8 +1411,7 @@ class Jastrow_three_body_data:
 
         aos_cart, transform_matrix = _aos_sphe_to_cart(self.orb_data)
 
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = get_dtype_np("jastrow_eval")
         square_sph = np.asarray(self.j_matrix[:, :-1], dtype=dtype_np)
         j1_sph = np.asarray(self.j_matrix[:, -1], dtype=dtype_np)
         square_cart = transform_matrix.T @ square_sph @ transform_matrix
@@ -1424,8 +1438,7 @@ class Jastrow_three_body_data:
 
         aos_sphe, transform_pinv = _aos_cart_to_sphe(self.orb_data)
 
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = get_dtype_np("jastrow_eval")
         square_cart = np.asarray(self.j_matrix[:, :-1], dtype=dtype_np)
         j1_cart = np.asarray(self.j_matrix[:, -1], dtype=dtype_np)
         square_sph = transform_pinv.T @ square_cart @ transform_pinv
@@ -1591,10 +1604,10 @@ class Jastrow_NN_data:
         # Dummy electron positions for parameter initialization:
         # use one spin-up and one spin-down electron at the origin so that
         # both PauliNet channels are initialized with valid shapes.
-        dtype = get_dtype("jastrow")
-        r_up_init = jnp.zeros((1, 3), dtype=dtype)
-        r_dn_init = jnp.zeros((1, 3), dtype=dtype)
-        R_n = jnp.asarray(structure_data.positions, dtype=dtype)  # (n_nuc, 3)
+        dtype_jnp = get_dtype_jnp("jastrow_eval")
+        r_up_init = jnp.zeros((1, 3), dtype=dtype_jnp)
+        r_dn_init = jnp.zeros((1, 3), dtype=dtype_jnp)
+        R_n = structure_data._positions_cart_jnp.astype(dtype_jnp)  # (n_nuc, 3)
         Z_n = jnp.asarray(structure_data.atomic_numbers)  # (n_nuc,)
 
         rngs = {"params": key}
@@ -1667,18 +1680,18 @@ def compute_Jastrow_three_body(
     Returns:
         float: Three-body Jastrow value (before exponentiation).
     """
-    dtype = get_dtype("jastrow")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
-    j_matrix = jastrow_three_body_data.j_matrix.astype(dtype)
+    # r_*_carts forwarded unchanged to ``compute_orb_api`` (the AO/MO kernels
+    # reconstruct ``r - R`` in float64 internally); do not pre-cast here.
+    dtype_jnp = get_dtype_jnp("jastrow_eval")
+    j_matrix = jastrow_three_body_data._j_matrix_jnp.astype(dtype_jnp)
     num_electron_up = len(r_up_carts)
     num_electron_dn = len(r_dn_carts)
 
-    aos_up = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts), dtype=dtype)
-    aos_dn = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts), dtype=dtype)
+    aos_up = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts), dtype=dtype_jnp)
+    aos_dn = jnp.array(jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts), dtype=dtype_jnp)
 
-    K_up = jnp.tril(jnp.ones((num_electron_up, num_electron_up), dtype=dtype), k=-1)
-    K_dn = jnp.tril(jnp.ones((num_electron_dn, num_electron_dn), dtype=dtype), k=-1)
+    K_up = jnp.tril(jnp.ones((num_electron_up, num_electron_up), dtype=dtype_jnp), k=-1)
+    K_dn = jnp.tril(jnp.ones((num_electron_dn, num_electron_dn), dtype=dtype_jnp), k=-1)
 
     j1_matrix_up = j_matrix[:, -1]
     j1_matrix_dn = j_matrix[:, -1]
@@ -1686,8 +1699,8 @@ def compute_Jastrow_three_body(
     j3_matrix_dn_dn = j_matrix[:, :-1]
     j3_matrix_up_dn = j_matrix[:, :-1]
 
-    e_up = jnp.ones(num_electron_up, dtype=dtype).T
-    e_dn = jnp.ones(num_electron_dn, dtype=dtype).T
+    e_up = jnp.ones(num_electron_up, dtype=dtype_jnp).T
+    e_dn = jnp.ones(num_electron_dn, dtype=dtype_jnp).T
 
     # print(f"aos_up.shape={aos_up.shape}")
     # print(f"aos_dn.shape={aos_dn.shape}")
@@ -1714,8 +1727,6 @@ def _compute_Jastrow_three_body_debug(
     r_dn_carts: npt.NDArray[np.float64],
 ) -> float:
     """See _api method."""
-    dtype = get_dtype("jastrow")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
     aos_up = jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_up_carts)
     aos_dn = jastrow_three_body_data.compute_orb_api(jastrow_three_body_data.orb_data, r_dn_carts)
 
@@ -1900,8 +1911,8 @@ class Jastrow_data:
         in ``Wavefunction_data.get_variational_blocks`` and add the
         corresponding handling here, without touching the SR/MCMC driver.
         """
-        dtype = get_dtype("jastrow")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_jnp = get_dtype_jnp("jastrow_eval")
+        dtype_np = get_dtype_np("jastrow_eval")
         j1 = self.jastrow_one_body_data
         j2 = self.jastrow_two_body_data
         j3 = self.jastrow_three_body_data
@@ -1927,15 +1938,15 @@ class Jastrow_data:
             j3 = Jastrow_three_body_data(orb_data=j3.orb_data, j_matrix=j3_new)
         elif block.name == "j3_basis_exp" and j3 is not None:
             new_exp = np.asarray(block.values, dtype=dtype_np)
-            new_exp = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_exp), dtype=dtype)
+            new_exp = self._symmetrize_ao_basis(j3.orb_data, new_exp)
             j3 = j3.with_updated_ao_exponents(new_exp)
         elif block.name == "j3_basis_coeff" and j3 is not None:
             new_coeff = np.asarray(block.values, dtype=dtype_np)
-            new_coeff = jnp.asarray(self._symmetrize_ao_basis(j3.orb_data, new_coeff), dtype=dtype)
+            new_coeff = self._symmetrize_ao_basis(j3.orb_data, new_coeff)
             j3 = j3.with_updated_ao_coefficients(new_coeff)
         elif block.name == "jastrow_nn_params" and nn3 is not None:
             # Update NN Jastrow parameters: block.values is the flattened parameter vector.
-            flat = jnp.asarray(block.values, dtype=dtype).reshape(-1)
+            flat = jnp.asarray(block.values, dtype=dtype_jnp).reshape(-1)
             params_new = nn3.unflatten_fn(flat)
             nn3 = nn3.replace(params=params_new)
 
@@ -2048,9 +2059,9 @@ def compute_Jastrow_part(jastrow_data: Jastrow_data, r_up_carts: jax.Array, r_dn
     Returns:
         float: Total Jastrow value before exponentiation.
     """
-    dtype = get_dtype("jastrow")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged to the sub-Jastrow kernels (each handles
+    # its own zone management). Do not pre-cast.
+    dtype_jnp = get_dtype_jnp("jastrow_eval")
 
     J1 = 0.0
     J2 = 0.0
@@ -2074,10 +2085,10 @@ def compute_Jastrow_part(jastrow_data: Jastrow_data, r_up_carts: jax.Array, r_dn
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
+        R_n = nn3.structure_data._positions_cart_jnp.astype(dtype_jnp)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype_jnp)
         nn_params = jax.tree_util.tree_map(
-            lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+            lambda x: x.astype(dtype_jnp) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
         )
         J3_nn = nn3.nn_def.apply({"params": nn_params}, r_up_carts, r_dn_carts, R_n, Z_n)
         J3 = J3 + J3_nn
@@ -2091,8 +2102,8 @@ def _compute_Jastrow_part_debug(
     jastrow_data: Jastrow_data, r_up_carts: npt.NDArray[np.float64], r_dn_carts: npt.NDArray[np.float64]
 ) -> float:
     """See compute_Jastrow_part_jax for more details."""
-    dtype = get_dtype("jastrow")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_jnp = get_dtype_jnp("jastrow_eval")
+    dtype_np = get_dtype_np("jastrow_eval")
     J1 = 0.0
     J2 = 0.0
     J3 = 0.0
@@ -2120,14 +2131,14 @@ def _compute_Jastrow_part_debug(
 
         # Use JAX NN for debug as well; convert inputs to jnp and back to float
         nn_params = jax.tree_util.tree_map(
-            lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+            lambda x: x.astype(dtype_jnp) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
         )
         J3_nn = nn3.nn_def.apply(
             {"params": nn_params},
-            jnp.asarray(r_up_carts, dtype=dtype),
-            jnp.asarray(r_dn_carts, dtype=dtype),
-            jnp.asarray(R_n, dtype=dtype),
-            jnp.asarray(Z_n, dtype=dtype),
+            jnp.asarray(r_up_carts, dtype=dtype_jnp),
+            jnp.asarray(r_dn_carts, dtype=dtype_jnp),
+            jnp.asarray(R_n, dtype=dtype_jnp),
+            jnp.asarray(Z_n, dtype=dtype_jnp),
         )
         J3 += float(J3_nn)
 
@@ -2169,11 +2180,13 @@ def _compute_ratio_Jastrow_part_rank1_update(
         grid generated by the MCMC loop, where exactly one electron is displaced
         per grid point by construction.
     """
-    dtype = get_dtype("mcmc")
-    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
-    new_r_up_carts_arr = jnp.asarray(new_r_up_carts_arr, dtype=dtype)
-    new_r_dn_carts_arr = jnp.asarray(new_r_dn_carts_arr, dtype=dtype)
+    # Forward old/new r_up/dn_carts as-is (Principle 3a — no parameter rebind).
+    # Module-level forwards (compute_Jastrow_part, compute_Jastrow_one_body,
+    # compute_orb_api, NN_Jastrow.apply) handle their own use-site casts.
+    # Inline arithmetic in the local J1/J2/J3 closures below casts at the diff
+    # site (Principle 3b) — for r-r differences the operand is reconstructed in
+    # caller-supplied precision (fp64 from MCMC walker state) before downcast.
+    dtype_jnp = get_dtype_jnp("jastrow_ratio")
 
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
@@ -2183,7 +2196,7 @@ def _compute_ratio_Jastrow_part_rank1_update(
         jastrow_xp = vmap(compute_Jastrow_part, in_axes=(None, 0, 0))(jastrow_data, new_r_up_carts_arr, new_r_dn_carts_arr)
         return jnp.exp(jastrow_xp - jastrow_x)
 
-    J_ratio = jnp.ones(n_grid, dtype=dtype)
+    J_ratio = jnp.ones(n_grid, dtype=dtype_jnp)
 
     # J1 part
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2197,8 +2210,12 @@ def _compute_ratio_Jastrow_part_rank1_update(
                 idx_dn = jnp.argmax(nonzero_dn)
                 r_dn_new = new_r_dn_carts[idx_dn]
                 r_dn_old = old_r_dn_carts[idx_dn]
-                j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0))
-                j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0))
+                j1_new = compute_Jastrow_one_body(
+                    j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_new, axis=0)
+                )
+                j1_old = compute_Jastrow_one_body(
+                    j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_old, axis=0)
+                )
                 return jnp.exp(j1_new - j1_old)
 
         elif num_dn == 0:
@@ -2209,8 +2226,12 @@ def _compute_ratio_Jastrow_part_rank1_update(
                 idx_up = jnp.argmax(nonzero_up)
                 r_up_new = new_r_up_carts[idx_up]
                 r_up_old = old_r_up_carts[idx_up]
-                j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype))
-                j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype))
+                j1_new = compute_Jastrow_one_body(
+                    j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp)
+                )
+                j1_old = compute_Jastrow_one_body(
+                    j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp)
+                )
                 return jnp.exp(j1_new - j1_old)
 
         else:
@@ -2230,10 +2251,10 @@ def _compute_ratio_Jastrow_part_rank1_update(
                     r_up_new = new_r_up_carts[idx_up]
                     r_up_old = old_r_up_carts[idx_up]
                     j1_new = compute_Jastrow_one_body(
-                        j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype)
+                        j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp)
                     )
                     j1_old = compute_Jastrow_one_body(
-                        j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype)
+                        j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp)
                     )
                     return jnp.exp(j1_new - j1_old)
 
@@ -2242,10 +2263,10 @@ def _compute_ratio_Jastrow_part_rank1_update(
                     r_dn_new = new_r_dn_carts[idx_dn]
                     r_dn_old = old_r_dn_carts[idx_dn]
                     j1_new = compute_Jastrow_one_body(
-                        j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0)
+                        j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_new, axis=0)
                     )
                     j1_old = compute_Jastrow_one_body(
-                        j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0)
+                        j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_old, axis=0)
                     )
                     return jnp.exp(j1_new - j1_old)
 
@@ -2267,11 +2288,15 @@ def _compute_ratio_Jastrow_part_rank1_update(
 
     def _two_body_jastrow_exp(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Exponential form of J2."""
-        return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * jnp.linalg.norm(r_cart_i - r_cart_j)))
+        # Reconstruct diff in caller-supplied precision then downcast (Principle 3b).
+        diff = (r_cart_i - r_cart_j).astype(dtype_jnp)
+        return 1.0 / (2.0 * param) * (1.0 - jnp.exp(-param * jnp.linalg.norm(diff)))
 
     def _two_body_jastrow_pade(param: float, r_cart_i: jnpt.ArrayLike, r_cart_j: jnpt.ArrayLike) -> float:
         """Pade form of J2."""
-        return jnp.linalg.norm(r_cart_i - r_cart_j) / 2.0 * (1.0 + param * jnp.linalg.norm(r_cart_i - r_cart_j)) ** (-1.0)
+        # Reconstruct diff in caller-supplied precision then downcast (Principle 3b).
+        diff = (r_cart_i - r_cart_j).astype(dtype_jnp)
+        return jnp.linalg.norm(diff) / 2.0 * (1.0 + param * jnp.linalg.norm(diff)) ** (-1.0)
 
     # Select the functional form based on type
     if jastrow_data.jastrow_two_body_data is not None:
@@ -2388,8 +2413,10 @@ def _compute_ratio_Jastrow_part_rank1_update(
 
         def compute_pairwise_sums(pos1, pos2):
             if pos1.shape[0] == 0 or pos2.shape[0] == 0:
-                return jnp.zeros(pos1.shape[0], dtype=dtype)
-            dists = _safe_norm(pos1[:, None, :] - pos2[None, :, :])
+                return jnp.zeros(pos1.shape[0], dtype=dtype_jnp)
+            # Reconstruct diff in caller-supplied precision then downcast (Principle 3b).
+            diff = (pos1[:, None, :] - pos2[None, :, :]).astype(dtype_jnp)
+            dists = _safe_norm(diff)
             vals = _j2_from_dist(dists, j2_param)
             return jnp.sum(vals, axis=1)
 
@@ -2412,9 +2439,14 @@ def _compute_ratio_Jastrow_part_rank1_update(
         r_dn_old = jnp.take(old_r_dn_carts, idx_dn, axis=0)
 
         def _batch_pairwise_sum(points_a, points_b, param):
-            norm_a2 = jnp.sum(points_a * points_a, axis=1, keepdims=True)
-            norm_b2 = jnp.sum(points_b * points_b, axis=1, keepdims=True).T
-            dots = jnp.dot(points_a, points_b.T)
+            # Cast operands to the jastrow_ratio zone at the arithmetic use site
+            # (Principle 3b). Inputs may arrive in caller-supplied precision; cast
+            # before consuming as norm/dot operands to keep the function in-zone.
+            pa = points_a.astype(dtype_jnp)
+            pb = points_b.astype(dtype_jnp)
+            norm_a2 = jnp.sum(pa * pa, axis=1, keepdims=True)
+            norm_b2 = jnp.sum(pb * pb, axis=1, keepdims=True).T
+            dots = jnp.dot(pa, pb.T)
             d2 = jnp.maximum(norm_a2 + norm_b2 - 2.0 * dots, 0.0)
             safe_d2 = jnp.where(d2 > 0, d2, jnp.ones_like(d2))
             d = jnp.where(d2 > 0, jnp.sqrt(safe_d2), jnp.zeros_like(d2))
@@ -2423,7 +2455,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
 
         # Up-move branch contributions (all grids in batch)
         up_up_new_raw = _batch_pairwise_sum(r_up_new, old_r_up_carts, j2_param)
-        up_up_self = _j2_from_dist(jnp.linalg.norm(r_up_new - r_up_old, axis=1), j2_param)
+        # Reconstruct diff in caller-supplied precision then downcast (Principle 3b).
+        up_up_self = _j2_from_dist(jnp.linalg.norm((r_up_new - r_up_old).astype(dtype_jnp), axis=1), j2_param)
         up_up_new = up_up_new_raw - up_up_self
         up_up_old = jnp.take(J2_sum_up_up, idx_up, axis=0)
 
@@ -2433,7 +2466,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
 
         # Down-move branch contributions (all grids in batch)
         dn_dn_new_raw = _batch_pairwise_sum(r_dn_new, old_r_dn_carts, j2_param)
-        dn_dn_self = _j2_from_dist(jnp.linalg.norm(r_dn_new - r_dn_old, axis=1), j2_param)
+        # Reconstruct diff in caller-supplied precision then downcast (Principle 3b).
+        dn_dn_self = _j2_from_dist(jnp.linalg.norm((r_dn_new - r_dn_old).astype(dtype_jnp), axis=1), j2_param)
         dn_dn_new = dn_dn_new_raw - dn_dn_self
         dn_dn_old = jnp.take(J2_sum_dn_dn, idx_dn, axis=0)
 
@@ -2448,12 +2482,12 @@ def _compute_ratio_Jastrow_part_rank1_update(
     # J3 part  (batched AO evaluation — avoids per-config compute_orb_api inside vmap)
     if jastrow_data.jastrow_three_body_data is not None:
         j3d = jastrow_data.jastrow_three_body_data
-        j3_mat = j3d.j_matrix[:, :-1]  # (n_ao, n_ao)  shared for up-up / dn-dn / up-dn
-        j1_vec = j3d.j_matrix[:, -1]  # (n_ao,)
+        j3_mat = j3d._j_matrix_jnp[:, :-1]  # (n_ao, n_ao)  shared for up-up / dn-dn / up-dn
+        j1_vec = j3d._j_matrix_jnp[:, -1]  # (n_ao,)
 
         # Old AOs evaluated once
-        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype)  # (n_ao, N_up)
-        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype)  # (n_ao, N_dn)
+        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype_jnp)  # (n_ao, N_up)
+        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype_jnp)  # (n_ao, N_dn)
 
         N_batch = new_r_up_carts_arr.shape[0]
 
@@ -2473,8 +2507,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         r_old_moved = jnp.where(up_moved_batch[:, None], r_old_up_moved, r_old_dn_moved)  # (N, 3)
 
         # Single batched AO evaluation for all N configs (replaces N per-config calls inside vmap)
-        aos_new_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_new_moved), dtype=dtype)  # (n_ao, N)
-        aos_old_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_old_moved), dtype=dtype)  # (n_ao, N)
+        aos_new_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_new_moved), dtype=dtype_jnp)  # (n_ao, N)
+        aos_old_batch = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_old_moved), dtype=dtype_jnp)  # (n_ao, N)
         aos_p_batch = aos_new_batch - aos_old_batch  # (n_ao, N)
 
         # Precompute constant products (independent of config)
@@ -2494,8 +2528,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         # UP formula  -----------------------------------------------------------
         V_up = jnp.dot(aos_p_batch.T, W_up)  # (N, N_up)
         P_up = jnp.dot(U_up, aos_p_batch)  # (N_up, N)
-        Q_up_c = (idx_for_Q[:, None] < jnp.arange(num_up)[None, :]).astype(dtype)  # (N, N_up)
-        Q_up_r = (idx_for_Q[:, None] > jnp.arange(num_up)[None, :]).astype(dtype)  # (N, N_up)
+        Q_up_c = (idx_for_Q[:, None] < jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (N, N_up)
+        Q_up_r = (idx_for_Q[:, None] > jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (N, N_up)
         term2_up = jnp.sum(V_up * Q_up_c, axis=1)  # (N,)
         term3_up = jnp.sum(P_up.T * Q_up_r, axis=1)  # (N,)
         term4_up = dn_cross_vec @ aos_p_batch  # (N,)
@@ -2504,8 +2538,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         # DN formula  -----------------------------------------------------------
         V_dn = jnp.dot(aos_p_batch.T, W_dn)  # (N, N_dn)
         P_dn = jnp.dot(U_dn, aos_p_batch)  # (N_dn, N)
-        Q_dn_c = (idx_for_Q[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype)  # (N, N_dn)
-        Q_dn_r = (idx_for_Q[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype)  # (N, N_dn)
+        Q_dn_c = (idx_for_Q[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (N, N_dn)
+        Q_dn_r = (idx_for_Q[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (N, N_dn)
         term2_dn = jnp.sum(V_dn * Q_dn_c, axis=1)  # (N,)
         term3_dn = jnp.sum(P_dn.T * Q_dn_r, axis=1)  # (N,)
         term4_dn = up_cross_vec @ aos_p_batch  # (N,)
@@ -2527,7 +2561,7 @@ def _compute_ratio_Jastrow_part_rank1_update(
         if nn.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn.structure_data.positions, dtype=dtype)
+        R_n = nn.structure_data._positions_cart_jnp.astype(dtype_jnp)
         Z_n = jnp.asarray(nn.structure_data.atomic_numbers)
 
         def compute_one_grid_JNN(new_r_up_carts, new_r_dn_carts):
@@ -2581,11 +2615,12 @@ def _compute_ratio_Jastrow_part_split_spin(
         exclusively for the block-structured non-local ECP grids produced by
         the MCMC loop.
     """
-    dtype = get_dtype("mcmc")
-    old_r_up_carts = jnp.asarray(old_r_up_carts, dtype=dtype)
-    old_r_dn_carts = jnp.asarray(old_r_dn_carts, dtype=dtype)
-    new_r_up_shifted = jnp.asarray(new_r_up_shifted, dtype=dtype)
-    new_r_dn_shifted = jnp.asarray(new_r_dn_shifted, dtype=dtype)
+    # Forward old/new r_up/dn_carts as-is (Principle 3a — no parameter rebind).
+    # Module-level forwards (compute_Jastrow_one_body, compute_orb_api,
+    # _compute_ratio_Jastrow_part_rank1_update, NN_Jastrow.apply) handle their
+    # own use-site casts. Inline diffs in the local J2 _safe_norm closure cast
+    # operands to the jastrow_ratio zone at the use site (Principle 3b).
+    dtype_jnp = get_dtype_jnp("jastrow_ratio")
 
     num_up = old_r_up_carts.shape[0]
     num_dn = old_r_dn_carts.shape[0]
@@ -2621,8 +2656,8 @@ def _compute_ratio_Jastrow_part_split_spin(
     r_up_old_moved = old_r_up_carts[idx_up_block]  # (G_up, 3)
     r_dn_old_moved = old_r_dn_carts[idx_dn_block]  # (G_dn, 3)
 
-    J_up = jnp.ones(g_up, dtype=dtype)
-    J_dn = jnp.ones(g_dn, dtype=dtype)
+    J_up = jnp.ones(g_up, dtype=dtype_jnp)
+    J_dn = jnp.ones(g_dn, dtype=dtype_jnp)
 
     # ── J1 part ──────────────────────────────────────────────────────────────
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2630,8 +2665,8 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # UP block: only the moved up electron contributes to the J1 change.
         def compute_J1_up_one(r_up_new: jax.Array, r_up_old: jax.Array) -> jax.Array:
-            j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype))
-            j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype))
+            j1_new = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_new, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp))
+            j1_old = compute_Jastrow_one_body(j1_data, jnp.expand_dims(r_up_old, axis=0), jnp.zeros((0, 3), dtype=dtype_jnp))
             return jnp.exp(j1_new - j1_old)
 
         J1_up_block = vmap(compute_J1_up_one)(r_up_moved, r_up_old_moved)  # (G_up,)
@@ -2639,8 +2674,8 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # DN block: only the moved dn electron contributes.
         def compute_J1_dn_one(r_dn_new: jax.Array, r_dn_old: jax.Array) -> jax.Array:
-            j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_new, axis=0))
-            j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype), jnp.expand_dims(r_dn_old, axis=0))
+            j1_new = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_new, axis=0))
+            j1_old = compute_Jastrow_one_body(j1_data, jnp.zeros((0, 3), dtype=dtype_jnp), jnp.expand_dims(r_dn_old, axis=0))
             return jnp.exp(j1_new - j1_old)
 
         J1_dn_block = vmap(compute_J1_dn_one)(r_dn_moved, r_dn_old_moved)  # (G_dn,)
@@ -2652,7 +2687,12 @@ def _compute_ratio_Jastrow_part_split_spin(
         _j2_type_split = jastrow_data.jastrow_two_body_data.jastrow_2b_type
 
         def _safe_norm(diff):
-            sq = jnp.sum(diff**2, axis=-1)
+            # Cast diff (reconstructed in caller-supplied precision by the
+            # caller, e.g. `pos1 - pos2`) to the jastrow_ratio zone at the use
+            # site (Principle 3b). New variable name `d` keeps the parameter
+            # `diff` itself frozen (Principle 3a).
+            d = diff.astype(dtype_jnp)
+            sq = jnp.sum(d**2, axis=-1)
             return jnp.where(sq > 0, jnp.sqrt(jnp.where(sq > 0, sq, jnp.ones_like(sq))), jnp.zeros_like(sq))
 
         if _j2_type_split == "pade":
@@ -2702,12 +2742,12 @@ def _compute_ratio_Jastrow_part_split_spin(
     # ── J3 part ──────────────────────────────────────────────────────────────
     if jastrow_data.jastrow_three_body_data is not None:
         j3d = jastrow_data.jastrow_three_body_data
-        j3_mat = j3d.j_matrix[:, :-1]  # (n_ao, n_ao)
-        j1_vec = j3d.j_matrix[:, -1]  # (n_ao,)
+        j3_mat = j3d._j_matrix_jnp[:, :-1]  # (n_ao, n_ao)
+        j1_vec = j3d._j_matrix_jnp[:, -1]  # (n_ao,)
 
         # Old AOs evaluated once; column slices give old AO at each moved position.
-        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype)  # (n_ao, N_up)
-        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype)  # (n_ao, N_dn)
+        aos_up_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_up_carts), dtype=dtype_jnp)  # (n_ao, N_up)
+        aos_dn_old = jnp.array(j3d.compute_orb_api(j3d.orb_data, old_r_dn_carts), dtype=dtype_jnp)  # (n_ao, N_dn)
 
         # Precompute constant products (shared between blocks).
         W_up = jnp.dot(j3_mat, aos_up_old)  # (n_ao, N_up)
@@ -2719,15 +2759,15 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # ── UP BLOCK ─────────────────────────────────────────────────────────
         # New AOs at the moved up-electron positions; old AOs by column-slice.
-        aos_up_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_up_moved), dtype=dtype)  # (n_ao, G_up)
+        aos_up_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_up_moved), dtype=dtype_jnp)  # (n_ao, G_up)
         aos_up_old_moved = aos_up_old[:, idx_up_block]  # (n_ao, G_up)
         aos_p_up = aos_up_new_moved - aos_up_old_moved  # (n_ao, G_up)
 
         term1_up = j1_vec @ aos_p_up  # (G_up,)
         V_up_block = jnp.dot(aos_p_up.T, W_up)  # (G_up, N_up)
         P_up_block = jnp.dot(U_up, aos_p_up)  # (N_up, G_up)
-        Q_up_c = (idx_up_block[:, None] < jnp.arange(num_up)[None, :]).astype(dtype)  # (G_up, N_up)
-        Q_up_r = (idx_up_block[:, None] > jnp.arange(num_up)[None, :]).astype(dtype)  # (G_up, N_up)
+        Q_up_c = (idx_up_block[:, None] < jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (G_up, N_up)
+        Q_up_r = (idx_up_block[:, None] > jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (G_up, N_up)
         term2_up = jnp.sum(V_up_block * Q_up_c, axis=1)  # (G_up,)
         term3_up = jnp.sum(P_up_block.T * Q_up_r, axis=1)  # (G_up,)
         term4_up = dn_cross_vec @ aos_p_up  # (G_up,)
@@ -2735,15 +2775,15 @@ def _compute_ratio_Jastrow_part_split_spin(
 
         # ── DN BLOCK ─────────────────────────────────────────────────────────
         # New AOs at the moved dn-electron positions; old AOs by column-slice.
-        aos_dn_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_dn_moved), dtype=dtype)  # (n_ao, G_dn)
+        aos_dn_new_moved = jnp.array(j3d.compute_orb_api(j3d.orb_data, r_dn_moved), dtype=dtype_jnp)  # (n_ao, G_dn)
         aos_dn_old_moved = aos_dn_old[:, idx_dn_block]  # (n_ao, G_dn)
         aos_p_dn = aos_dn_new_moved - aos_dn_old_moved  # (n_ao, G_dn)
 
         term1_dn = j1_vec @ aos_p_dn  # (G_dn,)
         V_dn_block = jnp.dot(aos_p_dn.T, W_dn)  # (G_dn, N_dn)
         P_dn_block = jnp.dot(U_dn, aos_p_dn)  # (N_dn, G_dn)
-        Q_dn_c = (idx_dn_block[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype)  # (G_dn, N_dn)
-        Q_dn_r = (idx_dn_block[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype)  # (G_dn, N_dn)
+        Q_dn_c = (idx_dn_block[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (G_dn, N_dn)
+        Q_dn_r = (idx_dn_block[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (G_dn, N_dn)
         term2_dn = jnp.sum(V_dn_block * Q_dn_c, axis=1)  # (G_dn,)
         term3_dn = jnp.sum(P_dn_block.T * Q_dn_r, axis=1)  # (G_dn,)
         term4_dn = up_cross_vec @ aos_p_dn  # (G_dn,)
@@ -2755,7 +2795,7 @@ def _compute_ratio_Jastrow_part_split_spin(
         if nn.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn.structure_data.positions, dtype=dtype)
+        R_n = nn.structure_data._positions_cart_jnp.astype(dtype_jnp)
         Z_n = jnp.asarray(nn.structure_data.atomic_numbers)
 
         def compute_one_grid_JNN_split(r_up: jax.Array, r_dn: jax.Array) -> jax.Array:
@@ -2782,8 +2822,7 @@ def _compute_ratio_Jastrow_part_debug(
     new_r_dn_carts_arr: npt.NDArray[np.float64],
 ) -> npt.NDArray:
     """See _api method."""
-    dtype = get_dtype("mcmc")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_ratio")
     return np.array(
         [
             np.exp(compute_Jastrow_part(jastrow_data, new_r_up_carts, new_r_dn_carts))
@@ -2821,14 +2860,14 @@ def compute_grads_and_laplacian_Jastrow_part(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``
             and Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
 
     grad_J_up = jnp.zeros_like(r_up)
     grad_J_dn = jnp.zeros_like(r_dn)
-    lap_J_up = jnp.zeros((r_up.shape[0],), dtype=dtype)
-    lap_J_dn = jnp.zeros((r_dn.shape[0],), dtype=dtype)
+    lap_J_up = jnp.zeros((r_up.shape[0],), dtype=dtype_jnp)
+    lap_J_dn = jnp.zeros((r_dn.shape[0],), dtype=dtype_jnp)
 
     # one-body (analytic)
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2872,14 +2911,14 @@ def compute_grads_and_laplacian_Jastrow_part(
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype)
-        r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype)
-        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
+        r_up_carts_jnp = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+        r_dn_carts_jnp = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
+        R_n = nn3.structure_data._positions_cart_jnp.astype(dtype_jnp)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype_jnp)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
             nn_params = jax.tree_util.tree_map(
-                lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+                lambda x: x.astype(dtype_jnp) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
             )
             return nn3.nn_def.apply({"params": nn_params}, r_up, r_dn, R_n, Z_n)
 
@@ -2924,14 +2963,14 @@ def _compute_grads_and_laplacian_Jastrow_part_auto(
     Returns:
         the gradients(x,y,z) of J and the sum of laplacians of J at (r_up_carts, r_dn_carts).
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts_jnp = jnp.array(r_up_carts, dtype=dtype)
-    r_dn_carts_jnp = jnp.array(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    r_up_carts_jnp = jnp.array(r_up_carts, dtype=dtype_jnp)
+    r_dn_carts_jnp = jnp.array(r_dn_carts, dtype=dtype_jnp)
 
     grad_J_up = jnp.zeros_like(r_up_carts_jnp)
     grad_J_dn = jnp.zeros_like(r_dn_carts_jnp)
-    lap_J_up = jnp.zeros((r_up_carts_jnp.shape[0],), dtype=dtype)
-    lap_J_dn = jnp.zeros((r_dn_carts_jnp.shape[0],), dtype=dtype)
+    lap_J_up = jnp.zeros((r_up_carts_jnp.shape[0],), dtype=dtype_jnp)
+    lap_J_dn = jnp.zeros((r_dn_carts_jnp.shape[0],), dtype=dtype_jnp)
 
     # one-body
     if jastrow_data.jastrow_one_body_data is not None:
@@ -2985,12 +3024,12 @@ def _compute_grads_and_laplacian_Jastrow_part_auto(
         if nn3.structure_data is None:
             raise ValueError("NN_Jastrow_data.structure_data must be set to evaluate NN J3.")
 
-        R_n = jnp.asarray(nn3.structure_data.positions, dtype=dtype)
-        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype)
+        R_n = nn3.structure_data._positions_cart_jnp.astype(dtype_jnp)
+        Z_n = jnp.asarray(nn3.structure_data.atomic_numbers, dtype=dtype_jnp)
 
         def _compute_Jastrow_nn_only(r_up, r_dn):
             nn_params = jax.tree_util.tree_map(
-                lambda x: x.astype(dtype) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
+                lambda x: x.astype(dtype_jnp) if hasattr(x, "dtype") and x.dtype.kind == "f" else x, nn3.params
             )
             return nn3.nn_def.apply({"params": nn_params}, r_up, r_dn, R_n, Z_n)
 
@@ -3026,8 +3065,7 @@ def _compute_grads_and_laplacian_Jastrow_part_debug(
     Uses central finite differences to approximate gradients and the
     sum of Laplacians of J at (r_up_carts, r_dn_carts).
     """
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_grad_lap")
     diff_h = 1.0e-5
 
     r_up_carts = np.array(r_up_carts, dtype=dtype_np)
@@ -3198,9 +3236,9 @@ def _compute_grads_and_laplacian_Jastrow_two_body_auto(
     #        jastrow_two_body_data, r_up_carts, r_dn_carts
     #    )
     # )
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.array(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    r_up_carts = jnp.array(r_up_carts, dtype=dtype_jnp)
+    r_dn_carts = jnp.array(r_dn_carts, dtype=dtype_jnp)
 
     # compute grad
     grad_J2_up = grad(compute_Jastrow_two_body, argnums=1)(jastrow_two_body_data, r_up_carts, r_dn_carts)
@@ -3238,20 +3276,20 @@ def compute_grads_and_laplacian_Jastrow_two_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    dtype = get_dtype("kinetic")
-    a = jastrow_two_body_data.jastrow_2b_param
-    eps = EPS_safe_distance
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
+    a = jnp.asarray(jastrow_two_body_data.jastrow_2b_param, dtype=dtype_jnp)
+    eps = jnp.asarray(EPS_safe_distance, dtype=dtype_jnp)
 
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
 
     num_up = r_up.shape[0]
     num_dn = r_dn.shape[0]
 
     grad_up = jnp.zeros_like(r_up)
     grad_dn = jnp.zeros_like(r_dn)
-    lap_up = jnp.zeros((num_up,), dtype=dtype)
-    lap_dn = jnp.zeros((num_dn,), dtype=dtype)
+    lap_up = jnp.zeros((num_up,), dtype=dtype_jnp)
+    lap_dn = jnp.zeros((num_dn,), dtype=dtype_jnp)
 
     j2b_type = jastrow_two_body_data.jastrow_2b_type
 
@@ -3327,8 +3365,7 @@ def _compute_grads_and_laplacian_Jastrow_two_body_debug(
     np.ndarray,
 ]:
     """See _api method."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_grad_lap")
     diff_h = 1.0e-5
 
     # grad up
@@ -3594,20 +3631,29 @@ def _compute_grads_and_laplacian_Jastrow_three_body_auto(
     Returns:
         the gradients(x,y,z) of J(threebody) and the sum of laplacians of J(threebody) at (r_up_carts, r_dn_carts).
     """
-    dtype = get_dtype("kinetic")
-    r_up_carts = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(r_dn_carts, dtype=dtype)
+    # Forward r_up/dn_carts as-is (Principle 3a — no parameter rebind). Cast to
+    # the jastrow_grad_lap zone at the use site (Principle 3b) before passing as
+    # the differentiation operand to grad/hessian.
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
 
     # compute grad
-    grad_J3_up = grad(compute_Jastrow_three_body, argnums=1)(jastrow_three_body_data, r_up_carts, r_dn_carts)
+    grad_J3_up = grad(compute_Jastrow_three_body, argnums=1)(
+        jastrow_three_body_data, r_up_carts.astype(dtype_jnp), r_dn_carts.astype(dtype_jnp)
+    )
 
-    grad_J3_dn = grad(compute_Jastrow_three_body, argnums=2)(jastrow_three_body_data, r_up_carts, r_dn_carts)
+    grad_J3_dn = grad(compute_Jastrow_three_body, argnums=2)(
+        jastrow_three_body_data, r_up_carts.astype(dtype_jnp), r_dn_carts.astype(dtype_jnp)
+    )
 
     # compute laplacians
-    hessian_J3_up = hessian(compute_Jastrow_three_body, argnums=1)(jastrow_three_body_data, r_up_carts, r_dn_carts)
+    hessian_J3_up = hessian(compute_Jastrow_three_body, argnums=1)(
+        jastrow_three_body_data, r_up_carts.astype(dtype_jnp), r_dn_carts.astype(dtype_jnp)
+    )
     laplacian_J3_up = jnp.einsum("ijij->i", hessian_J3_up)
 
-    hessian_J3_dn = hessian(compute_Jastrow_three_body, argnums=2)(jastrow_three_body_data, r_up_carts, r_dn_carts)
+    hessian_J3_dn = hessian(compute_Jastrow_three_body, argnums=2)(
+        jastrow_three_body_data, r_up_carts.astype(dtype_jnp), r_dn_carts.astype(dtype_jnp)
+    )
     laplacian_J3_dn = jnp.einsum("ijij->i", hessian_J3_dn)
 
     return grad_J3_up, grad_J3_dn, laplacian_J3_up, laplacian_J3_dn
@@ -3635,7 +3681,7 @@ def compute_grads_and_laplacian_Jastrow_three_body(
             Gradients for up/down electrons with shapes ``(N_up, 3)`` and ``(N_dn, 3)``,
             Laplacians for up/down electrons with shapes ``(N_up,)`` and ``(N_dn,)``.
     """
-    dtype = get_dtype("kinetic")
+    dtype_jnp = get_dtype_jnp("jastrow_grad_lap")
     orb_data = jastrow_three_body_data.orb_data
 
     if isinstance(orb_data, MOs_data):
@@ -3649,46 +3695,46 @@ def compute_grads_and_laplacian_Jastrow_three_body(
     else:
         raise NotImplementedError
 
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged to ``compute_orb`` / ``compute_orb_grad`` /
+    # ``compute_orb_lapl``; do not pre-cast (the AO/MO kernels reconstruct
+    # ``r - R`` in float64 internally).
+    aos_up = jnp.asarray(compute_orb(orb_data, r_up_carts), dtype=dtype_jnp)  # (n_orb, n_up)
+    aos_dn = jnp.asarray(compute_orb(orb_data, r_dn_carts), dtype=dtype_jnp)  # (n_orb, n_dn)
 
-    aos_up = jnp.asarray(compute_orb(orb_data, r_up), dtype=dtype)  # (n_orb, n_up)
-    aos_dn = jnp.asarray(compute_orb(orb_data, r_dn), dtype=dtype)  # (n_orb, n_dn)
-
-    grad_up_x, grad_up_y, grad_up_z = compute_orb_grad(orb_data, r_up)
-    grad_dn_x, grad_dn_y, grad_dn_z = compute_orb_grad(orb_data, r_dn)
+    grad_up_x, grad_up_y, grad_up_z = compute_orb_grad(orb_data, r_up_carts)
+    grad_dn_x, grad_dn_y, grad_dn_z = compute_orb_grad(orb_data, r_dn_carts)
 
     grad_up = jnp.stack([grad_up_x, grad_up_y, grad_up_z], axis=-1)  # (n_orb, n_up, 3)
     grad_dn = jnp.stack([grad_dn_x, grad_dn_y, grad_dn_z], axis=-1)  # (n_orb, n_dn, 3)
 
-    lap_up = jnp.asarray(compute_orb_lapl(orb_data, r_up), dtype=dtype)  # (n_orb, n_up)
-    lap_dn = jnp.asarray(compute_orb_lapl(orb_data, r_dn), dtype=dtype)  # (n_orb, n_dn)
+    lap_up = jnp.asarray(compute_orb_lapl(orb_data, r_up_carts), dtype=dtype_jnp)  # (n_orb, n_up)
+    lap_dn = jnp.asarray(compute_orb_lapl(orb_data, r_dn_carts), dtype=dtype_jnp)  # (n_orb, n_dn)
 
-    j1_vec = jnp.asarray(jastrow_three_body_data.j_matrix[:, -1], dtype=dtype)  # (n_orb,)
-    j3_mat = jnp.asarray(jastrow_three_body_data.j_matrix[:, :-1], dtype=dtype)  # (n_orb, n_orb)
+    j1_vec = jastrow_three_body_data._j_matrix_jnp[:, -1].astype(dtype_jnp)  # (n_orb,)
+    j3_mat = jastrow_three_body_data._j_matrix_jnp[:, :-1].astype(dtype_jnp)  # (n_orb, n_orb)
 
     num_up = aos_up.shape[1]
     num_dn = aos_dn.shape[1]
 
     # Precompute pair-accumulation masks
-    upper_up = jnp.triu(jnp.ones((num_up, num_up), dtype=dtype), k=1)
-    lower_up = jnp.tril(jnp.ones((num_up, num_up), dtype=dtype), k=-1)
-    upper_dn = jnp.triu(jnp.ones((num_dn, num_dn), dtype=dtype), k=1)
-    lower_dn = jnp.tril(jnp.ones((num_dn, num_dn), dtype=dtype), k=-1)
+    upper_up = jnp.triu(jnp.ones((num_up, num_up), dtype=dtype_jnp), k=1)
+    lower_up = jnp.tril(jnp.ones((num_up, num_up), dtype=dtype_jnp), k=-1)
+    upper_dn = jnp.triu(jnp.ones((num_dn, num_dn), dtype=dtype_jnp), k=1)
+    lower_dn = jnp.tril(jnp.ones((num_dn, num_dn), dtype=dtype_jnp), k=-1)
 
     # dJ/dA for each electron (orbital-space coefficients)
     g_up = (
         j1_vec[:, None]
         + jnp.dot(j3_mat, aos_up) @ lower_up
         + jnp.dot(j3_mat.T, aos_up) @ upper_up
-        + jnp.dot(j3_mat, aos_dn) @ jnp.ones((num_dn, 1), dtype=dtype)
+        + jnp.dot(j3_mat, aos_dn) @ jnp.ones((num_dn, 1), dtype=dtype_jnp)
     )  # (n_orb, n_up)
 
     g_dn = (
         j1_vec[:, None]
         + jnp.dot(j3_mat, aos_dn) @ lower_dn
         + jnp.dot(j3_mat.T, aos_dn) @ upper_dn
-        + jnp.dot(j3_mat.T, aos_up) @ jnp.ones((num_up, 1), dtype=dtype)
+        + jnp.dot(j3_mat.T, aos_up) @ jnp.ones((num_up, 1), dtype=dtype_jnp)
     )  # (n_orb, n_dn)
 
     grad_J3_up = jnp.einsum("on,onj->nj", g_up, grad_up)
@@ -3711,8 +3757,7 @@ def _compute_grads_and_laplacian_Jastrow_three_body_debug(
     np.ndarray,
 ]:
     """See _api method."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    dtype_np = get_dtype_np("jastrow_grad_lap")
     diff_h = 1.0e-5
 
     # grad up

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -244,10 +244,19 @@ def _cli():
         logger.info("")
 
     # --- precision configuration ---
-    precision_config = dict_toml.get("precision", {})
-    if not isinstance(precision_config, dict):
+    precision_section = dict_toml.get("precision", {})
+    if not isinstance(precision_section, dict):
         raise ValueError("The [precision] section must be a TOML table.")
-    configure_precision(precision_config)
+    precision_mode = precision_section.get("mode", "full")
+    extra_keys = set(precision_section.keys()) - {"mode"}
+    if extra_keys:
+        logger.warning(
+            "Per-zone precision overrides are no longer supported and will be "
+            "ignored: %s. Edit jqmc/_precision.py directly to change zone "
+            "assignments.",
+            sorted(extra_keys),
+        )
+    configure_precision(precision_mode)
     logger.info("")
 
     # default parameters

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -35,7 +35,7 @@
 # python modules
 import os
 import sys
-from logging import FileHandler, Formatter, StreamHandler, getLogger
+from logging import DEBUG, FileHandler, Formatter, StreamHandler, getLogger
 
 import jax
 import toml
@@ -48,6 +48,7 @@ from ._checkpoint import merge_rank_checkpoints
 
 # jQMC
 from ._header_footer import _print_footer, _print_header
+from ._jqmc_utility import num_sep_line
 from ._precision import configure as configure_precision
 from ._precision import mode_label as precision_mode_label
 from ._precision import zone_detail as precision_zone_detail
@@ -67,6 +68,25 @@ jax.config.update("jax_traceback_filtering", "off")
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
+
+
+def _log_precision_section() -> None:
+    """Log the active precision configuration as a labeled section.
+
+    Output format mirrors the ``hamiltonian_data`` info section: a title
+    line, top ``=`` separator, the summary at INFO level, the per-zone
+    detail at DEBUG level, and a bottom ``=`` separator.
+    """
+    logger.info("=" * num_sep_line)
+    logger.info("Printing out precision information.")
+    logger.info("=" * num_sep_line)
+    logger.info("Precision: %s", precision_mode_label())
+    if logger.isEnabledFor(DEBUG):
+        logger.debug("Zone detail:")
+        for line in precision_zone_detail().split("\n"):
+            logger.debug(line)
+    logger.info("=" * num_sep_line)
+    logger.info("")
 
 
 def _cli():
@@ -259,9 +279,6 @@ def _cli():
             sorted(extra_keys),
         )
     configure_precision(precision_mode)
-    logger.info("Precision: %s", precision_mode_label())
-    logger.debug("Precision zone detail:\n%s", precision_zone_detail())
-    logger.info("")
 
     # default parameters
     parameters = cli_parameters.copy()
@@ -337,6 +354,8 @@ def _cli():
                 comput_log_WF_param_deriv=parameter_derivatives,
                 use_swct=use_swct,
             )
+        _log_precision_section()
+        logger.info("=" * num_sep_line)
         logger.info("Printing out information in hamitonian_data instance.")
         mcmc.hamiltonian_data._logger_info()
         mcmc.run(num_mcmc_steps=num_mcmc_steps, max_time=max_time)
@@ -469,6 +488,8 @@ def _cli():
                 comput_log_WF_param_deriv=True,
                 comput_e_L_param_deriv=_need_eL_deriv,
             )
+        _log_precision_section()
+        logger.info("=" * num_sep_line)
         logger.info("Printing out information in hamitonian_data instance.")
         mcmc.hamiltonian_data._logger_info()
         mcmc.run_optimize(
@@ -580,6 +601,8 @@ def _cli():
                 epsilon_PW=epsilon_PW,
                 use_swct=use_swct,
             )
+        _log_precision_section()
+        logger.info("=" * num_sep_line)
         logger.info("Printing out information in hamitonian_data instance.")
         lrdmc.hamiltonian_data._logger_info()
         lrdmc.run(num_mcmc_steps=num_mcmc_steps, max_time=max_time)
@@ -682,6 +705,8 @@ def _cli():
                 epsilon_PW=epsilon_PW,
                 use_swct=use_swct,
             )
+        _log_precision_section()
+        logger.info("=" * num_sep_line)
         logger.info("Printing out information in hamitonian_data instance.")
         lrdmc.hamiltonian_data._logger_info()
         lrdmc.run(num_mcmc_steps=num_mcmc_steps, max_time=max_time)

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -48,6 +48,7 @@ from ._checkpoint import merge_rank_checkpoints
 
 # jQMC
 from ._header_footer import _print_footer, _print_header
+from ._precision import configure as configure_precision
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -241,6 +242,13 @@ def _cli():
         for key, item in dict_item.items():
             logger.info(f"  {key}={item}")
         logger.info("")
+
+    # --- precision configuration ---
+    precision_config = dict_toml.get("precision", {})
+    if not isinstance(precision_config, dict):
+        raise ValueError("The [precision] section must be a TOML table.")
+    configure_precision(precision_config)
+    logger.info("")
 
     # default parameters
     parameters = cli_parameters.copy()

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -49,6 +49,8 @@ from ._checkpoint import merge_rank_checkpoints
 # jQMC
 from ._header_footer import _print_footer, _print_header
 from ._precision import configure as configure_precision
+from ._precision import mode_label as precision_mode_label
+from ._precision import zone_detail as precision_zone_detail
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -257,6 +259,8 @@ def _cli():
             sorted(extra_keys),
         )
     configure_precision(precision_mode)
+    logger.info("Precision: %s", precision_mode_label())
+    logger.debug("Precision zone detail:\n%s", precision_zone_detail())
     logger.info("")
 
     # default parameters

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -1,4 +1,10 @@
-"""QMC module."""
+"""QMC module (GFMC).
+
+Precision Zones:
+    - ``gfmc``: all GFMC propagation functions.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -51,6 +57,7 @@ from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
 from ._jqmc_utility import _generate_init_electron_configurations
+from ._precision import get_dtype
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -58,7 +65,7 @@ from ._setting import (
     GFMC_ON_THE_FLY_BIN_BLOCKS,
     GFMC_ON_THE_FLY_COLLECT_STEPS,
     GFMC_ON_THE_FLY_WARMUP_STEPS,
-    EPS_rcond_SVD,
+    get_eps,
     rtol_debug_vs_production,
 )
 from .coulomb_potential import (
@@ -273,8 +280,9 @@ class GFMC_t:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("gfmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -311,22 +319,26 @@ class GFMC_t:
         n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
+        # gfmc zone dtype for stored numpy arrays
+        dtype = get_dtype("gfmc")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+
         # stored weight (w_L)
-        self.__stored_w_L = np.zeros((0, 1))
+        self.__stored_w_L = np.zeros((0, 1), dtype=dtype_np)
 
         # stored local energy (e_L)
-        self.__stored_e_L = np.zeros((0, 1))
+        self.__stored_e_L = np.zeros((0, 1), dtype=dtype_np)
 
         # stored local energy (e_L2)
-        self.__stored_e_L2 = np.zeros((0, 1))
+        self.__stored_e_L2 = np.zeros((0, 1), dtype=dtype_np)
 
         # average projection counter
-        self.__stored_average_projection_counter = np.zeros((0,))
+        self.__stored_average_projection_counter = np.zeros((0,), dtype=dtype_np)
 
         # stored force products (per-walker cross-correlation preserved)
-        self.__stored_force_HF = np.zeros((0, 1, n_atoms, 3))
-        self.__stored_force_PP = np.zeros((0, 1, n_atoms, 3))
-        self.__stored_E_L_force_PP = np.zeros((0, 1, n_atoms, 3))
+        self.__stored_force_HF = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
+        self.__stored_force_PP = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
+        self.__stored_E_L_force_PP = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
 
     def __validate_stored_shapes(self):
         """Assert that all stored observable arrays have consistent shapes."""
@@ -484,8 +496,9 @@ class GFMC_t:
         obj._GFMC_t__jax_PRNG_key_list_init = jnp.array(rng["jax_PRNG_key_list_init"])
 
         # -- Walker state --
-        obj._GFMC_t__latest_r_up_carts = jnp.array(ws["latest_r_up_carts"])
-        obj._GFMC_t__latest_r_dn_carts = jnp.array(ws["latest_r_dn_carts"])
+        dtype = get_dtype("gfmc")
+        obj._GFMC_t__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype)
+        obj._GFMC_t__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype)
 
         # -- Observables --
         def _load_obs(obs_arr, default):
@@ -660,6 +673,9 @@ class GFMC_t:
         np.random.seed(self.__mpi_seed)
 
         # precompute geminal inverses per walker for fast kinetic updates
+        dtype = get_dtype("gfmc")
+        eps_rcond = get_eps("rcond_svd", dtype)
+
         def _compute_initial_A_inv_t(r_up_carts, r_dn_carts):
             geminal = compute_geminal_all_elements(
                 geminal_data=self.__hamiltonian_data.wavefunction_data.geminal_data,
@@ -667,7 +683,7 @@ class GFMC_t:
                 r_dn_carts=r_dn_carts,
             )
             U, s, Vt = jnp.linalg.svd(geminal, full_matrices=False)
-            s_inv = jnp.where(s > EPS_rcond_SVD * s[0], 1.0 / s, 0.0)
+            s_inv = jnp.where(s > eps_rcond * s[0], 1.0 / s, 0.0)
             return (Vt.T * s_inv[jnp.newaxis, :]) @ U.T
 
         self.__latest_A_old_inv = vmap(_compute_initial_A_inv_t, in_axes=(0, 0))(
@@ -1089,8 +1105,8 @@ class GFMC_t:
         logger.info("Start compilation of the GFMC projection funciton.")
         logger.info("  Compilation is in progress...")
         projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-        tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)])
-        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+        tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
         (_, _, _, _, _, _, _, _, _) = vmap(_projection_t, in_axes=(0, 0, 0, 0, 0, 0, 0, None, None, None, None))(
             projection_counter_list,
             tau_left_list,
@@ -1335,7 +1351,7 @@ class GFMC_t:
             start_init_force = time.perf_counter()
             logger.info("Start compilation of force gradient functions.")
             logger.info("  Compilation is in progress...")
-            _dummy_RTs = jnp.stack([jnp.eye(3)] * self.__num_walkers)
+            _dummy_RTs = jnp.stack([jnp.eye(3, dtype=get_dtype("gfmc"))] * self.__num_walkers)
             _, _, _ = _jit_vmap_grad_e_L_t(
                 hamiltonian_for_position_grads,
                 self.__latest_r_up_carts,
@@ -1367,9 +1383,12 @@ class GFMC_t:
         num_mcmc_done = 0
 
         # -- Extend stored arrays with zero-padding for new steps --
+        # gfmc zone dtype for stored numpy arrays
+        dtype_gfmc = get_dtype("gfmc")
+        dtype_np = np.float64 if dtype_gfmc == jnp.float64 else np.float32
         # average_projection_counter is stored on all ranks
         self.__stored_average_projection_counter = np.concatenate(
-            [self.__stored_average_projection_counter, np.zeros((num_mcmc_steps,))]
+            [self.__stored_average_projection_counter, np.zeros((num_mcmc_steps,), dtype=dtype_np)]
         )
         # other observables are stored on rank 0 only
         if mpi_rank == 0:
@@ -1377,14 +1396,18 @@ class GFMC_t:
             n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
             n_atoms = self.__hamiltonian_data.structure_data.natom
 
-            self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, 1))])
-            self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, 1))])
-            self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, 1))])
+            self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
+            self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
+            self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
             if self.__comput_position_deriv:
-                self.__stored_force_HF = np.concatenate([self.__stored_force_HF, np.zeros((num_mcmc_steps, 1, n_atoms, 3))])
-                self.__stored_force_PP = np.concatenate([self.__stored_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3))])
+                self.__stored_force_HF = np.concatenate(
+                    [self.__stored_force_HF, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
+                )
+                self.__stored_force_PP = np.concatenate(
+                    [self.__stored_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
+                )
                 self.__stored_E_L_force_PP = np.concatenate(
-                    [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3))]
+                    [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
                 )
 
         for i_branching in range(num_mcmc_steps):
@@ -1397,8 +1420,8 @@ class GFMC_t:
 
             # Always set the initial weight list to 1.0
             projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-            tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)])
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+            tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
 
             start_projection = time.perf_counter()
             # projection loop
@@ -1681,6 +1704,9 @@ class GFMC_t:
             local_probabilities = w_L_latest / global_weight_sum
 
             # Compute the local cumulative probabilities.
+            # NOTE: MPI reductions for branching probabilities are kept float64
+            # unconditionally (regardless of the gfmc precision zone) to avoid
+            # population collapse from float32 round-off in the branching step.
             local_cumprob = np.cumsum(local_probabilities)
             local_sum_arr = np.array(np.sum(local_probabilities), dtype=np.float64)
             offset_arr = np.zeros(1, dtype=np.float64)
@@ -2637,8 +2663,9 @@ class _GFMC_t_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("gfmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -2993,7 +3020,7 @@ class _GFMC_t_debug:
             # Always set the initial weight list to 1.0
             projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
             e_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
 
             logger.devel("  Projection is on going....")
 
@@ -3036,7 +3063,7 @@ class _GFMC_t_debug:
 
                     # generate a random rotation matrix
                     jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
-                    R = jnp.eye(3)  # Rotate in the order x -> y -> z
+                    R = jnp.eye(3, dtype=get_dtype("gfmc"))  # Rotate in the order x -> y -> z
 
                     # compute discretized kinetic energy and mesh (with a random rotation)
                     mesh_kinetic_part_r_up_carts, mesh_kinetic_part_r_dn_carts, elements_non_diagonal_kinetic_part = (
@@ -3311,7 +3338,7 @@ class _GFMC_t_debug:
             # atomic force related
             if self.__comput_position_deriv:
                 # RT is always eye(3) in _GFMC_t_debug (no random_discretized_mesh)
-                RT_eye = jnp.eye(3)
+                RT_eye = jnp.eye(3, dtype=get_dtype("gfmc"))
 
                 _grad_e_L_fn = grad(_compute_local_energy_t_debug, argnums=(0, 1, 2))
                 _grad_e_L_results = [
@@ -3944,8 +3971,9 @@ class GFMC_n:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("gfmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -3982,19 +4010,23 @@ class GFMC_n:
         n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
+        # gfmc zone dtype for stored numpy arrays
+        dtype = get_dtype("gfmc")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+
         # stored weight (w_L)
-        self.__stored_w_L = np.zeros((0, 1))
+        self.__stored_w_L = np.zeros((0, 1), dtype=dtype_np)
 
         # stored local energy (e_L)
-        self.__stored_e_L = np.zeros((0, 1))
+        self.__stored_e_L = np.zeros((0, 1), dtype=dtype_np)
 
         # stored local energy (e_L2)
-        self.__stored_e_L2 = np.zeros((0, 1))
+        self.__stored_e_L2 = np.zeros((0, 1), dtype=dtype_np)
 
         # stored force products (per-walker cross-correlation preserved)
-        self.__stored_force_HF = np.zeros((0, 1, n_atoms, 3))
-        self.__stored_force_PP = np.zeros((0, 1, n_atoms, 3))
-        self.__stored_E_L_force_PP = np.zeros((0, 1, n_atoms, 3))
+        self.__stored_force_HF = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
+        self.__stored_force_PP = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
+        self.__stored_E_L_force_PP = np.zeros((0, 1, n_atoms, 3), dtype=dtype_np)
 
         # stored G_L and G_e_L for updating the E_scf (kept as lists — variable count per run)
         self.__G_L = []
@@ -4157,8 +4189,9 @@ class GFMC_n:
         obj._GFMC_n__jax_PRNG_key_list_init = jnp.array(rng["jax_PRNG_key_list_init"])
 
         # -- Walker state --
-        obj._GFMC_n__latest_r_up_carts = jnp.array(ws["latest_r_up_carts"])
-        obj._GFMC_n__latest_r_dn_carts = jnp.array(ws["latest_r_dn_carts"])
+        dtype = get_dtype("gfmc")
+        obj._GFMC_n__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype)
+        obj._GFMC_n__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype)
 
         # -- Observables --
         n_up = obj._GFMC_n__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
@@ -4339,6 +4372,9 @@ class GFMC_n:
         gfmc_total_start = time.perf_counter()
 
         # precompute geminal inverses per walker for fast updates across projections
+        dtype = get_dtype("gfmc")
+        eps_rcond = get_eps("rcond_svd", dtype)
+
         def _compute_initial_A_inv_n(r_up_carts, r_dn_carts):
             geminal = compute_geminal_all_elements(
                 geminal_data=self.__hamiltonian_data.wavefunction_data.geminal_data,
@@ -4346,7 +4382,7 @@ class GFMC_n:
                 r_dn_carts=r_dn_carts,
             )
             U, s, Vt = jnp.linalg.svd(geminal, full_matrices=False)
-            s_inv = jnp.where(s > EPS_rcond_SVD * s[0], 1.0 / s, 0.0)
+            s_inv = jnp.where(s > eps_rcond * s[0], 1.0 / s, 0.0)
             return (Vt.T * s_inv[jnp.newaxis, :]) @ U.T
 
         _jit_vmap_A_inv_n = jit(vmap(_compute_initial_A_inv_n, in_axes=(0, 0)))
@@ -4799,10 +4835,10 @@ class GFMC_n:
                     init_w_L,
                     init_r_up_carts,
                     init_r_dn_carts,
-                    jnp.eye(3),
+                    jnp.eye(3, dtype=get_dtype("gfmc")),
                     init_A_old_inv,
-                    jnp.asarray(0.0),
-                    jnp.asarray(0.0),
+                    jnp.asarray(0.0, dtype=get_dtype("gfmc")),
+                    jnp.asarray(0.0, dtype=get_dtype("gfmc")),
                 ),
             )
 
@@ -4843,13 +4879,14 @@ class GFMC_n:
 
             if use_fast_update:
                 # precompute geminal inverse for fast updates (SVD-based, robust for near-singular G)
+                _eps_rcond = get_eps("rcond_svd", get_dtype("gfmc"))
                 geminal = compute_geminal_all_elements(
                     geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
                     r_up_carts=r_up_carts,
                     r_dn_carts=r_dn_carts,
                 )
                 _U, _s, _Vt = jnp.linalg.svd(geminal, full_matrices=False)
-                _s_inv = jnp.where(_s > EPS_rcond_SVD * _s[0], 1.0 / _s, 0.0)
+                _s_inv = jnp.where(_s > _eps_rcond * _s[0], 1.0 / _s, 0.0)
                 A_old_inv = (_Vt.T * _s_inv[jnp.newaxis, :]) @ _U.T
 
                 # compute discretized kinetic energy and mesh (with a random rotation)
@@ -5133,7 +5170,7 @@ class GFMC_n:
         start_init = time.perf_counter()
         logger.info("Start compilation of the GFMC projection funciton.")
         logger.info("  Compilation is in progress...")
-        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
         (
             _,
             _,
@@ -5199,14 +5236,22 @@ class GFMC_n:
             n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
             n_atoms = self.__hamiltonian_data.structure_data.natom
 
-            self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, 1))])
-            self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, 1))])
-            self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, 1))])
+            # gfmc zone dtype for stored numpy arrays
+            dtype_gfmc = get_dtype("gfmc")
+            dtype_np = np.float64 if dtype_gfmc == jnp.float64 else np.float32
+
+            self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
+            self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
+            self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
             if self.__comput_position_deriv:
-                self.__stored_force_HF = np.concatenate([self.__stored_force_HF, np.zeros((num_mcmc_steps, 1, n_atoms, 3))])
-                self.__stored_force_PP = np.concatenate([self.__stored_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3))])
+                self.__stored_force_HF = np.concatenate(
+                    [self.__stored_force_HF, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
+                )
+                self.__stored_force_PP = np.concatenate(
+                    [self.__stored_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
+                )
                 self.__stored_E_L_force_PP = np.concatenate(
-                    [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3))]
+                    [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, 1, n_atoms, 3), dtype=dtype_np)]
                 )
 
         progress = (self.__mcmc_counter) / (num_mcmc_steps + self.__mcmc_counter) * 100.0
@@ -5225,7 +5270,7 @@ class GFMC_n:
                 )
 
             # Always set the initial weight list to 1.0
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
 
             start_projection = time.perf_counter()
 
@@ -5526,6 +5571,9 @@ class GFMC_n:
             local_probabilities = w_L_latest / global_weight_sum
 
             # Compute the local cumulative probabilities.
+            # NOTE: MPI reductions for branching probabilities are kept float64
+            # unconditionally (regardless of the gfmc precision zone) to avoid
+            # population collapse from float32 round-off in the branching step.
             local_cumprob = np.cumsum(local_probabilities)
             local_sum_arr = np.array(np.sum(local_probabilities), dtype=np.float64)
             offset_arr = np.zeros(1, dtype=np.float64)
@@ -6542,8 +6590,9 @@ class _GFMC_n_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("gfmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -7241,7 +7290,7 @@ class _GFMC_n_debug:
                 )
 
             # Always set the initial weight list to 1.0
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
 
             logger.devel("  Projection is on going....")
 

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -57,7 +57,7 @@ from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
 from ._jqmc_utility import _generate_init_electron_configurations
-from ._precision import get_dtype, get_tolerance_min
+from ._precision import get_tolerance_min
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -279,9 +279,9 @@ class GFMC_t:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("gfmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -319,8 +319,7 @@ class GFMC_t:
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
         # gfmc zone dtype for stored numpy arrays
-        dtype = get_dtype("gfmc")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = np.float64
 
         # stored weight (w_L)
         self.__stored_w_L = np.zeros((0, 1), dtype=dtype_np)
@@ -495,9 +494,9 @@ class GFMC_t:
         obj._GFMC_t__jax_PRNG_key_list_init = jnp.array(rng["jax_PRNG_key_list_init"])
 
         # -- Walker state --
-        dtype = get_dtype("gfmc")
-        obj._GFMC_t__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype)
-        obj._GFMC_t__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype)
+        dtype_jnp = jnp.float64
+        obj._GFMC_t__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype_jnp)
+        obj._GFMC_t__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype_jnp)
 
         # -- Observables --
         def _load_obs(obs_arr, default):
@@ -672,8 +671,8 @@ class GFMC_t:
         np.random.seed(self.__mpi_seed)
 
         # precompute geminal inverses per walker for fast kinetic updates
-        dtype = get_dtype("gfmc")
-        eps_rcond = get_eps("rcond_svd", dtype)
+        dtype_jnp = jnp.float64
+        eps_rcond = get_eps("rcond_svd", dtype_jnp)
 
         def _compute_initial_A_inv_t(r_up_carts, r_dn_carts):
             geminal = compute_geminal_all_elements(
@@ -704,7 +703,7 @@ class GFMC_t:
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
                 ],
-                dtype=get_dtype("gfmc"),
+                dtype=jnp.float64,
             )
             return R
 
@@ -1050,10 +1049,11 @@ class GFMC_t:
                 Ainv_u = A_old_inv @ u
                 vT_Ainv = v.T @ A_old_inv
                 det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                # Cast back to A_old_inv.dtype: geminal elements live in the fp64
-                # geminal zone, so the update would otherwise promote A_new_inv to
-                # fp64 and break the lax.cond dtype agreement with _no_update_t.
-                return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
+                # Consumer-zone explicit cast: cast the rank-1 update to the
+                # local gfmc zone dtype so the result agrees with the
+                # _no_update_t lax.cond branch and never depends on
+                # A_old_inv's upstream dtype.
+                return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=jnp.float64)
 
             def _no_update_t(_):
                 return A_old_inv
@@ -1079,8 +1079,8 @@ class GFMC_t:
                     Ainv_u = A_old_inv @ u
                     vT_Ainv = v.T @ A_old_inv
                     det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                    # See note in _update_inv_up_t: cast back to A_old_inv.dtype.
-                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
+                    # See note in _update_inv_up_t: consumer-zone explicit cast.
+                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=jnp.float64)
 
             if num_up_electrons == 0:
                 A_new_inv = A_old_inv
@@ -1109,8 +1109,8 @@ class GFMC_t:
         logger.info("Start compilation of the GFMC projection funciton.")
         logger.info("  Compilation is in progress...")
         projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-        tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
-        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+        tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=jnp.float64)
+        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
         (_, _, _, _, _, _, _, _, _) = vmap(_projection_t, in_axes=(0, 0, 0, 0, 0, 0, 0, None, None, None, None))(
             projection_counter_list,
             tau_left_list,
@@ -1355,7 +1355,7 @@ class GFMC_t:
             start_init_force = time.perf_counter()
             logger.info("Start compilation of force gradient functions.")
             logger.info("  Compilation is in progress...")
-            _dummy_RTs = jnp.stack([jnp.eye(3, dtype=get_dtype("gfmc"))] * self.__num_walkers)
+            _dummy_RTs = jnp.stack([jnp.eye(3, dtype=jnp.float64)] * self.__num_walkers)
             _, _, _ = _jit_vmap_grad_e_L_t(
                 hamiltonian_for_position_grads,
                 self.__latest_r_up_carts,
@@ -1388,8 +1388,7 @@ class GFMC_t:
 
         # -- Extend stored arrays with zero-padding for new steps --
         # gfmc zone dtype for stored numpy arrays
-        dtype_gfmc = get_dtype("gfmc")
-        dtype_np = np.float64 if dtype_gfmc == jnp.float64 else np.float32
+        dtype_np = np.float64
         # average_projection_counter is stored on all ranks
         self.__stored_average_projection_counter = np.concatenate(
             [self.__stored_average_projection_counter, np.zeros((num_mcmc_steps,), dtype=dtype_np)]
@@ -1424,8 +1423,8 @@ class GFMC_t:
 
             # Always set the initial weight list to 1.0
             projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-            tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+            tau_left_list = jnp.array([self.__tau for _ in range(self.__num_walkers)], dtype=jnp.float64)
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
 
             start_projection = time.perf_counter()
             # projection loop
@@ -1551,10 +1550,10 @@ class GFMC_t:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=jnp.float64)
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=jnp.float64)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
 
             end_observable = time.perf_counter()
             timer_observable += end_observable - start_observable
@@ -1946,8 +1945,8 @@ class GFMC_t:
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
             self.__stored_average_projection_counter[self.__mcmc_counter + num_mcmc_done] = ave_projection_counter
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=jnp.float64)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=jnp.float64)
             self.__latest_A_old_inv = vmap(_compute_initial_A_inv_t, in_axes=(0, 0))(
                 self.__latest_r_up_carts, self.__latest_r_dn_carts
             )
@@ -2667,9 +2666,9 @@ class _GFMC_t_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("gfmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -3023,8 +3022,8 @@ class _GFMC_t_debug:
 
             # Always set the initial weight list to 1.0
             projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-            e_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+            e_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
 
             logger.devel("  Projection is on going....")
 
@@ -3067,7 +3066,7 @@ class _GFMC_t_debug:
 
                     # generate a random rotation matrix
                     jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
-                    R = jnp.eye(3, dtype=get_dtype("gfmc"))  # Rotate in the order x -> y -> z
+                    R = jnp.eye(3, dtype=jnp.float64)  # Rotate in the order x -> y -> z
 
                     # compute discretized kinetic energy and mesh (with a random rotation)
                     mesh_kinetic_part_r_up_carts, mesh_kinetic_part_r_dn_carts, elements_non_diagonal_kinetic_part = (
@@ -3331,10 +3330,10 @@ class _GFMC_t_debug:
 
             # projection ends
             projection_counter_list = jnp.array(projection_counter_list)
-            e_L_list = jnp.asarray(e_L_list, dtype=get_dtype("gfmc"))
-            w_L_list = jnp.asarray(w_L_list, dtype=get_dtype("gfmc"))
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=get_dtype("gfmc"))
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=get_dtype("gfmc"))
+            e_L_list = jnp.asarray(e_L_list, dtype=jnp.float64)
+            w_L_list = jnp.asarray(w_L_list, dtype=jnp.float64)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=jnp.float64)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=jnp.float64)
             self.__jax_PRNG_key_list = jnp.array(jax_PRNG_key_list)
 
             logger.debug("  Projection ends.")
@@ -3342,7 +3341,7 @@ class _GFMC_t_debug:
             # atomic force related
             if self.__comput_position_deriv:
                 # RT is always eye(3) in _GFMC_t_debug (no random_discretized_mesh)
-                RT_eye = jnp.eye(3, dtype=get_dtype("gfmc"))
+                RT_eye = jnp.eye(3, dtype=jnp.float64)
 
                 _grad_e_L_fn = grad(_compute_local_energy_t_debug, argnums=(0, 1, 2))
                 _grad_e_L_results = [
@@ -3433,10 +3432,10 @@ class _GFMC_t_debug:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=jnp.float64)
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=jnp.float64)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
 
             # jnp.array -> np.array
             w_L_latest = np.array(w_L_list)
@@ -3631,8 +3630,8 @@ class _GFMC_t_debug:
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
             self.__stored_average_projection_counter.append(ave_projection_counter)
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=jnp.float64)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=jnp.float64)
 
             # count up, here is the end of the branching step.
             num_mcmc_done += 1
@@ -3975,9 +3974,9 @@ class GFMC_n:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("gfmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -4015,8 +4014,7 @@ class GFMC_n:
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
         # gfmc zone dtype for stored numpy arrays
-        dtype = get_dtype("gfmc")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = np.float64
 
         # stored weight (w_L)
         self.__stored_w_L = np.zeros((0, 1), dtype=dtype_np)
@@ -4193,9 +4191,9 @@ class GFMC_n:
         obj._GFMC_n__jax_PRNG_key_list_init = jnp.array(rng["jax_PRNG_key_list_init"])
 
         # -- Walker state --
-        dtype = get_dtype("gfmc")
-        obj._GFMC_n__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype)
-        obj._GFMC_n__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype)
+        dtype_jnp = jnp.float64
+        obj._GFMC_n__latest_r_up_carts = jnp.asarray(ws["latest_r_up_carts"], dtype=dtype_jnp)
+        obj._GFMC_n__latest_r_dn_carts = jnp.asarray(ws["latest_r_dn_carts"], dtype=dtype_jnp)
 
         # -- Observables --
         n_up = obj._GFMC_n__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
@@ -4376,8 +4374,8 @@ class GFMC_n:
         gfmc_total_start = time.perf_counter()
 
         # precompute geminal inverses per walker for fast updates across projections
-        dtype = get_dtype("gfmc")
-        eps_rcond = get_eps("rcond_svd", dtype)
+        dtype_jnp = jnp.float64
+        eps_rcond = get_eps("rcond_svd", dtype_jnp)
 
         def _compute_initial_A_inv_n(r_up_carts, r_dn_carts):
             geminal = compute_geminal_all_elements(
@@ -4407,7 +4405,7 @@ class GFMC_n:
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
                 ],
-                dtype=get_dtype("gfmc"),
+                dtype=jnp.float64,
             )
             return R
 
@@ -4762,10 +4760,11 @@ class GFMC_n:
                     Ainv_u = A_old_inv @ u
                     vT_Ainv = v.T @ A_old_inv
                     det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                    # Cast back to A_old_inv.dtype: geminal elements live in the fp64
-                    # geminal zone, so the update would otherwise promote A_new_inv to
-                    # fp64 and break the lax.cond dtype agreement with _no_update_n.
-                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
+                    # Consumer-zone explicit cast: cast the rank-1 update to the
+                    # local gfmc zone dtype so the result agrees with the
+                    # _no_update_n lax.cond branch and never depends on
+                    # A_old_inv's upstream dtype.
+                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=jnp.float64)
 
                 def _no_update_n(_):
                     return A_old_inv
@@ -4791,8 +4790,8 @@ class GFMC_n:
                         Ainv_u = A_old_inv @ u
                         vT_Ainv = v.T @ A_old_inv
                         det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                        # See note in _update_inv_up_n: cast back to A_old_inv.dtype.
-                        return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
+                        # See note in _update_inv_up_n: consumer-zone explicit cast.
+                        return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=jnp.float64)
 
                 if num_up_electrons == 0:
                     A_new_inv = A_old_inv
@@ -4844,10 +4843,10 @@ class GFMC_n:
                     init_w_L,
                     init_r_up_carts,
                     init_r_dn_carts,
-                    jnp.eye(3, dtype=get_dtype("gfmc")),
+                    jnp.eye(3, dtype=jnp.float64),
                     init_A_old_inv,
-                    jnp.asarray(0.0, dtype=get_dtype("gfmc")),
-                    jnp.asarray(0.0, dtype=get_dtype("gfmc")),
+                    jnp.asarray(0.0, dtype=jnp.float64),
+                    jnp.asarray(0.0, dtype=jnp.float64),
                 ),
             )
 
@@ -4888,7 +4887,7 @@ class GFMC_n:
 
             if use_fast_update:
                 # precompute geminal inverse for fast updates (SVD-based, robust for near-singular G)
-                _eps_rcond = get_eps("rcond_svd", get_dtype("gfmc"))
+                _eps_rcond = get_eps("rcond_svd", jnp.float64)
                 geminal = compute_geminal_all_elements(
                     geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
                     r_up_carts=r_up_carts,
@@ -5179,7 +5178,7 @@ class GFMC_n:
         start_init = time.perf_counter()
         logger.info("Start compilation of the GFMC projection funciton.")
         logger.info("  Compilation is in progress...")
-        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+        w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
         (
             _,
             _,
@@ -5246,8 +5245,7 @@ class GFMC_n:
             n_atoms = self.__hamiltonian_data.structure_data.natom
 
             # gfmc zone dtype for stored numpy arrays
-            dtype_gfmc = get_dtype("gfmc")
-            dtype_np = np.float64 if dtype_gfmc == jnp.float64 else np.float32
+            dtype_np = np.float64
 
             self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
             self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, 1), dtype=dtype_np)])
@@ -5279,7 +5277,7 @@ class GFMC_n:
                 )
 
             # Always set the initial weight list to 1.0
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
 
             start_projection = time.perf_counter()
 
@@ -5425,10 +5423,10 @@ class GFMC_n:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=jnp.float64)
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=jnp.float64)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
 
             # Barrier before MPI operation
             start_mpi_barrier = time.perf_counter()
@@ -5813,8 +5811,8 @@ class GFMC_n:
             # here update the walker positions!!
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=jnp.float64)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=jnp.float64)
             self.__latest_A_old_inv = _jit_vmap_A_inv_n(self.__latest_r_up_carts, self.__latest_r_dn_carts)
 
             mpi_comm.Barrier()
@@ -6599,9 +6597,9 @@ class _GFMC_n_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("gfmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -6742,7 +6740,7 @@ class _GFMC_n_debug:
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
                 ],
-                dtype=get_dtype("gfmc"),
+                dtype=jnp.float64,
             )
             return R
 
@@ -7300,7 +7298,7 @@ class _GFMC_n_debug:
                 )
 
             # Always set the initial weight list to 1.0
-            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
+            w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=jnp.float64)
 
             logger.devel("  Projection is on going....")
 
@@ -7357,10 +7355,11 @@ class _GFMC_n_debug:
                         for i in range(self.__num_walkers)
                     ]
                 )
-                # e_L crosses orb_eval/jastrow/geminal/coulomb/kinetic/gfmc; bound
-                # the agreement by the weakest zone (fp32 in mixed precision).
+                # e_L crosses ao_eval/jastrow_eval/det_eval/coulomb/
+                # local_energy; bound the agreement by the weakest zone (fp32 in
+                # mixed precision).
                 _atol_eL, _rtol_eL = get_tolerance_min(
-                    ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+                    ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "local_energy"),
                     "strict",
                 )
                 if np.max(np.abs(e_L_list - e_list_debug)) > _rtol_eL:
@@ -7461,10 +7460,10 @@ class _GFMC_n_debug:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=jnp.float64)
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=jnp.float64)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=jnp.float64)
 
             # jnp.array -> np.array
             w_L_latest = np.array(w_L_list)
@@ -7669,8 +7668,8 @@ class _GFMC_n_debug:
             # here update the walker positions!!
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=jnp.float64)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=jnp.float64)
 
             # update E_scf
             eq_steps = GFMC_ON_THE_FLY_WARMUP_STEPS
@@ -7707,8 +7706,8 @@ class _GFMC_n_debug:
             # logger.info(f"  (w_L_eq) = {(w_L_eq)}")
             logger.devel("  Progress: Computing G_eq and G_e_L_eq.")
 
-            w_L_eq = jnp.asarray(w_L_eq, dtype=get_dtype("gfmc"))
-            e_L_eq = jnp.asarray(e_L_eq, dtype=get_dtype("gfmc"))
+            w_L_eq = jnp.asarray(w_L_eq, dtype=jnp.float64)
+            e_L_eq = jnp.asarray(e_L_eq, dtype=jnp.float64)
             G_eq = _compute_G_L_debug(w_L_eq, num_gfmc_collect_steps)
             G_e_L_eq = e_L_eq * G_eq
             G_eq = np.array(G_eq)

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -57,7 +57,7 @@ from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
 from ._jqmc_utility import _generate_init_electron_configurations
-from ._precision import get_dtype
+from ._precision import get_dtype, get_tolerance_min
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -66,7 +66,6 @@ from ._setting import (
     GFMC_ON_THE_FLY_COLLECT_STEPS,
     GFMC_ON_THE_FLY_WARMUP_STEPS,
     get_eps,
-    rtol_debug_vs_production,
 )
 from .coulomb_potential import (
     compute_bare_coulomb_potential_el_el,
@@ -1051,7 +1050,10 @@ class GFMC_t:
                 Ainv_u = A_old_inv @ u
                 vT_Ainv = v.T @ A_old_inv
                 det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                return A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio
+                # Cast back to A_old_inv.dtype: geminal elements live in the fp64
+                # geminal zone, so the update would otherwise promote A_new_inv to
+                # fp64 and break the lax.cond dtype agreement with _no_update_t.
+                return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
 
             def _no_update_t(_):
                 return A_old_inv
@@ -1077,7 +1079,8 @@ class GFMC_t:
                     Ainv_u = A_old_inv @ u
                     vT_Ainv = v.T @ A_old_inv
                     det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                    return A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio
+                    # See note in _update_inv_up_t: cast back to A_old_inv.dtype.
+                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
 
             if num_up_electrons == 0:
                 A_new_inv = A_old_inv
@@ -4759,7 +4762,10 @@ class GFMC_n:
                     Ainv_u = A_old_inv @ u
                     vT_Ainv = v.T @ A_old_inv
                     det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                    return A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio
+                    # Cast back to A_old_inv.dtype: geminal elements live in the fp64
+                    # geminal zone, so the update would otherwise promote A_new_inv to
+                    # fp64 and break the lax.cond dtype agreement with _no_update_n.
+                    return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
 
                 def _no_update_n(_):
                     return A_old_inv
@@ -4785,7 +4791,8 @@ class GFMC_n:
                         Ainv_u = A_old_inv @ u
                         vT_Ainv = v.T @ A_old_inv
                         det_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]
-                        return A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio
+                        # See note in _update_inv_up_n: cast back to A_old_inv.dtype.
+                        return jnp.asarray(A_old_inv - (Ainv_u @ vT_Ainv) / det_ratio, dtype=A_old_inv.dtype)
 
                 if num_up_electrons == 0:
                     A_new_inv = A_old_inv
@@ -7350,12 +7357,18 @@ class _GFMC_n_debug:
                         for i in range(self.__num_walkers)
                     ]
                 )
-                if np.max(np.abs(e_L_list - e_list_debug)) > rtol_debug_vs_production:
+                # e_L crosses orb_eval/jastrow/geminal/coulomb/kinetic/gfmc; bound
+                # the agreement by the weakest zone (fp32 in mixed precision).
+                _atol_eL, _rtol_eL = get_tolerance_min(
+                    ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+                    "strict",
+                )
+                if np.max(np.abs(e_L_list - e_list_debug)) > _rtol_eL:
                     logger.info(f"max(e_list - e_list_debug) = {np.max(np.abs(e_L_list - e_list_debug))}.")
                     logger.info(f"w_L_list = {w_L_list}.")
                     logger.info(f"e_L_list = {e_L_list}.")
                     logger.info(f"e_list_debug = {e_list_debug}.")
-                np.testing.assert_almost_equal(np.array(e_L_list), np.array(e_list_debug), decimal=6)
+                np.testing.assert_allclose(np.array(e_L_list), np.array(e_list_debug), atol=_atol_eL, rtol=_rtol_eL)
 
             # atomic force related
             if self.__comput_position_deriv:

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -704,7 +704,8 @@ class GFMC_t:
                     [cos_b * cos_g, cos_g * sin_a * sin_b - cos_a * sin_g, sin_a * sin_g + cos_a * cos_g * sin_b],
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
-                ]
+                ],
+                dtype=get_dtype("gfmc"),
             )
             return R
 
@@ -1547,10 +1548,10 @@ class GFMC_t:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
 
             end_observable = time.perf_counter()
             timer_observable += end_observable - start_observable
@@ -1942,8 +1943,8 @@ class GFMC_t:
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
             self.__stored_average_projection_counter[self.__mcmc_counter + num_mcmc_done] = ave_projection_counter
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts_after_branching)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts_after_branching)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
             self.__latest_A_old_inv = vmap(_compute_initial_A_inv_t, in_axes=(0, 0))(
                 self.__latest_r_up_carts, self.__latest_r_dn_carts
             )
@@ -3019,7 +3020,7 @@ class _GFMC_t_debug:
 
             # Always set the initial weight list to 1.0
             projection_counter_list = jnp.array([0 for _ in range(self.__num_walkers)])
-            e_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)])
+            e_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
             w_L_list = jnp.array([1.0 for _ in range(self.__num_walkers)], dtype=get_dtype("gfmc"))
 
             logger.devel("  Projection is on going....")
@@ -3327,10 +3328,10 @@ class _GFMC_t_debug:
 
             # projection ends
             projection_counter_list = jnp.array(projection_counter_list)
-            e_L_list = jnp.array(e_L_list)
-            w_L_list = jnp.array(w_L_list)
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts)
+            e_L_list = jnp.asarray(e_L_list, dtype=get_dtype("gfmc"))
+            w_L_list = jnp.asarray(w_L_list, dtype=get_dtype("gfmc"))
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=get_dtype("gfmc"))
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=get_dtype("gfmc"))
             self.__jax_PRNG_key_list = jnp.array(jax_PRNG_key_list)
 
             logger.debug("  Projection ends.")
@@ -3429,10 +3430,10 @@ class _GFMC_t_debug:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
 
             # jnp.array -> np.array
             w_L_latest = np.array(w_L_list)
@@ -3627,8 +3628,8 @@ class _GFMC_t_debug:
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
             self.__stored_average_projection_counter.append(ave_projection_counter)
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts_after_branching)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts_after_branching)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
 
             # count up, here is the end of the branching step.
             num_mcmc_done += 1
@@ -4402,7 +4403,8 @@ class GFMC_n:
                     [cos_b * cos_g, cos_g * sin_a * sin_b - cos_a * sin_g, sin_a * sin_g + cos_a * cos_g * sin_b],
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
-                ]
+                ],
+                dtype=get_dtype("gfmc"),
             )
             return R
 
@@ -5416,10 +5418,10 @@ class GFMC_n:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
 
             # Barrier before MPI operation
             start_mpi_barrier = time.perf_counter()
@@ -5804,8 +5806,8 @@ class GFMC_n:
             # here update the walker positions!!
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts_after_branching)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts_after_branching)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
             self.__latest_A_old_inv = _jit_vmap_A_inv_n(self.__latest_r_up_carts, self.__latest_r_dn_carts)
 
             mpi_comm.Barrier()
@@ -6732,7 +6734,8 @@ class _GFMC_n_debug:
                     [cos_b * cos_g, cos_g * sin_a * sin_b - cos_a * sin_g, sin_a * sin_g + cos_a * cos_g * sin_b],
                     [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                     [-sin_b, cos_b * sin_a, cos_a * cos_b],
-                ]
+                ],
+                dtype=get_dtype("gfmc"),
             )
             return R
 
@@ -7445,10 +7448,10 @@ class _GFMC_n_debug:
                     _n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     _n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     _n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up))
-                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3))
+                    omega_up = jnp.zeros((self.__num_walkers, _n_atoms, _n_up), dtype=get_dtype("gfmc"))
+                    omega_dn = jnp.zeros((self.__num_walkers, _n_atoms, _n_dn), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, _n_atoms, 3), dtype=get_dtype("gfmc"))
 
             # jnp.array -> np.array
             w_L_latest = np.array(w_L_list)
@@ -7653,8 +7656,8 @@ class _GFMC_n_debug:
             # here update the walker positions!!
             self.__num_survived_walkers += num_survived_walkers
             self.__num_killed_walkers += num_killed_walkers
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts_after_branching)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts_after_branching)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts_after_branching, dtype=get_dtype("gfmc"))
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts_after_branching, dtype=get_dtype("gfmc"))
 
             # update E_scf
             eq_steps = GFMC_ON_THE_FLY_WARMUP_STEPS
@@ -7691,8 +7694,8 @@ class _GFMC_n_debug:
             # logger.info(f"  (w_L_eq) = {(w_L_eq)}")
             logger.devel("  Progress: Computing G_eq and G_e_L_eq.")
 
-            w_L_eq = jnp.array(w_L_eq)
-            e_L_eq = jnp.array(e_L_eq)
+            w_L_eq = jnp.asarray(w_L_eq, dtype=get_dtype("gfmc"))
+            e_L_eq = jnp.asarray(e_L_eq, dtype=get_dtype("gfmc"))
             G_eq = _compute_G_L_debug(w_L_eq, num_gfmc_collect_steps)
             G_e_L_eq = e_L_eq * G_eq
             G_eq = np.array(G_eq)

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -1,4 +1,11 @@
-"""QMC module."""
+"""QMC module (VMC / MCMC).
+
+Precision Zones:
+    - ``mcmc``: sampling, Sherman--Morrison updates, accept/reject, statistics.
+    - ``optimization``: SR matrix construction and parameter updates (run_optimize).
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -53,12 +60,14 @@ from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
 from ._jqmc_utility import _generate_init_electron_configurations
+from ._precision import get_dtype
 from ._setting import (
     MCMC_MIN_BIN_BLOCKS,
     MCMC_MIN_WARMUP_STEPS,
     EPS_rcond_SVD,
     EPS_zero_division,
     atol_consistency,
+    get_eps,
     min_S_diag_abs,
 )
 from .atomic_orbital import compute_overlap_matrix
@@ -224,8 +233,9 @@ class MCMC:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("mcmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -254,23 +264,27 @@ class MCMC:
         nw = self.__num_walkers
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
+        # mcmc zone dtype for stored numpy arrays
+        dtype = get_dtype("mcmc")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+
         # stored weight (w_L)
-        self.__stored_w_L = np.zeros((0, nw))
+        self.__stored_w_L = np.zeros((0, nw), dtype=dtype_np)
 
         # stored local energy (e_L)
-        self.__stored_e_L = np.zeros((0, nw))
+        self.__stored_e_L = np.zeros((0, nw), dtype=dtype_np)
 
         # stored local energy (e_L2)
-        self.__stored_e_L2 = np.zeros((0, nw))
+        self.__stored_e_L2 = np.zeros((0, nw), dtype=dtype_np)
 
         # stored force_HF per walker (HF force = de_L/dR + Omega . de_L/dr)
-        self.__stored_force_HF = np.zeros((0, nw, n_atoms, 3))
+        self.__stored_force_HF = np.zeros((0, nw, n_atoms, 3), dtype=dtype_np)
 
         # stored force_PP per walker (Pulay force = dln_Psi/dR + Omega . dln_Psi/dr + 1/2 * d_omega/dr)
-        self.__stored_force_PP = np.zeros((0, nw, n_atoms, 3))
+        self.__stored_force_PP = np.zeros((0, nw, n_atoms, 3), dtype=dtype_np)
 
         # stored E_L * force_PP per walker (for covariance in Pulay force)
-        self.__stored_E_L_force_PP = np.zeros((0, nw, n_atoms, 3))
+        self.__stored_E_L_force_PP = np.zeros((0, nw, n_atoms, 3), dtype=dtype_np)
 
         # stored parameter gradients keyed by block name
         self.__stored_log_WF_param_grads: dict[str, list] = defaultdict(list)
@@ -486,7 +500,10 @@ class MCMC:
             self.__latest_r_dn_carts,
         )
 
-        RTs = jnp.broadcast_to(jnp.eye(3), (len(self.__jax_PRNG_key_list), 3, 3))
+        dtype = get_dtype("mcmc")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+
+        RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype), (len(self.__jax_PRNG_key_list), 3, 3))
 
         # Warm-up compilation: trigger JIT tracing on the first run() call
         # so that the MCMC loop does not stall on the first step.
@@ -620,14 +637,18 @@ class MCMC:
         nw = self.__num_walkers
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
-        self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, nw))])
-        self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, nw))])
-        self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, nw))])
+        self.__stored_e_L = np.concatenate([self.__stored_e_L, np.zeros((num_mcmc_steps, nw), dtype=dtype_np)])
+        self.__stored_e_L2 = np.concatenate([self.__stored_e_L2, np.zeros((num_mcmc_steps, nw), dtype=dtype_np)])
+        self.__stored_w_L = np.concatenate([self.__stored_w_L, np.zeros((num_mcmc_steps, nw), dtype=dtype_np)])
         if self.__comput_position_deriv:
-            self.__stored_force_HF = np.concatenate([self.__stored_force_HF, np.zeros((num_mcmc_steps, nw, n_atoms, 3))])
-            self.__stored_force_PP = np.concatenate([self.__stored_force_PP, np.zeros((num_mcmc_steps, nw, n_atoms, 3))])
+            self.__stored_force_HF = np.concatenate(
+                [self.__stored_force_HF, np.zeros((num_mcmc_steps, nw, n_atoms, 3), dtype=dtype_np)]
+            )
+            self.__stored_force_PP = np.concatenate(
+                [self.__stored_force_PP, np.zeros((num_mcmc_steps, nw, n_atoms, 3), dtype=dtype_np)]
+            )
             self.__stored_E_L_force_PP = np.concatenate(
-                [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, nw, n_atoms, 3))]
+                [self.__stored_E_L_force_PP, np.zeros((num_mcmc_steps, nw, n_atoms, 3), dtype=dtype_np)]
             )
 
         geminal, geminal_inv, _, _ = _geminal_inv_batched(
@@ -699,7 +720,7 @@ class MCMC:
             if self.__random_discretized_mesh:
                 RTs = _jit_vmap_generate_RTs(self.__jax_PRNG_key_list)
             else:
-                RTs = jnp.broadcast_to(jnp.eye(3), (len(self.__jax_PRNG_key_list), 3, 3))
+                RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype), (len(self.__jax_PRNG_key_list), 3, 3))
 
             # Evaluate observables each MCMC cycle
             start = time.perf_counter()
@@ -787,10 +808,10 @@ class MCMC:
                 else:
                     n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
-                    omega_up_step = jnp.zeros((nw, n_atoms, n_up))
-                    omega_dn_step = jnp.zeros((nw, n_atoms, n_dn))
-                    grad_omega_dr_up_step = jnp.zeros((nw, n_atoms, 3))
-                    grad_omega_dr_dn_step = jnp.zeros((nw, n_atoms, 3))
+                    omega_up_step = jnp.zeros((nw, n_atoms, n_up), dtype=dtype)
+                    omega_dn_step = jnp.zeros((nw, n_atoms, n_dn), dtype=dtype)
+                    grad_omega_dr_up_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype)
+                    grad_omega_dr_dn_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype)
 
                 # Compute per-walker force products preserving cross-correlations
                 _grad_e_L_r_up_np = np.array(grad_e_L_r_up_step)  # (nw, n_up, 3)
@@ -2190,10 +2211,12 @@ class MCMC:
         # ==================================================================
 
         # ---- Step 1: Remove parameters with near-zero diag(S) ----
+        dtype_opt = get_dtype("optimization")
+        dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
         diag_S = np.diag(S_matrix)
         max_diag_S = np.max(np.abs(diag_S))
         # parcut2 ~ machine_precision^2, effectively only removes exact zeros
-        parcut2 = np.finfo(np.float64).eps ** 2
+        parcut2 = np.finfo(dtype_opt_np).eps ** 2
         alive = np.abs(diag_S) > parcut2 * max_diag_S
         n_removed_step1 = p - int(np.count_nonzero(alive))
         if n_removed_step1 > 0:
@@ -2201,11 +2224,11 @@ class MCMC:
 
         if not np.any(alive):
             logger.warning("  LM dgelscut: all parameters removed in Step 1; returning zero update.")
-            return np.zeros(p), H_0
+            return np.zeros(p, dtype=dtype_opt_np), H_0
 
         # ---- Step 2: Build correlation matrix for alive parameters ----
         alive_idx = np.where(alive)[0]
-        D_inv_sqrt = np.zeros(p)
+        D_inv_sqrt = np.zeros(p, dtype=dtype_opt_np)
         D_inv_sqrt[alive_idx] = 1.0 / np.sqrt(np.abs(diag_S[alive_idx]))
 
         # ---- Step 3: Iteratively remove parameters until well-conditioned ----
@@ -2214,7 +2237,7 @@ class MCMC:
             n_alive = len(idx)
             if n_alive == 0:
                 logger.warning("  LM dgelscut: all parameters removed; returning zero update.")
-                return np.zeros(p), H_0
+                return np.zeros(p, dtype=dtype_opt_np), H_0
 
             # Build correlation matrix for current alive set
             D_sub = D_inv_sqrt[idx]  # (n_alive,)
@@ -2274,7 +2297,7 @@ class MCMC:
 
         if p_prime == 0:
             logger.warning("  LM: no positive S eigenvalues after dgelscut; returning zero update.")
-            return np.zeros(p), H_0
+            return np.zeros(p, dtype=dtype_opt_np), H_0
 
         # P = U Λ^{-1/2} (S-orthonormal basis)
         inv_sqrt_Lambda = 1.0 / np.sqrt(Lambda)
@@ -2286,8 +2309,8 @@ class MCMC:
 
         # ---- Build extended matrices (p'+1) x (p'+1) ----
         dim = p_prime + 1
-        H_bar = np.zeros((dim, dim))
-        S_bar = np.eye(dim)  # identity (S-orthonormal basis)
+        H_bar = np.zeros((dim, dim), dtype=dtype_opt_np)
+        S_bar = np.eye(dim, dtype=dtype_opt_np)  # identity (S-orthonormal basis)
 
         H_bar[0, 0] = H_0
         H_bar[0, 1:] = -0.5 * f_new
@@ -2324,7 +2347,7 @@ class MCMC:
 
         # ---- Back-transform: P @ c_new → alive parameter space → full space ----
         c_alive = P @ c_new  # (n_alive,)
-        c_vec = np.zeros(p)
+        c_vec = np.zeros(p, dtype=dtype_opt_np)
         c_vec[idx] = c_alive
 
         logger.info(
@@ -2540,9 +2563,11 @@ class MCMC:
             max_iter: int,
             tol: float,
         ) -> tuple[npt.NDArray[np.float64], float, int]:
-            x = np.array(x0, dtype=np.float64, copy=True)
-            r = np.array(b, dtype=np.float64, copy=False) - apply_A(x)
-            p = np.array(r, dtype=np.float64, copy=True)
+            dtype_opt = get_dtype("optimization")
+            dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
+            x = np.array(x0, dtype=dtype_opt_np, copy=True)
+            r = np.array(b, dtype=dtype_opt_np, copy=False) - apply_A(x)
+            p = np.array(r, dtype=dtype_opt_np, copy=True)
             rs_old = float(np.dot(r, r))
 
             if not np.isfinite(rs_old):
@@ -2551,7 +2576,7 @@ class MCMC:
             if np.sqrt(rs_old) <= tol:
                 return x, np.sqrt(rs_old), 0
 
-            tiny = np.finfo(np.float64).tiny
+            tiny = np.finfo(dtype_opt_np).tiny
             num_iter = 0
             for i in range(int(max_iter)):
                 Ap = apply_A(p)
@@ -2677,6 +2702,9 @@ class MCMC:
             logger.info(f"Bin blocks = {num_mcmc_bin_blocks}.")
             logger.info("")
 
+            dtype_opt = get_dtype("optimization")
+            dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
+
             lambda_projectors = None
             num_orb_projection = None
             if opt_with_projected_MOs:
@@ -2684,10 +2712,14 @@ class MCMC:
                 geminal_mo_current = wavefunction_data_step.geminal_data
                 num_orb_projection = int(geminal_mo_current.num_electron_dn)
 
-                mo_coefficients_up = np.asarray(geminal_mo_current.orb_data_up_spin.mo_coefficients, dtype=np.float64)
-                mo_coefficients_dn = np.asarray(geminal_mo_current.orb_data_dn_spin.mo_coefficients, dtype=np.float64)
-                overlap_up = np.asarray(compute_overlap_matrix(geminal_mo_current.orb_data_up_spin.aos_data), dtype=np.float64)
-                overlap_dn = np.asarray(compute_overlap_matrix(geminal_mo_current.orb_data_dn_spin.aos_data), dtype=np.float64)
+                mo_coefficients_up = np.asarray(geminal_mo_current.orb_data_up_spin.mo_coefficients, dtype=dtype_opt_np)
+                mo_coefficients_dn = np.asarray(geminal_mo_current.orb_data_dn_spin.mo_coefficients, dtype=dtype_opt_np)
+                overlap_up = np.asarray(
+                    compute_overlap_matrix(geminal_mo_current.orb_data_up_spin.aos_data), dtype=dtype_opt_np
+                )
+                overlap_dn = np.asarray(
+                    compute_overlap_matrix(geminal_mo_current.orb_data_dn_spin.aos_data), dtype=dtype_opt_np
+                )
                 overlap_up = 0.5 * (overlap_up + overlap_up.T)
                 overlap_dn = 0.5 * (overlap_dn + overlap_dn.T)
 
@@ -2723,7 +2755,7 @@ class MCMC:
                 # ------------------------------------------------------------------
                 # DEVEL: orthogonal complement-projector diagnostics  (I - L') and (I - R')
                 # ------------------------------------------------------------------
-                _I = np.eye(left_projector.shape[0], dtype=np.float64)
+                _I = np.eye(left_projector.shape[0], dtype=dtype_opt_np)
                 _comp_L = _I - left_projector  # (I - L')  — symmetric
                 _comp_R = _I - right_projector  # (I - R')  — symmetric
 
@@ -2843,13 +2875,15 @@ class MCMC:
 
             if not (use_sr or use_lm):
                 if blocks:
-                    flat_param_vector = np.concatenate([np.ravel(np.array(block.values, dtype=np.float64)) for block in blocks])
+                    flat_param_vector = np.concatenate(
+                        [np.ravel(np.array(block.values, dtype=dtype_opt_np)) for block in blocks]
+                    )
                 else:
-                    flat_param_vector = np.array([], dtype=np.float64)
+                    flat_param_vector = np.array([], dtype=dtype_opt_np)
 
                 if optax_state is None:
                     optax_param_size = flat_param_vector.size
-                    optax_state = optax_tx.init(jnp.array(flat_param_vector))
+                    optax_state = optax_tx.init(jnp.asarray(flat_param_vector, dtype=dtype_opt))
                 elif flat_param_vector.size != optax_param_size:
                     raise ValueError("The number of variational parameters changed after initializing the optax optimizer.")
 
@@ -3004,7 +3038,7 @@ class MCMC:
 
                 # compute X_w@F
                 X_F_local = X_local @ F_local  # shape (num_param, )
-                X_F = np.empty(X_F_local.shape, dtype=np.float64)
+                X_F = np.empty(X_F_local.shape, dtype=dtype_opt_np)
                 mpi_comm.Allreduce(X_F_local, X_F, op=MPI.SUM)
 
                 # compute f_argmax (index in reduced space)
@@ -3026,7 +3060,7 @@ class MCMC:
                 # make the SR matrix scale-invariant (i.e., normalize)
                 ## compute X_w@X.T
                 diag_S_local = np.einsum("jk,kj->j", X_local, X_local.T)
-                diag_S = np.empty(diag_S_local.shape, dtype=np.float64)
+                diag_S = np.empty(diag_S_local.shape, dtype=dtype_opt_np)
                 mpi_comm.Allreduce(diag_S_local, diag_S, op=MPI.SUM)
                 logger.info(f"max. and min. diag_S = {np.max(diag_S)}, {np.min(diag_S)}.")
                 # ------------------------------------------------------------------
@@ -3087,7 +3121,7 @@ class MCMC:
                         logger.devel(f"X_X_T_local.shape = {X_X_T_local.shape}.")
                         # compute global sum of X * X^T
                         if mpi_rank == 0:
-                            X_X_T = np.empty(X_X_T_local.shape, dtype=np.float64)
+                            X_X_T = np.empty(X_X_T_local.shape, dtype=dtype_opt_np)
                         else:
                             X_X_T = None
                         mpi_comm.Reduce(X_X_T_local, X_X_T, op=MPI.SUM, root=0)
@@ -3096,7 +3130,7 @@ class MCMC:
                         logger.devel(f"X_F_local.shape = {X_F_local.shape}.")
                         # compute global sum of X @ F
                         if mpi_rank == 0:
-                            X_F = np.empty(X_F_local.shape, dtype=np.float64)
+                            X_F = np.empty(X_F_local.shape, dtype=dtype_opt_np)
                         else:
                             X_F = None
                         mpi_comm.Reduce(X_F_local, X_F, op=MPI.SUM, root=0)
@@ -3141,9 +3175,9 @@ class MCMC:
                             x0 = np.zeros_like(X_F)
 
                         theta_all, final_residual, num_steps = _conjugate_gradient_numpy(
-                            np.asarray(X_F, dtype=np.float64),
+                            np.asarray(X_F, dtype=dtype_opt_np),
                             apply_S_primal_numpy,
-                            np.asarray(x0, dtype=np.float64),
+                            np.asarray(x0, dtype=dtype_opt_np),
                             sr_cg_max_iter,
                             sr_cg_tol,
                         )
@@ -3213,7 +3247,7 @@ class MCMC:
                         logger.devel(f"X_T_X_local.shape = {X_T_X_local.shape}.")
                         # compute global sum of X^T * X
                         if mpi_rank == 0:
-                            X_T_X = np.empty(X_T_X_local.shape, dtype=np.float64)
+                            X_T_X = np.empty(X_T_X_local.shape, dtype=dtype_opt_np)
                         else:
                             X_T_X = None
                         mpi_comm.Reduce(X_T_X_local, X_T_X, op=MPI.SUM, root=0)
@@ -3222,7 +3256,7 @@ class MCMC:
                         F_recvcounts = mpi_comm.gather(F_local_count, root=0)
                         if mpi_rank == 0:
                             F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                            F = np.empty(sum(F_recvcounts), dtype=np.float64)
+                            F = np.empty(sum(F_recvcounts), dtype=dtype_opt_np)
                         else:
                             F_displs = None
                             F = None
@@ -3244,7 +3278,7 @@ class MCMC:
                         # Broadcast K to all ranks so they know how big each chunk is
                         K = mpi_comm.bcast(K, root=0)
 
-                        X_T_X_inv_F_local = np.empty(K, dtype=np.float64)
+                        X_T_X_inv_F_local = np.empty(K, dtype=dtype_opt_np)
 
                         mpi_comm.Scatter(
                             [X_T_X_inv_F, MPI.DOUBLE],  # send buffer (only significant on root)
@@ -3253,7 +3287,7 @@ class MCMC:
                         )
                         # theta = X_w (X^T X_w + eps*I)^{-1} F
                         theta_all_local = X_local @ X_T_X_inv_F_local
-                        theta_all = np.empty(theta_all_local.shape, dtype=np.float64)
+                        theta_all = np.empty(theta_all_local.shape, dtype=dtype_opt_np)
                         mpi_comm.Allreduce(theta_all_local, theta_all, op=MPI.SUM)
                         logger.devel(f"[new] theta_all (w/ the push through identity) = {theta_all}.")
                         logger.devel(
@@ -3275,7 +3309,7 @@ class MCMC:
                         F_local_count = F_local.shape[0]
                         F_recvcounts = mpi_comm.allgather(F_local_count)
                         F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                        F_total = np.empty(sum(F_recvcounts), dtype=np.float64)
+                        F_total = np.empty(sum(F_recvcounts), dtype=dtype_opt_np)
                         mpi_comm.Allgatherv(
                             [F_local, MPI.DOUBLE],
                             [F_total, (F_recvcounts, F_displs), MPI.DOUBLE],
@@ -3287,7 +3321,7 @@ class MCMC:
                         x_sol, final_residual, num_steps = _conjugate_gradient_numpy(
                             F_total,
                             apply_dual_S_numpy,
-                            np.asarray(x0, dtype=np.float64),
+                            np.asarray(x0, dtype=dtype_opt_np),
                             sr_cg_max_iter,
                             sr_cg_tol,
                         )
@@ -3378,10 +3412,10 @@ class MCMC:
             # optax optimizer
             #############################
             else:
-                params = jnp.array(flat_param_vector)
-                grads = -jnp.array(f)
+                params = jnp.asarray(flat_param_vector, dtype=dtype_opt)
+                grads = -jnp.asarray(f, dtype=dtype_opt)
                 updates, optax_state = optax_tx.update(grads, optax_state, params)
-                theta_all = np.array(updates, dtype=np.float64)
+                theta_all = np.array(updates, dtype=dtype_opt_np)
                 if optax_param_size is None:
                     optax_param_size = flat_param_vector.size
                 self.__set_optimizer_runtime(
@@ -3398,11 +3432,11 @@ class MCMC:
             # 1) Expand theta_all to full parameter space.
             # ------------------------------------------------------------------
             if use_sr:
-                theta = np.zeros(total_num_params, dtype=np.float64)
+                theta = np.zeros(total_num_params, dtype=dtype_opt_np)
                 theta[:] = theta_all
             else:
                 # optax
-                theta = np.zeros(total_num_params, dtype=np.float64)
+                theta = np.zeros(total_num_params, dtype=dtype_opt_np)
                 theta[:] = theta_all
 
             # ------------------------------------------------------------------
@@ -3485,7 +3519,7 @@ class MCMC:
                     theta = 0.1 * g_sr
                 else:
                     # Back-transform: c_vec[0] = c₀ (SR direction), c_vec[1:] = c_k (individual params)
-                    theta = np.zeros(total_num_params, dtype=np.float64)
+                    theta = np.zeros(total_num_params, dtype=dtype_opt_np)
                     theta[:] += c_vec[0] * g_sr  # SR collective variable (affects all params)
                     if lm_subspace_dim == -1 or lm_subspace_dim >= total_num_params:
                         theta[:] += c_vec[1:]
@@ -3532,7 +3566,7 @@ class MCMC:
             # ------------------------------------------------------------------
             if use_sr and lambda_projectors is not None and len(lambda_projectors) == 4:
                 _left_proj, _right_proj, _, _ = lambda_projectors
-                _identity_proj = np.eye(_left_proj.shape[0], dtype=np.float64)
+                _identity_proj = np.eye(_left_proj.shape[0], dtype=dtype_opt_np)
                 _comp_L = _identity_proj - _left_proj
                 _comp_R = _identity_proj - _right_proj
                 for _blk, _s, _e in offsets:
@@ -4190,6 +4224,7 @@ class MCMC:
 @jit
 def _generate_rotation_matrix(jax_PRNG_key):
     """Sample a random 3×3 rotation matrix (Euler angles)."""
+    dtype = get_dtype("mcmc")
     _, subkey = jax.random.split(jax_PRNG_key)
     alpha, beta, gamma = jax.random.uniform(subkey, shape=(3,), minval=-2 * jnp.pi, maxval=2 * jnp.pi)
     cos_a, sin_a = jnp.cos(alpha), jnp.sin(alpha)
@@ -4200,7 +4235,8 @@ def _generate_rotation_matrix(jax_PRNG_key):
             [cos_b * cos_g, cos_g * sin_a * sin_b - cos_a * sin_g, sin_a * sin_g + cos_a * cos_g * sin_b],
             [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
             [-sin_b, cos_b * sin_a, cos_a * cos_b],
-        ]
+        ],
+        dtype=dtype,
     )
     return R.T
 
@@ -4208,13 +4244,15 @@ def _generate_rotation_matrix(jax_PRNG_key):
 @jit
 def _geminal_inv_single(geminal_data, I, r_up_carts, r_dn_carts):
     """Build G and invert via SVD-based pseudoinverse (single sample)."""
+    dtype = get_dtype("mcmc")
+    eps_rcond = get_eps("rcond_svd", dtype)
     G = compute_geminal_all_elements(
         geminal_data=geminal_data,
         r_up_carts=r_up_carts,
         r_dn_carts=r_dn_carts,
     )
     U, s, Vt = jnp.linalg.svd(G, full_matrices=False)
-    s_inv = jnp.where(s > EPS_rcond_SVD * s[0], 1.0 / s, 0.0)
+    s_inv = jnp.where(s > eps_rcond * s[0], 1.0 / s, 0.0)
     Ginv = (Vt.T * s_inv[jnp.newaxis, :]) @ U.T
     return G, Ginv, jnp.zeros_like(G), jnp.zeros(G.shape[0], dtype=jnp.int32)
 
@@ -4222,8 +4260,9 @@ def _geminal_inv_single(geminal_data, I, r_up_carts, r_dn_carts):
 @jit
 def _geminal_inv_batched(geminal_data, r_up_batch, r_dn_batch):
     """Batched geminal inverse over walkers."""
+    dtype = get_dtype("mcmc")
     N_up = r_up_batch.shape[-2]
-    I = jnp.eye(N_up)
+    I = jnp.eye(N_up, dtype=dtype)
     G_b, Ginv_b, lu_b, piv_b = vmap(
         _geminal_inv_single,
         in_axes=(None, None, 0, 0),
@@ -4262,10 +4301,11 @@ def _update_electron_positions(
         updated_r_up_cart (jnpt.ArrayLike): up electron position. dim: (N_e^up, 3)
         updated_r_dn_cart (jnpt.ArrayLike): down electron position. dim: (N_e^down, 3)
     """
+    dtype = get_dtype("mcmc")
     accepted_moves = 0
     rejected_moves = 0
-    r_up_carts = init_r_up_carts
-    r_dn_carts = init_r_dn_carts
+    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype)
     geminal = geminal_init
     geminal_inv = geminal_inv_init
 
@@ -4323,7 +4363,7 @@ def _update_electron_positions(
         random_index = jax.random.randint(subkey, shape=(), minval=0, maxval=3)
 
         # plug g into g_vector
-        g_vector = jnp.zeros(3)
+        g_vector = jnp.zeros(3, dtype=dtype)
         g_vector = g_vector.at[random_index].set(g)
 
         new_r_cart = old_r_cart + g_vector
@@ -4434,7 +4474,7 @@ def _update_electron_positions(
         # compute R_ratio
         R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
-        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio]))
+        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
 
         jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
         b = jax.random.uniform(subkey, shape=(), minval=0.0, maxval=1.0)
@@ -4486,10 +4526,11 @@ def _update_electron_positions_only_up_electron(
     geminal_init,
 ):
     """Update electron positions based on the MH method (up-spin electrons only)."""
+    dtype = get_dtype("mcmc")
     accepted_moves = 0
     rejected_moves = 0
-    r_up_carts = init_r_up_carts
-    r_dn_carts = init_r_dn_carts
+    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype)
+    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype)
     geminal_inv = geminal_inv_init
     geminal = geminal_init
 
@@ -4539,7 +4580,7 @@ def _update_electron_positions_only_up_electron(
         random_index = jax.random.randint(subkey, shape=(), minval=0, maxval=3)
 
         # plug g into g_vector
-        g_vector = jnp.zeros(3)
+        g_vector = jnp.zeros(3, dtype=dtype)
         g_vector = g_vector.at[random_index].set(g)
 
         new_r_cart = old_r_cart + g_vector
@@ -4616,7 +4657,7 @@ def _update_electron_positions_only_up_electron(
         # compute R_ratio
         R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
-        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio]))
+        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
 
         jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
         b = jax.random.uniform(subkey, shape=(), minval=0.0, maxval=1.0)
@@ -4773,8 +4814,9 @@ class _MCMC_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        self.__latest_r_up_carts = jnp.array(r_carts_up)
-        self.__latest_r_dn_carts = jnp.array(r_carts_dn)
+        dtype = get_dtype("mcmc")
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -4858,6 +4900,9 @@ class _MCMC_debug:
         logger.info("")
         logger.info("This is a debugging class! It supposed to be very slow.")
         logger.info("")
+
+        dtype = get_dtype("mcmc")
+        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
 
         # MAIN MCMC loop from here !!!
         logger.info("Start MCMC")
@@ -4945,7 +4990,7 @@ class _MCMC_debug:
                     random_index = jax.random.randint(subkey, shape=(), minval=0, maxval=3)
 
                     # plug g into g_vector
-                    g_vector = np.zeros(3)
+                    g_vector = np.zeros(3, dtype=dtype_np)
                     g_vector[random_index] = g
 
                     new_r_cart = old_r_cart + g_vector
@@ -5021,7 +5066,7 @@ class _MCMC_debug:
                     R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
                     logger.devel(f"R_ratio, T_ratio = {R_ratio}, {T_ratio}")
-                    acceptance_ratio = np.min(jnp.array([1.0, R_ratio * T_ratio]))
+                    acceptance_ratio = np.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
                     logger.devel(f"acceptance_ratio = {acceptance_ratio}")
 
                     jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
@@ -5043,8 +5088,8 @@ class _MCMC_debug:
             # store vmapped outcomes
             self.__accepted_moves = self.__accepted_moves + np.sum(accepted_moves_nw)
             self.__rejected_moves = self.__rejected_moves + np.sum(rejected_moves_nw)
-            self.__latest_r_up_carts = jnp.array(latest_r_up_carts)
-            self.__latest_r_dn_carts = jnp.array(latest_r_dn_carts)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=dtype)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=dtype)
             self.__jax_PRNG_key_list = jnp.array(jax_PRNG_key_list)
 
             # generate rotation matrices (for non-local ECPs)
@@ -5065,11 +5110,12 @@ class _MCMC_debug:
                             [cos_b * cos_g, cos_g * sin_a * sin_b - cos_a * sin_g, sin_a * sin_g + cos_a * cos_g * sin_b],
                             [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                             [-sin_b, cos_b * sin_a, cos_a * cos_b],
-                        ]
+                        ],
+                        dtype=dtype,
                     )
                     RTs.append(R.T)
                 else:
-                    RTs.append(jnp.eye(3))
+                    RTs.append(jnp.eye(3, dtype=dtype))
             RTs = jnp.array(RTs)
 
             # evaluate observables
@@ -5167,10 +5213,10 @@ class _MCMC_debug:
                     n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, n_atoms, n_up))
-                    omega_dn = jnp.zeros((self.__num_walkers, n_atoms, n_dn))
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, n_atoms, 3))
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, n_atoms, 3))
+                    omega_up = jnp.zeros((self.__num_walkers, n_atoms, n_up), dtype=dtype)
+                    omega_dn = jnp.zeros((self.__num_walkers, n_atoms, n_dn), dtype=dtype)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype)
 
                 self.__stored_omega_up.append(omega_up)
                 self.__stored_omega_dn.append(omega_dn)

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -4406,40 +4406,56 @@ def _update_electron_positions(
         )[0]
 
         # Determinant part, fast update using the matrix determinant lemma
+        # Cast both lax.cond branches to geminal_inv.dtype: the geminal-diff branch
+        # lives in the geminal zone (fp64) while jax.nn.one_hot defaults to fp32,
+        # so without an explicit cast the cond branches disagree in mixed precision.
+        _gem_dtype = geminal_inv.dtype
         v = lax.cond(
             is_up,
-            lambda _: (
-                compute_geminal_up_one_row_elements(
-                    geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
-                    # inline "as_row3": force (1,3) even if source is (3,)
-                    r_up_cart=jnp.reshape(proposed_r_up_carts[selected_electron_index], (1, 3)),
-                    r_dn_carts=r_dn_carts,
-                )
-                - compute_geminal_up_one_row_elements(
-                    geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
-                    r_up_cart=jnp.reshape(r_up_carts[selected_electron_index], (1, 3)),
-                    r_dn_carts=r_dn_carts,
-                )
-            )[:, None],
-            lambda _: jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],
+            lambda _: jnp.asarray(
+                (
+                    compute_geminal_up_one_row_elements(
+                        geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
+                        # inline "as_row3": force (1,3) even if source is (3,)
+                        r_up_cart=jnp.reshape(proposed_r_up_carts[selected_electron_index], (1, 3)),
+                        r_dn_carts=r_dn_carts,
+                    )
+                    - compute_geminal_up_one_row_elements(
+                        geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
+                        r_up_cart=jnp.reshape(r_up_carts[selected_electron_index], (1, 3)),
+                        r_dn_carts=r_dn_carts,
+                    )
+                )[:, None],
+                dtype=_gem_dtype,
+            ),
+            lambda _: jnp.asarray(
+                jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],
+                dtype=_gem_dtype,
+            ),
             operand=None,
         )
 
         u = lax.cond(
             is_up,
-            lambda _: jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],  # (N_up, 1)
-            lambda _: (
-                compute_geminal_dn_one_column_elements(
-                    geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
-                    r_up_carts=r_up_carts,
-                    r_dn_cart=jnp.reshape(proposed_r_dn_carts[selected_electron_index], (1, 3)),  # inline "as_row3"
-                )
-                - compute_geminal_dn_one_column_elements(
-                    geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
-                    r_up_carts=r_up_carts,
-                    r_dn_cart=jnp.reshape(r_dn_carts[selected_electron_index], (1, 3)),
-                )
-            )[:, None],  # -> (N_up, 1)
+            lambda _: jnp.asarray(
+                jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],  # (N_up, 1)
+                dtype=_gem_dtype,
+            ),
+            lambda _: jnp.asarray(
+                (
+                    compute_geminal_dn_one_column_elements(
+                        geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
+                        r_up_carts=r_up_carts,
+                        r_dn_cart=jnp.reshape(proposed_r_dn_carts[selected_electron_index], (1, 3)),  # inline "as_row3"
+                    )
+                    - compute_geminal_dn_one_column_elements(
+                        geminal_data=hamiltonian_data.wavefunction_data.geminal_data,
+                        r_up_carts=r_up_carts,
+                        r_dn_cart=jnp.reshape(r_dn_carts[selected_electron_index], (1, 3)),
+                    )
+                )[:, None],  # -> (N_up, 1)
+                dtype=_gem_dtype,
+            ),
             operand=None,
         )
 
@@ -4639,7 +4655,11 @@ def _update_electron_positions_only_up_electron(
         Det_T_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]  # scalar
 
         # (A+uv^T)^{-1} = A^{-1} - (A^{-1} u v^T A^{-1}) / (1 + v^T A^{-1} u)
-        geminal_inv_new = geminal_inv - (Ainv_u @ vT_Ainv) / Det_T_ratio
+        # Cast back to geminal_inv.dtype: ``v`` originates in the geminal zone (fp64)
+        # while geminal_inv lives in its own zone (e.g. fp32 in mixed precision), so
+        # the rank-1 update would otherwise promote and break the lax.cond dtype
+        # agreement with the rejected branch.
+        geminal_inv_new = jnp.asarray(geminal_inv - (Ainv_u @ vT_Ainv) / Det_T_ratio, dtype=geminal_inv.dtype)
 
         geminal_new = geminal.at[selected_electron_index, :].add(v.squeeze(-1))
 

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -60,11 +60,9 @@ from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
 from ._jqmc_utility import _generate_init_electron_configurations
-from ._precision import get_dtype
 from ._setting import (
     MCMC_MIN_BIN_BLOCKS,
     MCMC_MIN_WARMUP_STEPS,
-    EPS_rcond_SVD,
     EPS_zero_division,
     atol_consistency,
     get_eps,
@@ -233,9 +231,9 @@ class MCMC:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("mcmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -265,8 +263,7 @@ class MCMC:
         n_atoms = self.__hamiltonian_data.structure_data.natom
 
         # mcmc zone dtype for stored numpy arrays
-        dtype = get_dtype("mcmc")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_np = np.float64
 
         # stored weight (w_L)
         self.__stored_w_L = np.zeros((0, nw), dtype=dtype_np)
@@ -500,10 +497,10 @@ class MCMC:
             self.__latest_r_dn_carts,
         )
 
-        dtype = get_dtype("mcmc")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_jnp = jnp.float64
+        dtype_np = np.float64
 
-        RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype), (len(self.__jax_PRNG_key_list), 3, 3))
+        RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype_jnp), (len(self.__jax_PRNG_key_list), 3, 3))
 
         # Warm-up compilation: trigger JIT tracing on the first run() call
         # so that the MCMC loop does not stall on the first step.
@@ -720,7 +717,7 @@ class MCMC:
             if self.__random_discretized_mesh:
                 RTs = _jit_vmap_generate_RTs(self.__jax_PRNG_key_list)
             else:
-                RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype), (len(self.__jax_PRNG_key_list), 3, 3))
+                RTs = jnp.broadcast_to(jnp.eye(3, dtype=dtype_jnp), (len(self.__jax_PRNG_key_list), 3, 3))
 
             # Evaluate observables each MCMC cycle
             start = time.perf_counter()
@@ -808,10 +805,10 @@ class MCMC:
                 else:
                     n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
-                    omega_up_step = jnp.zeros((nw, n_atoms, n_up), dtype=dtype)
-                    omega_dn_step = jnp.zeros((nw, n_atoms, n_dn), dtype=dtype)
-                    grad_omega_dr_up_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype)
-                    grad_omega_dr_dn_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype)
+                    omega_up_step = jnp.zeros((nw, n_atoms, n_up), dtype=dtype_jnp)
+                    omega_dn_step = jnp.zeros((nw, n_atoms, n_dn), dtype=dtype_jnp)
+                    grad_omega_dr_up_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype_jnp)
+                    grad_omega_dr_dn_step = jnp.zeros((nw, n_atoms, 3), dtype=dtype_jnp)
 
                 # Compute per-walker force products preserving cross-correlations
                 _grad_e_L_r_up_np = np.array(grad_e_L_r_up_step)  # (nw, n_up, 3)
@@ -1402,7 +1399,7 @@ class MCMC:
         # here, the third index indicates the flattened variational parameter index.
         O_matrix = np.empty((self.mcmc_counter, self.num_walkers, 0))
 
-        for dln_Psi_dc, block in zip(dln_Psi_dc_list, matched_blocks):
+        for dln_Psi_dc, _ in zip(dln_Psi_dc_list, matched_blocks):
             logger.devel(f"dln_Psi_dc.shape={dln_Psi_dc.shape}.")
             if dln_Psi_dc.ndim == 2:  # scalar variational param.
                 dln_Psi_dc_reshaped = dln_Psi_dc.reshape(dln_Psi_dc.shape[0], dln_Psi_dc.shape[1], 1)
@@ -2211,12 +2208,11 @@ class MCMC:
         # ==================================================================
 
         # ---- Step 1: Remove parameters with near-zero diag(S) ----
-        dtype_opt = get_dtype("optimization")
-        dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
+        dtype_mcmc_np = np.float64
         diag_S = np.diag(S_matrix)
         max_diag_S = np.max(np.abs(diag_S))
         # parcut2 ~ machine_precision^2, effectively only removes exact zeros
-        parcut2 = np.finfo(dtype_opt_np).eps ** 2
+        parcut2 = np.finfo(dtype_mcmc_np).eps ** 2
         alive = np.abs(diag_S) > parcut2 * max_diag_S
         n_removed_step1 = p - int(np.count_nonzero(alive))
         if n_removed_step1 > 0:
@@ -2224,11 +2220,11 @@ class MCMC:
 
         if not np.any(alive):
             logger.warning("  LM dgelscut: all parameters removed in Step 1; returning zero update.")
-            return np.zeros(p, dtype=dtype_opt_np), H_0
+            return np.zeros(p, dtype=dtype_mcmc_np), H_0
 
         # ---- Step 2: Build correlation matrix for alive parameters ----
         alive_idx = np.where(alive)[0]
-        D_inv_sqrt = np.zeros(p, dtype=dtype_opt_np)
+        D_inv_sqrt = np.zeros(p, dtype=dtype_mcmc_np)
         D_inv_sqrt[alive_idx] = 1.0 / np.sqrt(np.abs(diag_S[alive_idx]))
 
         # ---- Step 3: Iteratively remove parameters until well-conditioned ----
@@ -2237,7 +2233,7 @@ class MCMC:
             n_alive = len(idx)
             if n_alive == 0:
                 logger.warning("  LM dgelscut: all parameters removed; returning zero update.")
-                return np.zeros(p, dtype=dtype_opt_np), H_0
+                return np.zeros(p, dtype=dtype_mcmc_np), H_0
 
             # Build correlation matrix for current alive set
             D_sub = D_inv_sqrt[idx]  # (n_alive,)
@@ -2297,7 +2293,7 @@ class MCMC:
 
         if p_prime == 0:
             logger.warning("  LM: no positive S eigenvalues after dgelscut; returning zero update.")
-            return np.zeros(p, dtype=dtype_opt_np), H_0
+            return np.zeros(p, dtype=dtype_mcmc_np), H_0
 
         # P = U Λ^{-1/2} (S-orthonormal basis)
         inv_sqrt_Lambda = 1.0 / np.sqrt(Lambda)
@@ -2309,8 +2305,8 @@ class MCMC:
 
         # ---- Build extended matrices (p'+1) x (p'+1) ----
         dim = p_prime + 1
-        H_bar = np.zeros((dim, dim), dtype=dtype_opt_np)
-        S_bar = np.eye(dim, dtype=dtype_opt_np)  # identity (S-orthonormal basis)
+        H_bar = np.zeros((dim, dim), dtype=dtype_mcmc_np)
+        # S_bar = np.eye(dim, dtype=dtype_mcmc_np)  # identity (S-orthonormal basis)
 
         H_bar[0, 0] = H_0
         H_bar[0, 1:] = -0.5 * f_new
@@ -2347,7 +2343,7 @@ class MCMC:
 
         # ---- Back-transform: P @ c_new → alive parameter space → full space ----
         c_alive = P @ c_new  # (n_alive,)
-        c_vec = np.zeros(p, dtype=dtype_opt_np)
+        c_vec = np.zeros(p, dtype=dtype_mcmc_np)
         c_vec[idx] = c_alive
 
         logger.info(
@@ -2563,11 +2559,10 @@ class MCMC:
             max_iter: int,
             tol: float,
         ) -> tuple[npt.NDArray[np.float64], float, int]:
-            dtype_opt = get_dtype("optimization")
-            dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
-            x = np.array(x0, dtype=dtype_opt_np, copy=True)
-            r = np.array(b, dtype=dtype_opt_np, copy=False) - apply_A(x)
-            p = np.array(r, dtype=dtype_opt_np, copy=True)
+            dtype_mcmc_np = np.float64
+            x = np.array(x0, dtype=dtype_mcmc_np, copy=True)
+            r = np.array(b, dtype=dtype_mcmc_np, copy=False) - apply_A(x)
+            p = np.array(r, dtype=dtype_mcmc_np, copy=True)
             rs_old = float(np.dot(r, r))
 
             if not np.isfinite(rs_old):
@@ -2576,7 +2571,7 @@ class MCMC:
             if np.sqrt(rs_old) <= tol:
                 return x, np.sqrt(rs_old), 0
 
-            tiny = np.finfo(dtype_opt_np).tiny
+            tiny = np.finfo(dtype_mcmc_np).tiny
             num_iter = 0
             for i in range(int(max_iter)):
                 Ap = apply_A(p)
@@ -2702,8 +2697,8 @@ class MCMC:
             logger.info(f"Bin blocks = {num_mcmc_bin_blocks}.")
             logger.info("")
 
-            dtype_opt = get_dtype("optimization")
-            dtype_opt_np = np.float64 if dtype_opt == jnp.float64 else np.float32
+            dtype_mcmc_jnp = jnp.float64
+            dtype_mcmc_np = np.float64
 
             lambda_projectors = None
             num_orb_projection = None
@@ -2712,13 +2707,13 @@ class MCMC:
                 geminal_mo_current = wavefunction_data_step.geminal_data
                 num_orb_projection = int(geminal_mo_current.num_electron_dn)
 
-                mo_coefficients_up = np.asarray(geminal_mo_current.orb_data_up_spin.mo_coefficients, dtype=dtype_opt_np)
-                mo_coefficients_dn = np.asarray(geminal_mo_current.orb_data_dn_spin.mo_coefficients, dtype=dtype_opt_np)
+                mo_coefficients_up = np.asarray(geminal_mo_current.orb_data_up_spin.mo_coefficients, dtype=dtype_mcmc_np)
+                mo_coefficients_dn = np.asarray(geminal_mo_current.orb_data_dn_spin.mo_coefficients, dtype=dtype_mcmc_np)
                 overlap_up = np.asarray(
-                    compute_overlap_matrix(geminal_mo_current.orb_data_up_spin.aos_data), dtype=dtype_opt_np
+                    compute_overlap_matrix(geminal_mo_current.orb_data_up_spin.aos_data), dtype=dtype_mcmc_np
                 )
                 overlap_dn = np.asarray(
-                    compute_overlap_matrix(geminal_mo_current.orb_data_dn_spin.aos_data), dtype=dtype_opt_np
+                    compute_overlap_matrix(geminal_mo_current.orb_data_dn_spin.aos_data), dtype=dtype_mcmc_np
                 )
                 overlap_up = 0.5 * (overlap_up + overlap_up.T)
                 overlap_dn = 0.5 * (overlap_dn + overlap_dn.T)
@@ -2755,7 +2750,7 @@ class MCMC:
                 # ------------------------------------------------------------------
                 # DEVEL: orthogonal complement-projector diagnostics  (I - L') and (I - R')
                 # ------------------------------------------------------------------
-                _I = np.eye(left_projector.shape[0], dtype=dtype_opt_np)
+                _I = np.eye(left_projector.shape[0], dtype=dtype_mcmc_np)
                 _comp_L = _I - left_projector  # (I - L')  — symmetric
                 _comp_R = _I - right_projector  # (I - R')  — symmetric
 
@@ -2876,14 +2871,14 @@ class MCMC:
             if not (use_sr or use_lm):
                 if blocks:
                     flat_param_vector = np.concatenate(
-                        [np.ravel(np.array(block.values, dtype=dtype_opt_np)) for block in blocks]
+                        [np.ravel(np.array(block.values, dtype=dtype_mcmc_np)) for block in blocks]
                     )
                 else:
-                    flat_param_vector = np.array([], dtype=dtype_opt_np)
+                    flat_param_vector = np.array([], dtype=dtype_mcmc_np)
 
                 if optax_state is None:
                     optax_param_size = flat_param_vector.size
-                    optax_state = optax_tx.init(jnp.asarray(flat_param_vector, dtype=dtype_opt))
+                    optax_state = optax_tx.init(jnp.asarray(flat_param_vector, dtype=dtype_mcmc_jnp))
                 elif flat_param_vector.size != optax_param_size:
                     raise ValueError("The number of variational parameters changed after initializing the optax optimizer.")
 
@@ -3038,7 +3033,7 @@ class MCMC:
 
                 # compute X_w@F
                 X_F_local = X_local @ F_local  # shape (num_param, )
-                X_F = np.empty(X_F_local.shape, dtype=dtype_opt_np)
+                X_F = np.empty(X_F_local.shape, dtype=dtype_mcmc_np)
                 mpi_comm.Allreduce(X_F_local, X_F, op=MPI.SUM)
 
                 # compute f_argmax (index in reduced space)
@@ -3060,7 +3055,7 @@ class MCMC:
                 # make the SR matrix scale-invariant (i.e., normalize)
                 ## compute X_w@X.T
                 diag_S_local = np.einsum("jk,kj->j", X_local, X_local.T)
-                diag_S = np.empty(diag_S_local.shape, dtype=dtype_opt_np)
+                diag_S = np.empty(diag_S_local.shape, dtype=dtype_mcmc_np)
                 mpi_comm.Allreduce(diag_S_local, diag_S, op=MPI.SUM)
                 logger.info(f"max. and min. diag_S = {np.max(diag_S)}, {np.min(diag_S)}.")
                 # ------------------------------------------------------------------
@@ -3121,7 +3116,7 @@ class MCMC:
                         logger.devel(f"X_X_T_local.shape = {X_X_T_local.shape}.")
                         # compute global sum of X * X^T
                         if mpi_rank == 0:
-                            X_X_T = np.empty(X_X_T_local.shape, dtype=dtype_opt_np)
+                            X_X_T = np.empty(X_X_T_local.shape, dtype=dtype_mcmc_np)
                         else:
                             X_X_T = None
                         mpi_comm.Reduce(X_X_T_local, X_X_T, op=MPI.SUM, root=0)
@@ -3130,7 +3125,7 @@ class MCMC:
                         logger.devel(f"X_F_local.shape = {X_F_local.shape}.")
                         # compute global sum of X @ F
                         if mpi_rank == 0:
-                            X_F = np.empty(X_F_local.shape, dtype=dtype_opt_np)
+                            X_F = np.empty(X_F_local.shape, dtype=dtype_mcmc_np)
                         else:
                             X_F = None
                         mpi_comm.Reduce(X_F_local, X_F, op=MPI.SUM, root=0)
@@ -3175,9 +3170,9 @@ class MCMC:
                             x0 = np.zeros_like(X_F)
 
                         theta_all, final_residual, num_steps = _conjugate_gradient_numpy(
-                            np.asarray(X_F, dtype=dtype_opt_np),
+                            np.asarray(X_F, dtype=dtype_mcmc_np),
                             apply_S_primal_numpy,
-                            np.asarray(x0, dtype=dtype_opt_np),
+                            np.asarray(x0, dtype=dtype_mcmc_np),
                             sr_cg_max_iter,
                             sr_cg_tol,
                         )
@@ -3247,7 +3242,7 @@ class MCMC:
                         logger.devel(f"X_T_X_local.shape = {X_T_X_local.shape}.")
                         # compute global sum of X^T * X
                         if mpi_rank == 0:
-                            X_T_X = np.empty(X_T_X_local.shape, dtype=dtype_opt_np)
+                            X_T_X = np.empty(X_T_X_local.shape, dtype=dtype_mcmc_np)
                         else:
                             X_T_X = None
                         mpi_comm.Reduce(X_T_X_local, X_T_X, op=MPI.SUM, root=0)
@@ -3256,7 +3251,7 @@ class MCMC:
                         F_recvcounts = mpi_comm.gather(F_local_count, root=0)
                         if mpi_rank == 0:
                             F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                            F = np.empty(sum(F_recvcounts), dtype=dtype_opt_np)
+                            F = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
                         else:
                             F_displs = None
                             F = None
@@ -3278,7 +3273,7 @@ class MCMC:
                         # Broadcast K to all ranks so they know how big each chunk is
                         K = mpi_comm.bcast(K, root=0)
 
-                        X_T_X_inv_F_local = np.empty(K, dtype=dtype_opt_np)
+                        X_T_X_inv_F_local = np.empty(K, dtype=dtype_mcmc_np)
 
                         mpi_comm.Scatter(
                             [X_T_X_inv_F, MPI.DOUBLE],  # send buffer (only significant on root)
@@ -3287,7 +3282,7 @@ class MCMC:
                         )
                         # theta = X_w (X^T X_w + eps*I)^{-1} F
                         theta_all_local = X_local @ X_T_X_inv_F_local
-                        theta_all = np.empty(theta_all_local.shape, dtype=dtype_opt_np)
+                        theta_all = np.empty(theta_all_local.shape, dtype=dtype_mcmc_np)
                         mpi_comm.Allreduce(theta_all_local, theta_all, op=MPI.SUM)
                         logger.devel(f"[new] theta_all (w/ the push through identity) = {theta_all}.")
                         logger.devel(
@@ -3309,7 +3304,7 @@ class MCMC:
                         F_local_count = F_local.shape[0]
                         F_recvcounts = mpi_comm.allgather(F_local_count)
                         F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                        F_total = np.empty(sum(F_recvcounts), dtype=dtype_opt_np)
+                        F_total = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
                         mpi_comm.Allgatherv(
                             [F_local, MPI.DOUBLE],
                             [F_total, (F_recvcounts, F_displs), MPI.DOUBLE],
@@ -3321,7 +3316,7 @@ class MCMC:
                         x_sol, final_residual, num_steps = _conjugate_gradient_numpy(
                             F_total,
                             apply_dual_S_numpy,
-                            np.asarray(x0, dtype=dtype_opt_np),
+                            np.asarray(x0, dtype=dtype_mcmc_np),
                             sr_cg_max_iter,
                             sr_cg_tol,
                         )
@@ -3412,10 +3407,10 @@ class MCMC:
             # optax optimizer
             #############################
             else:
-                params = jnp.asarray(flat_param_vector, dtype=dtype_opt)
-                grads = -jnp.asarray(f, dtype=dtype_opt)
+                params = jnp.asarray(flat_param_vector, dtype=dtype_mcmc_jnp)
+                grads = -jnp.asarray(f, dtype=dtype_mcmc_jnp)
                 updates, optax_state = optax_tx.update(grads, optax_state, params)
-                theta_all = np.array(updates, dtype=dtype_opt_np)
+                theta_all = np.array(updates, dtype=dtype_mcmc_np)
                 if optax_param_size is None:
                     optax_param_size = flat_param_vector.size
                 self.__set_optimizer_runtime(
@@ -3432,11 +3427,11 @@ class MCMC:
             # 1) Expand theta_all to full parameter space.
             # ------------------------------------------------------------------
             if use_sr:
-                theta = np.zeros(total_num_params, dtype=dtype_opt_np)
+                theta = np.zeros(total_num_params, dtype=dtype_mcmc_np)
                 theta[:] = theta_all
             else:
                 # optax
-                theta = np.zeros(total_num_params, dtype=dtype_opt_np)
+                theta = np.zeros(total_num_params, dtype=dtype_mcmc_np)
                 theta[:] = theta_all
 
             # ------------------------------------------------------------------
@@ -3519,7 +3514,7 @@ class MCMC:
                     theta = 0.1 * g_sr
                 else:
                     # Back-transform: c_vec[0] = c₀ (SR direction), c_vec[1:] = c_k (individual params)
-                    theta = np.zeros(total_num_params, dtype=dtype_opt_np)
+                    theta = np.zeros(total_num_params, dtype=dtype_mcmc_np)
                     theta[:] += c_vec[0] * g_sr  # SR collective variable (affects all params)
                     if lm_subspace_dim == -1 or lm_subspace_dim >= total_num_params:
                         theta[:] += c_vec[1:]
@@ -3566,7 +3561,7 @@ class MCMC:
             # ------------------------------------------------------------------
             if use_sr and lambda_projectors is not None and len(lambda_projectors) == 4:
                 _left_proj, _right_proj, _, _ = lambda_projectors
-                _identity_proj = np.eye(_left_proj.shape[0], dtype=dtype_opt_np)
+                _identity_proj = np.eye(_left_proj.shape[0], dtype=dtype_mcmc_np)
                 _comp_L = _identity_proj - _left_proj
                 _comp_R = _identity_proj - _right_proj
                 for _blk, _s, _e in offsets:
@@ -4224,7 +4219,7 @@ class MCMC:
 @jit
 def _generate_rotation_matrix(jax_PRNG_key):
     """Sample a random 3×3 rotation matrix (Euler angles)."""
-    dtype = get_dtype("mcmc")
+    dtype_jnp = jnp.float64
     _, subkey = jax.random.split(jax_PRNG_key)
     alpha, beta, gamma = jax.random.uniform(subkey, shape=(3,), minval=-2 * jnp.pi, maxval=2 * jnp.pi)
     cos_a, sin_a = jnp.cos(alpha), jnp.sin(alpha)
@@ -4236,7 +4231,7 @@ def _generate_rotation_matrix(jax_PRNG_key):
             [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
             [-sin_b, cos_b * sin_a, cos_a * cos_b],
         ],
-        dtype=dtype,
+        dtype=dtype_jnp,
     )
     return R.T
 
@@ -4244,8 +4239,8 @@ def _generate_rotation_matrix(jax_PRNG_key):
 @jit
 def _geminal_inv_single(geminal_data, I, r_up_carts, r_dn_carts):
     """Build G and invert via SVD-based pseudoinverse (single sample)."""
-    dtype = get_dtype("mcmc")
-    eps_rcond = get_eps("rcond_svd", dtype)
+    dtype_jnp = jnp.float64
+    eps_rcond = get_eps("rcond_svd", dtype_jnp)
     G = compute_geminal_all_elements(
         geminal_data=geminal_data,
         r_up_carts=r_up_carts,
@@ -4260,9 +4255,9 @@ def _geminal_inv_single(geminal_data, I, r_up_carts, r_dn_carts):
 @jit
 def _geminal_inv_batched(geminal_data, r_up_batch, r_dn_batch):
     """Batched geminal inverse over walkers."""
-    dtype = get_dtype("mcmc")
+    dtype_jnp = jnp.float64
     N_up = r_up_batch.shape[-2]
-    I = jnp.eye(N_up, dtype=dtype)
+    I = jnp.eye(N_up, dtype=dtype_jnp)
     G_b, Ginv_b, lu_b, piv_b = vmap(
         _geminal_inv_single,
         in_axes=(None, None, 0, 0),
@@ -4301,11 +4296,11 @@ def _update_electron_positions(
         updated_r_up_cart (jnpt.ArrayLike): up electron position. dim: (N_e^up, 3)
         updated_r_dn_cart (jnpt.ArrayLike): down electron position. dim: (N_e^down, 3)
     """
-    dtype = get_dtype("mcmc")
+    dtype_jnp = jnp.float64
     accepted_moves = 0
     rejected_moves = 0
-    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype)
+    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype_jnp)
+    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype_jnp)
     geminal = geminal_init
     geminal_inv = geminal_inv_init
 
@@ -4363,7 +4358,7 @@ def _update_electron_positions(
         random_index = jax.random.randint(subkey, shape=(), minval=0, maxval=3)
 
         # plug g into g_vector
-        g_vector = jnp.zeros(3, dtype=dtype)
+        g_vector = jnp.zeros(3, dtype=dtype_jnp)
         g_vector = g_vector.at[random_index].set(g)
 
         new_r_cart = old_r_cart + g_vector
@@ -4405,11 +4400,11 @@ def _update_electron_positions(
             new_r_dn_carts_arr=jnp.expand_dims(proposed_r_dn_carts, axis=0),
         )[0]
 
-        # Determinant part, fast update using the matrix determinant lemma
-        # Cast both lax.cond branches to geminal_inv.dtype: the geminal-diff branch
-        # lives in the geminal zone (fp64) while jax.nn.one_hot defaults to fp32,
-        # so without an explicit cast the cond branches disagree in mixed precision.
-        _gem_dtype = geminal_inv.dtype
+        # Determinant part, fast update using the matrix determinant lemma.
+        # Consumer-zone explicit cast: cast both lax.cond branches to the local
+        # mcmc zone dtype. The geminal-diff branch lives in the det_eval zone
+        # (fp64) while jax.nn.one_hot defaults to fp32, so without an explicit
+        # cast the cond branches disagree in mixed precision.
         v = lax.cond(
             is_up,
             lambda _: jnp.asarray(
@@ -4426,11 +4421,11 @@ def _update_electron_positions(
                         r_dn_carts=r_dn_carts,
                     )
                 )[:, None],
-                dtype=_gem_dtype,
+                dtype=dtype_jnp,
             ),
             lambda _: jnp.asarray(
                 jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],
-                dtype=_gem_dtype,
+                dtype=dtype_jnp,
             ),
             operand=None,
         )
@@ -4439,7 +4434,7 @@ def _update_electron_positions(
             is_up,
             lambda _: jnp.asarray(
                 jax.nn.one_hot(selected_electron_index, num_up_electrons)[:, None],  # (N_up, 1)
-                dtype=_gem_dtype,
+                dtype=dtype_jnp,
             ),
             lambda _: jnp.asarray(
                 (
@@ -4454,7 +4449,7 @@ def _update_electron_positions(
                         r_dn_cart=jnp.reshape(r_dn_carts[selected_electron_index], (1, 3)),
                     )
                 )[:, None],  # -> (N_up, 1)
-                dtype=_gem_dtype,
+                dtype=dtype_jnp,
             ),
             operand=None,
         )
@@ -4490,7 +4485,7 @@ def _update_electron_positions(
         # compute R_ratio
         R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
-        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
+        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype_jnp))
 
         jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
         b = jax.random.uniform(subkey, shape=(), minval=0.0, maxval=1.0)
@@ -4542,11 +4537,11 @@ def _update_electron_positions_only_up_electron(
     geminal_init,
 ):
     """Update electron positions based on the MH method (up-spin electrons only)."""
-    dtype = get_dtype("mcmc")
+    dtype_jnp = jnp.float64
     accepted_moves = 0
     rejected_moves = 0
-    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype)
-    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype)
+    r_up_carts = jnp.asarray(init_r_up_carts, dtype=dtype_jnp)
+    r_dn_carts = jnp.asarray(init_r_dn_carts, dtype=dtype_jnp)
     geminal_inv = geminal_inv_init
     geminal = geminal_init
 
@@ -4596,7 +4591,7 @@ def _update_electron_positions_only_up_electron(
         random_index = jax.random.randint(subkey, shape=(), minval=0, maxval=3)
 
         # plug g into g_vector
-        g_vector = jnp.zeros(3, dtype=dtype)
+        g_vector = jnp.zeros(3, dtype=dtype_jnp)
         g_vector = g_vector.at[random_index].set(g)
 
         new_r_cart = old_r_cart + g_vector
@@ -4630,6 +4625,8 @@ def _update_electron_positions_only_up_electron(
             r_up_carts=r_up_carts,
             r_dn_carts=r_dn_carts,
         )
+        Jastrow_T_p = jnp.asarray(Jastrow_T_p, dtype=dtype_jnp)
+        Jastrow_T_o = jnp.asarray(Jastrow_T_o, dtype=dtype_jnp)
 
         # Determinant part, fast update using the matrix determinant lemma
         v = (
@@ -4655,11 +4652,10 @@ def _update_electron_positions_only_up_electron(
         Det_T_ratio = 1.0 + (v.T @ Ainv_u)[0, 0]  # scalar
 
         # (A+uv^T)^{-1} = A^{-1} - (A^{-1} u v^T A^{-1}) / (1 + v^T A^{-1} u)
-        # Cast back to geminal_inv.dtype: ``v`` originates in the geminal zone (fp64)
-        # while geminal_inv lives in its own zone (e.g. fp32 in mixed precision), so
-        # the rank-1 update would otherwise promote and break the lax.cond dtype
-        # agreement with the rejected branch.
-        geminal_inv_new = jnp.asarray(geminal_inv - (Ainv_u @ vT_Ainv) / Det_T_ratio, dtype=geminal_inv.dtype)
+        # Consumer-zone explicit cast: cast the rank-1 update to the local mcmc
+        # zone dtype so the result agrees with the rejected lax.cond branch and
+        # never depends on geminal_inv's upstream dtype.
+        geminal_inv_new = jnp.asarray(geminal_inv - (Ainv_u @ vT_Ainv) / Det_T_ratio, dtype=dtype_jnp)
 
         geminal_new = geminal.at[selected_electron_index, :].add(v.squeeze(-1))
 
@@ -4672,12 +4668,13 @@ def _update_electron_positions_only_up_electron(
 
         # modified trial WFs
         R_AS_ratio = (R_AS_p_eps / R_AS_p) / (R_AS_o_eps / R_AS_o)
+        Det_T_ratio = jnp.asarray(Det_T_ratio, dtype=dtype_jnp)
         WF_ratio = jnp.exp(Jastrow_T_p - Jastrow_T_o) * (Det_T_ratio)
 
         # compute R_ratio
         R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
-        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
+        acceptance_ratio = jnp.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype_jnp))
 
         jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
         b = jax.random.uniform(subkey, shape=(), minval=0.0, maxval=1.0)
@@ -4834,9 +4831,9 @@ class _MCMC_debug:
             logger.debug(f"  dn counts: {dn_counts}")
             logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
-        dtype = get_dtype("mcmc")
-        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype)
-        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype)
+        dtype_jnp = jnp.float64
+        self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
+        self.__latest_r_dn_carts = jnp.asarray(r_carts_dn, dtype=dtype_jnp)
 
         logger.debug(f"  initial r_up_carts= {self.__latest_r_up_carts}")
         logger.debug(f"  initial r_dn_carts = {self.__latest_r_dn_carts}")
@@ -4921,8 +4918,8 @@ class _MCMC_debug:
         logger.info("This is a debugging class! It supposed to be very slow.")
         logger.info("")
 
-        dtype = get_dtype("mcmc")
-        dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+        dtype_jnp = jnp.float64
+        dtype_np = np.float64
 
         # MAIN MCMC loop from here !!!
         logger.info("Start MCMC")
@@ -5086,7 +5083,7 @@ class _MCMC_debug:
                     R_ratio = (R_AS_ratio * WF_ratio) ** 2.0
 
                     logger.devel(f"R_ratio, T_ratio = {R_ratio}, {T_ratio}")
-                    acceptance_ratio = np.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype))
+                    acceptance_ratio = np.min(jnp.array([1.0, R_ratio * T_ratio], dtype=dtype_jnp))
                     logger.devel(f"acceptance_ratio = {acceptance_ratio}")
 
                     jax_PRNG_key, subkey = jax.random.split(jax_PRNG_key)
@@ -5108,8 +5105,8 @@ class _MCMC_debug:
             # store vmapped outcomes
             self.__accepted_moves = self.__accepted_moves + np.sum(accepted_moves_nw)
             self.__rejected_moves = self.__rejected_moves + np.sum(rejected_moves_nw)
-            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=dtype)
-            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=dtype)
+            self.__latest_r_up_carts = jnp.asarray(latest_r_up_carts, dtype=dtype_jnp)
+            self.__latest_r_dn_carts = jnp.asarray(latest_r_dn_carts, dtype=dtype_jnp)
             self.__jax_PRNG_key_list = jnp.array(jax_PRNG_key_list)
 
             # generate rotation matrices (for non-local ECPs)
@@ -5131,11 +5128,11 @@ class _MCMC_debug:
                             [cos_b * sin_g, cos_a * cos_g + sin_a * sin_b * sin_g, cos_a * sin_b * sin_g - cos_g * sin_a],
                             [-sin_b, cos_b * sin_a, cos_a * cos_b],
                         ],
-                        dtype=dtype,
+                        dtype=dtype_jnp,
                     )
                     RTs.append(R.T)
                 else:
-                    RTs.append(jnp.eye(3, dtype=dtype))
+                    RTs.append(jnp.eye(3, dtype=dtype_jnp))
             RTs = jnp.array(RTs)
 
             # evaluate observables
@@ -5233,10 +5230,10 @@ class _MCMC_debug:
                     n_up = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_up
                     n_dn = self.__hamiltonian_data.wavefunction_data.geminal_data.num_electron_dn
                     n_atoms = self.__hamiltonian_data.structure_data.natom
-                    omega_up = jnp.zeros((self.__num_walkers, n_atoms, n_up), dtype=dtype)
-                    omega_dn = jnp.zeros((self.__num_walkers, n_atoms, n_dn), dtype=dtype)
-                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype)
-                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype)
+                    omega_up = jnp.zeros((self.__num_walkers, n_atoms, n_up), dtype=dtype_jnp)
+                    omega_dn = jnp.zeros((self.__num_walkers, n_atoms, n_dn), dtype=dtype_jnp)
+                    grad_omega_dr_up = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype_jnp)
+                    grad_omega_dr_dn = jnp.zeros((self.__num_walkers, n_atoms, 3), dtype=dtype_jnp)
 
                 self.__stored_omega_up.append(omega_up)
                 self.__stored_omega_dn.append(omega_dn)

--- a/jqmc/jqmc_tool.py
+++ b/jqmc/jqmc_tool.py
@@ -40,22 +40,18 @@ See :mod:`jqmc._precision` for details.
 # POSSIBILITY OF SUCH DAMAGE.
 
 import inspect
-import os
 import re
-import shutil
 import sys
 from enum import Enum
 from logging import Formatter, StreamHandler, getLogger
 from typing import List
 
 import click
+import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
 import tomlkit
 import typer
-
-import jax.numpy as jnp
-
 from uncertainties import ufloat
 
 from ._checkpoint import (
@@ -64,7 +60,6 @@ from ._checkpoint import (
     load_hamiltonian_from_checkpoint,
     load_observables_from_checkpoint,
 )
-from ._precision import get_dtype
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -413,9 +408,9 @@ def trexio_convert_to(
 
             # 10) Reconstruct all common dataclass fields for the new AO object
             new_orbital_indices = [new_idx_map[aos_data.orbital_indices[p]] for p in new_prims]
-            dtype_io = get_dtype("io")
-            new_exponents = jnp.array([float(aos_data.exponents[p]) for p in new_prims], dtype=dtype_io)
-            new_coefficients = jnp.array([float(aos_data.coefficients[p]) for p in new_prims], dtype=dtype_io)
+            dtype_io_jnp = jnp.float64
+            new_exponents = jnp.array([float(aos_data.exponents[p]) for p in new_prims], dtype=dtype_io_jnp)
+            new_coefficients = jnp.array([float(aos_data.coefficients[p]) for p in new_prims], dtype=dtype_io_jnp)
             new_nucleus_index = [aos_data.nucleus_index[i] for i in selected_ao_indices]
             new_angular_momentums = [aos_data.angular_momentums[i] for i in selected_ao_indices]
 

--- a/jqmc/jqmc_tool.py
+++ b/jqmc/jqmc_tool.py
@@ -1,4 +1,10 @@
-"""jQMC tools."""
+"""jQMC tools.
+
+Precision Zones:
+    - ``io``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 
 # Copyright (C) 2024- Kosuke Nakano
@@ -58,6 +64,7 @@ from ._checkpoint import (
     load_hamiltonian_from_checkpoint,
     load_observables_from_checkpoint,
 )
+from ._precision import get_dtype
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
     GFMC_MIN_COLLECT_STEPS,
@@ -406,8 +413,9 @@ def trexio_convert_to(
 
             # 10) Reconstruct all common dataclass fields for the new AO object
             new_orbital_indices = [new_idx_map[aos_data.orbital_indices[p]] for p in new_prims]
-            new_exponents = jnp.array([float(aos_data.exponents[p]) for p in new_prims], dtype=jnp.float64)
-            new_coefficients = jnp.array([float(aos_data.coefficients[p]) for p in new_prims], dtype=jnp.float64)
+            dtype_io = get_dtype("io")
+            new_exponents = jnp.array([float(aos_data.exponents[p]) for p in new_prims], dtype=dtype_io)
+            new_coefficients = jnp.array([float(aos_data.coefficients[p]) for p in new_prims], dtype=dtype_io)
             new_nucleus_index = [aos_data.nucleus_index[i] for i in selected_ao_indices]
             new_angular_momentums = [aos_data.angular_momentums[i] for i in selected_ao_indices]
 

--- a/jqmc/molecular_orbital.py
+++ b/jqmc/molecular_orbital.py
@@ -2,7 +2,8 @@
 
 Precision Zones:
     - ``mo_eval``: forward MO evaluation (compute_MOs).
-    - ``mo_grad_lap``: MO gradient and Laplacian (compute_MOs_grad, compute_MOs_laplacian).
+    - ``mo_grad``: MO gradient (compute_MOs_grad).
+    - ``mo_lap``: MO Laplacian (compute_MOs_laplacian).
 
 See :mod:`jqmc._precision` for details.
 """
@@ -285,10 +286,10 @@ def compute_MOs_laplacian(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     Returns:
         jax.Array: Laplacians of each MO, shape ``(num_mo, N_e)``.
     """
-    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    dtype_jnp = get_dtype_jnp("mo_lap")
     mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     ao_lap = compute_AOs_laplacian(mos_data.aos_data, r_carts)
-    # ao_lap lives in the ao_grad_lap zone; cast to mo_grad_lap at the use site
+    # ao_lap lives in the ao_lap zone; cast to mo_lap at the use site
     # (Principle 3b — cast operands to this function's own zone immediately
     # before consuming them as arithmetic operands).
     return jnp.dot(mo_coefficients, ao_lap.astype(dtype_jnp))
@@ -352,10 +353,10 @@ def compute_MOs_grad(
         tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]: Gradients per component
         ``(grad_x, grad_y, grad_z)``, each of shape ``(num_mo, N_e)``.
     """
-    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    dtype_jnp = get_dtype_jnp("mo_grad")
     mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = compute_AOs_grad(mos_data.aos_data, r_carts)
-    # AO gradient outputs live in the ao_grad_lap zone; cast to mo_grad_lap at the
+    # AO gradient outputs live in the ao_grad zone; cast to mo_grad at the
     # use site (Principle 3b — cast operands to this function's own zone immediately
     # before consuming them as arithmetic operands).
     mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x.astype(dtype_jnp))
@@ -374,10 +375,10 @@ def _compute_MOs_grad_autodiff(
     npt.NDArray[np.float64],
 ]:
     """This method is for computing the gradients (x,y,z) of the given molecular orbital at r_carts."""
-    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    dtype_jnp = get_dtype_jnp("mo_grad")
     mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = _compute_AOs_grad_autodiff(mos_data.aos_data, r_carts)
-    # AO gradient outputs live in the ao_grad_lap zone; cast to mo_grad_lap at the
+    # AO gradient outputs live in the ao_grad zone; cast to mo_grad at the
     # use site (Principle 3b).
     mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x.astype(dtype_jnp))
     mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y.astype(dtype_jnp))

--- a/jqmc/molecular_orbital.py
+++ b/jqmc/molecular_orbital.py
@@ -232,8 +232,10 @@ def compute_MOs(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     Returns:
         jax.Array: MO values with shape ``(num_mo, N_e)``.
     """
+    dtype = get_dtype("orb_eval")
+    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
     answer = jnp.dot(
-        mos_data.mo_coefficients,
+        mo_coefficients,
         compute_AOs(aos_data=mos_data.aos_data, r_carts=r_carts),
     )
 
@@ -271,8 +273,10 @@ def compute_MOs_laplacian(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     Returns:
         jax.Array: Laplacians of each MO, shape ``(num_mo, N_e)``.
     """
+    dtype = get_dtype("kinetic")
+    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
     ao_lap = compute_AOs_laplacian(mos_data.aos_data, r_carts)
-    return jnp.dot(mos_data.mo_coefficients, ao_lap)
+    return jnp.dot(mo_coefficients, ao_lap)
 
 
 def _compute_MOs_laplacian_debug(mos_data: MOs_data, r_carts: npt.NDArray[np.float64]):
@@ -333,10 +337,12 @@ def compute_MOs_grad(
         tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]: Gradients per component
         ``(grad_x, grad_y, grad_z)``, each of shape ``(num_mo, N_e)``.
     """
+    dtype = get_dtype("kinetic")
+    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = compute_AOs_grad(mos_data.aos_data, r_carts)
-    mo_matrix_grad_x = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_x)
-    mo_matrix_grad_y = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_y)
-    mo_matrix_grad_z = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_z)
+    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x)
+    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y)
+    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z)
 
     return mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z
 
@@ -350,10 +356,12 @@ def _compute_MOs_grad_autodiff(
     npt.NDArray[np.float64],
 ]:
     """This method is for computing the gradients (x,y,z) of the given molecular orbital at r_carts."""
+    dtype = get_dtype("kinetic")
+    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = _compute_AOs_grad_autodiff(mos_data.aos_data, r_carts)
-    mo_matrix_grad_x = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_x)
-    mo_matrix_grad_y = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_y)
-    mo_matrix_grad_z = jnp.dot(mos_data.mo_coefficients, mo_matrix_grad_z)
+    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x)
+    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y)
+    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z)
 
     return mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z
 

--- a/jqmc/molecular_orbital.py
+++ b/jqmc/molecular_orbital.py
@@ -1,4 +1,11 @@
-"""Molecular Orbital module."""
+"""Molecular Orbital module.
+
+Precision Zones:
+    - ``orb_eval``: forward MO evaluation (compute_MOs).
+    - ``kinetic``: MO gradient and Laplacian (compute_MOs_grad, compute_MOs_laplacian).
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -46,6 +53,7 @@ from jax import jit
 from jax import typing as jnpt
 
 # myqmc module
+from ._precision import get_dtype
 from .atomic_orbital import (
     AOs_cart_data,
     AOs_sphe_data,
@@ -180,8 +188,9 @@ class MOs_data:
             return self
         if not isinstance(self.aos_data, AOs_sphe_data):
             raise ValueError("Cartesian conversion is only available from spherical AOs.")
+        dtype = get_dtype("orb_eval")
         aos_cart, transform_matrix = _aos_sphe_to_cart(self.aos_data)
-        cart_coeffs = np.asarray(self.mo_coefficients, dtype=np.float64) @ transform_matrix
+        cart_coeffs = np.asarray(self.mo_coefficients, dtype=dtype) @ transform_matrix
         cart_coeffs = cart_coeffs.astype(np.asarray(self.mo_coefficients).dtype, copy=False)
 
         return MOs_data(num_mo=self.num_mo, aos_data=aos_cart, mo_coefficients=cart_coeffs)
@@ -203,8 +212,9 @@ class MOs_data:
             return self
         if not isinstance(self.aos_data, AOs_cart_data):
             raise ValueError("Spherical conversion is only available from Cartesian AOs.")
+        dtype = get_dtype("orb_eval")
         aos_sphe, transform_pinv = _aos_cart_to_sphe(self.aos_data)
-        sph_coeffs = np.asarray(self.mo_coefficients, dtype=np.float64) @ transform_pinv
+        sph_coeffs = np.asarray(self.mo_coefficients, dtype=dtype) @ transform_pinv
         sph_coeffs = sph_coeffs.astype(np.asarray(self.mo_coefficients).dtype, copy=False)
 
         return MOs_data(num_mo=self.num_mo, aos_data=aos_sphe, mo_coefficients=sph_coeffs)

--- a/jqmc/molecular_orbital.py
+++ b/jqmc/molecular_orbital.py
@@ -1,8 +1,8 @@
 """Molecular Orbital module.
 
 Precision Zones:
-    - ``orb_eval``: forward MO evaluation (compute_MOs).
-    - ``kinetic``: MO gradient and Laplacian (compute_MOs_grad, compute_MOs_laplacian).
+    - ``mo_eval``: forward MO evaluation (compute_MOs).
+    - ``mo_grad_lap``: MO gradient and Laplacian (compute_MOs_grad, compute_MOs_laplacian).
 
 See :mod:`jqmc._precision` for details.
 """
@@ -50,10 +50,11 @@ import numpy as np
 import numpy.typing as npt
 from flax import struct
 from jax import jit
-from jax import typing as jnpt
+
+from ._jqmc_utility import _cart_to_spherical_matrix, _spherical_to_cart_matrix  # noqa: F401
 
 # myqmc module
-from ._precision import get_dtype
+from ._precision import get_dtype_jnp
 from .atomic_orbital import (
     AOs_cart_data,
     AOs_sphe_data,
@@ -66,7 +67,6 @@ from .atomic_orbital import (
     compute_AOs_grad,
     compute_AOs_laplacian,
 )
-from ._jqmc_utility import _cart_to_spherical_matrix, _spherical_to_cart_matrix  # noqa: F401
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -86,8 +86,8 @@ class MOs_data:
         num_mo (int): Number of molecular orbitals.
         aos_data (AOs_sphe_data | AOs_cart_data): AO definition supplying centers, exponents/coefficients,
             angular data, and contraction mapping.
-        mo_coefficients (npt.NDArray | jax.Array): Coefficient matrix of shape ``(num_mo, num_ao)``. Rows
-            correspond to MOs; columns correspond to contracted AOs.
+        mo_coefficients (npt.NDArray[np.float64]): Coefficient matrix of shape ``(num_mo, num_ao)``. Rows
+            correspond to MOs; columns correspond to contracted AOs. dtype: float64.
 
     Examples:
         Minimal runnable setup (2 AOs -> 1 MO)::
@@ -127,8 +127,10 @@ class MOs_data:
     num_mo: int = struct.field(pytree_node=False, default=0)
     #: AO definition supplying centers, exponents/coefficients, angular data, and contraction mapping.
     aos_data: AOs_sphe_data | AOs_cart_data = struct.field(pytree_node=True, default_factory=lambda: AOs_sphe_data())
-    #: MO coefficient matrix, shape ``(num_mo, num_ao)``.
-    mo_coefficients: npt.NDArray | jnpt.ArrayLike = struct.field(pytree_node=True, default_factory=lambda: np.array([]))
+    #: MO coefficient matrix, shape ``(num_mo, num_ao)``. dtype: float64.
+    mo_coefficients: npt.NDArray[np.float64] = struct.field(
+        pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64)
+    )
 
     def sanity_check(self) -> None:
         """Validate internal consistency.
@@ -172,6 +174,13 @@ class MOs_data:
         """Return the number of orbitals."""
         return self.num_mo
 
+    @property
+    def _mo_coefficients_jnp(self) -> jax.Array:
+        """Return MO coefficients as a jax.Array (jnp view of the underlying numpy storage)."""
+        # Lift-only fp64 basis-data storage accessor (see _precision.py exemption);
+        # consumer casts to its own zone at use site.
+        return jnp.asarray(self.mo_coefficients, dtype=jnp.float64)
+
     def to_cartesian(self) -> "MOs_data":
         """Convert spherical AOs to Cartesian AOs and transform MO coefficients.
 
@@ -188,9 +197,9 @@ class MOs_data:
             return self
         if not isinstance(self.aos_data, AOs_sphe_data):
             raise ValueError("Cartesian conversion is only available from spherical AOs.")
-        dtype = get_dtype("orb_eval")
+        dtype_np = np.dtype(get_dtype_jnp("mo_eval"))
         aos_cart, transform_matrix = _aos_sphe_to_cart(self.aos_data)
-        cart_coeffs = np.asarray(self.mo_coefficients, dtype=dtype) @ transform_matrix
+        cart_coeffs = np.asarray(self.mo_coefficients, dtype=dtype_np) @ transform_matrix
         cart_coeffs = cart_coeffs.astype(np.asarray(self.mo_coefficients).dtype, copy=False)
 
         return MOs_data(num_mo=self.num_mo, aos_data=aos_cart, mo_coefficients=cart_coeffs)
@@ -212,9 +221,9 @@ class MOs_data:
             return self
         if not isinstance(self.aos_data, AOs_cart_data):
             raise ValueError("Spherical conversion is only available from Cartesian AOs.")
-        dtype = get_dtype("orb_eval")
+        dtype_np = np.dtype(get_dtype_jnp("mo_eval"))
         aos_sphe, transform_pinv = _aos_cart_to_sphe(self.aos_data)
-        sph_coeffs = np.asarray(self.mo_coefficients, dtype=dtype) @ transform_pinv
+        sph_coeffs = np.asarray(self.mo_coefficients, dtype=dtype_np) @ transform_pinv
         sph_coeffs = sph_coeffs.astype(np.asarray(self.mo_coefficients).dtype, copy=False)
 
         return MOs_data(num_mo=self.num_mo, aos_data=aos_sphe, mo_coefficients=sph_coeffs)
@@ -237,9 +246,9 @@ def compute_MOs(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     # ``determinant`` precision (fp64 by default).  This avoids amplifying fp32
     # round-off through downstream determinant / kinetic / energy paths while
     # preserving the speed of the AO kernels (see bug/fp32 diagnostics).
-    out_dtype = get_dtype("determinant")
+    out_dtype = get_dtype_jnp("mo_eval")
     aos = compute_AOs(aos_data=mos_data.aos_data, r_carts=r_carts).astype(out_dtype)
-    mo_coefficients = mos_data.mo_coefficients.astype(out_dtype)
+    mo_coefficients = mos_data._mo_coefficients_jnp.astype(out_dtype)
     answer = jnp.dot(mo_coefficients, aos)
 
     return answer
@@ -258,7 +267,7 @@ def _compute_MOs_debug(mos_data: MOs_data, r_carts: npt.NDArray[np.float64]) -> 
 def _compute_MOs_laplacian_autodiff(mos_data: MOs_data, r_carts: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
     """See _api method."""
     mo_matrix_laplacian = jnp.dot(
-        mos_data.mo_coefficients,
+        mos_data._mo_coefficients_jnp,
         _compute_AOs_laplacian_autodiff(mos_data.aos_data, r_carts),
     )
 
@@ -276,10 +285,13 @@ def compute_MOs_laplacian(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     Returns:
         jax.Array: Laplacians of each MO, shape ``(num_mo, N_e)``.
     """
-    dtype = get_dtype("kinetic")
-    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
+    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     ao_lap = compute_AOs_laplacian(mos_data.aos_data, r_carts)
-    return jnp.dot(mo_coefficients, ao_lap)
+    # ao_lap lives in the ao_grad_lap zone; cast to mo_grad_lap at the use site
+    # (Principle 3b — cast operands to this function's own zone immediately
+    # before consuming them as arithmetic operands).
+    return jnp.dot(mo_coefficients, ao_lap.astype(dtype_jnp))
 
 
 def _compute_MOs_laplacian_debug(mos_data: MOs_data, r_carts: npt.NDArray[np.float64]):
@@ -340,12 +352,15 @@ def compute_MOs_grad(
         tuple[npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]: Gradients per component
         ``(grad_x, grad_y, grad_z)``, each of shape ``(num_mo, N_e)``.
     """
-    dtype = get_dtype("kinetic")
-    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
+    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = compute_AOs_grad(mos_data.aos_data, r_carts)
-    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x)
-    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y)
-    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z)
+    # AO gradient outputs live in the ao_grad_lap zone; cast to mo_grad_lap at the
+    # use site (Principle 3b — cast operands to this function's own zone immediately
+    # before consuming them as arithmetic operands).
+    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x.astype(dtype_jnp))
+    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y.astype(dtype_jnp))
+    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z.astype(dtype_jnp))
 
     return mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z
 
@@ -359,12 +374,14 @@ def _compute_MOs_grad_autodiff(
     npt.NDArray[np.float64],
 ]:
     """This method is for computing the gradients (x,y,z) of the given molecular orbital at r_carts."""
-    dtype = get_dtype("kinetic")
-    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
+    dtype_jnp = get_dtype_jnp("mo_grad_lap")
+    mo_coefficients = mos_data._mo_coefficients_jnp.astype(dtype_jnp)
     mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z = _compute_AOs_grad_autodiff(mos_data.aos_data, r_carts)
-    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x)
-    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y)
-    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z)
+    # AO gradient outputs live in the ao_grad_lap zone; cast to mo_grad_lap at the
+    # use site (Principle 3b).
+    mo_matrix_grad_x = jnp.dot(mo_coefficients, mo_matrix_grad_x.astype(dtype_jnp))
+    mo_matrix_grad_y = jnp.dot(mo_coefficients, mo_matrix_grad_y.astype(dtype_jnp))
+    mo_matrix_grad_z = jnp.dot(mo_coefficients, mo_matrix_grad_z.astype(dtype_jnp))
 
     return mo_matrix_grad_x, mo_matrix_grad_y, mo_matrix_grad_z
 

--- a/jqmc/molecular_orbital.py
+++ b/jqmc/molecular_orbital.py
@@ -232,12 +232,15 @@ def compute_MOs(mos_data: MOs_data, r_carts: jax.Array) -> jax.Array:
     Returns:
         jax.Array: MO values with shape ``(num_mo, N_e)``.
     """
-    dtype = get_dtype("orb_eval")
-    mo_coefficients = mos_data.mo_coefficients.astype(dtype)
-    answer = jnp.dot(
-        mo_coefficients,
-        compute_AOs(aos_data=mos_data.aos_data, r_carts=r_carts),
-    )
+    # Heavy AO evaluation runs in ``orb_eval`` precision (e.g. fp32 in mixed mode),
+    # but the (small) MO matmul and the returned MO matrix are kept in the
+    # ``determinant`` precision (fp64 by default).  This avoids amplifying fp32
+    # round-off through downstream determinant / kinetic / energy paths while
+    # preserving the speed of the AO kernels (see bug/fp32 diagnostics).
+    out_dtype = get_dtype("determinant")
+    aos = compute_AOs(aos_data=mos_data.aos_data, r_carts=r_carts).astype(out_dtype)
+    mo_coefficients = mos_data.mo_coefficients.astype(out_dtype)
+    answer = jnp.dot(mo_coefficients, aos)
 
     return answer
 

--- a/jqmc/structure.py
+++ b/jqmc/structure.py
@@ -466,9 +466,11 @@ def _get_min_dist_rel_R_cart_jnp(
     """
     if dtype is None:
         dtype = get_dtype("io")
-    r_cart = jnp.array(r_cart, dtype=dtype)
-    R_cart = jnp.array(structure_data._positions_cart_jnp[i_atom], dtype=dtype)
-    diff = R_cart - r_cart
+    # Compute R - r in float64 to avoid catastrophic cancellation under float32 zones,
+    # then downcast.
+    _r_f64 = jnp.asarray(r_cart, dtype=jnp.float64)
+    _R_f64 = jnp.asarray(structure_data._positions_cart_jnp[i_atom], dtype=jnp.float64)
+    diff = (_R_f64 - _r_f64).astype(dtype)
     if structure_data.pbc_flag:
         cell = jnp.array(structure_data.cell, dtype=dtype)
         inv_cell = jnp.linalg.inv(cell)

--- a/jqmc/structure.py
+++ b/jqmc/structure.py
@@ -50,10 +50,7 @@ import numpy.typing as npt
 from flax import struct
 from jax import jit
 from jax import numpy as jnp
-from jax import typing as jnpt
 from numpy import linalg as LA
-
-from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -73,7 +70,7 @@ class Structure_data:
     element metadata used by AOs/MOs, Coulomb, and Hamiltonian builders.
 
     Attributes:
-        positions (npt.NDArray | jax.Array): Atomic Cartesian coordinates with shape ``(N, 3)`` in Bohr.
+        positions (npt.NDArray[np.float64]): Atomic Cartesian coordinates with shape ``(N, 3)`` in Bohr. dtype: float64.
         pbc_flag (bool): Whether periodic boundary conditions are active. If ``True``, lattice
             vectors ``vec_a|b|c`` must be provided; otherwise they must be empty.
         vec_a (list[float] | tuple[float]): Lattice vector **a** (Bohr) when ``pbc_flag=True``.
@@ -99,8 +96,8 @@ class Structure_data:
             structure.sanity_check()
     """
 
-    #: Atomic Cartesian coordinates with shape ``(N, 3)`` in Bohr.
-    positions: npt.NDArray | jnpt.ArrayLike = struct.field(pytree_node=True, default_factory=lambda: np.array([]))
+    #: Atomic Cartesian coordinates with shape ``(N, 3)`` in Bohr. dtype: float64.
+    positions: npt.NDArray[np.float64] = struct.field(pytree_node=True, default_factory=lambda: np.array([], dtype=np.float64))
     #: Whether periodic boundary conditions are active.
     pbc_flag: bool = struct.field(pytree_node=False, default=False)
     #: Lattice vector **a** in Bohr (requires ``pbc_flag=True``).
@@ -189,8 +186,8 @@ class Structure_data:
     @property
     def cell(self) -> npt.NDArray:
         """Lattice vectors as a ``(3, 3)`` matrix in Bohr (``[a, b, c]``)."""
-        dtype = get_dtype("io")
-        cell = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype)
+        dtype_np = np.float64
+        cell = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype_np)
         return cell
 
     @property
@@ -206,10 +203,10 @@ class Structure_data:
 
         and asserts the orthonormality condition :math:`T_i \cdot G_j = 2\pi\,\delta_{ij}`.
         """
-        dtype = get_dtype("io")
-        va = np.asarray(self.vec_a, dtype=dtype)
-        vb = np.asarray(self.vec_b, dtype=dtype)
-        vc = np.asarray(self.vec_c, dtype=dtype)
+        dtype_np = np.float64
+        va = np.asarray(self.vec_a, dtype=dtype_np)
+        vb = np.asarray(self.vec_b, dtype=dtype_np)
+        vc = np.asarray(self.vec_c, dtype=dtype_np)
         recip_a = 2 * np.pi * (np.cross(vb, vc)) / (np.dot(va, np.cross(vb, vc)))
         recip_b = 2 * np.pi * (np.cross(vc, va)) / (np.dot(vb, np.cross(vc, va)))
         recip_c = 2 * np.pi * (np.cross(va, vb)) / (np.dot(vc, np.cross(va, vb)))
@@ -225,7 +222,7 @@ class Structure_data:
             else:
                 np.testing.assert_almost_equal(np.dot(lattice_vec, recip_vec), 0.0, decimal=15)
 
-        recip_cell = np.array([recip_a, recip_b, recip_c], dtype=dtype)
+        recip_cell = np.array([recip_a, recip_b, recip_c], dtype=dtype_np)
         return recip_cell
 
     @property
@@ -321,23 +318,23 @@ class Structure_data:
     @property
     def _positions_cart_np(self) -> npt.NDArray:
         """Atomic positions as ``numpy.ndarray`` with shape ``(N, 3)`` in Bohr."""
-        dtype = get_dtype("io")
-        return np.array(self.positions, dtype=dtype)
+        dtype_np = np.float64
+        return np.array(self.positions, dtype=dtype_np)
 
     @property
     def _positions_cart_jnp(self) -> jax.Array:
         """Atomic positions as ``jax.Array`` with shape ``(N, 3)`` in Bohr."""
-        dtype = get_dtype("io")
-        return jnp.array(self.positions, dtype=dtype)
+        dtype_jnp = jnp.float64
+        return jnp.array(self.positions, dtype=dtype_jnp)
 
     @property
     def _positions_frac_np(self) -> npt.NDArray:
         """Fractional (crystal) coordinates as ``numpy.ndarray`` with shape ``(N, 3)``."""
-        dtype = get_dtype("io")
-        h = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype)
+        dtype_np = np.float64
+        h = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype_np)
         positions_frac = np.array(
-            [np.dot(np.asarray(pos, dtype=dtype), np.linalg.inv(h)) for pos in self._positions_cart_np],
-            dtype=dtype,
+            [np.dot(np.asarray(pos, dtype=dtype_np), np.linalg.inv(h)) for pos in self._positions_cart_np],
+            dtype=dtype_np,
         )
         return positions_frac
 
@@ -394,9 +391,9 @@ def _find_nearest_index_jnp(structure: Structure_data, r_cart: list[float]) -> i
 
 def _find_nearest_nucleus_indices_np(structure_data: Structure_data, r_cart, N):
     """See find_nearest_index."""
-    dtype = get_dtype("io")
+    dtype_np = np.float64
     positions = structure_data._positions_cart_np
-    r_cart = np.array(r_cart, dtype=dtype)
+    r_cart = np.array(r_cart, dtype=dtype_np)
     diffs = positions - r_cart
     if structure_data.pbc_flag:
         cell = structure_data.cell
@@ -413,12 +410,12 @@ def _find_nearest_nucleus_indices_np(structure_data: Structure_data, r_cart, N):
 @partial(jit, static_argnums=2)
 def _find_nearest_nucleus_indices_jnp(structure_data: Structure_data, r_cart, N):
     """See find_nearest_index."""
-    dtype = get_dtype("io")
+    dtype_jnp = jnp.float64
     positions = structure_data._positions_cart_jnp
-    r_cart = jnp.array(r_cart, dtype=dtype)
+    r_cart = jnp.array(r_cart, dtype=dtype_jnp)
     diffs = positions - r_cart
     if structure_data.pbc_flag:
-        cell = jnp.array(structure_data.cell, dtype=dtype)
+        cell = jnp.array(structure_data.cell, dtype=dtype_jnp)
         inv_cell = jnp.linalg.inv(cell)
         diffs_frac = diffs @ inv_cell
         diffs_frac = diffs_frac - jnp.round(diffs_frac)
@@ -442,8 +439,8 @@ def _get_min_dist_rel_R_cart_np(structure_data: Structure_data, r_cart: list[flo
         with respect to the given r_cart in cartesian. The unit is Bohr
 
     """
-    dtype = get_dtype("io")
-    r_cart = np.array(r_cart, dtype=dtype)
+    dtype_np = np.float64
+    r_cart = np.array(r_cart, dtype=dtype_np)
     R_cart = structure_data._positions_cart_np[i_atom]
     diff = R_cart - r_cart
     if structure_data.pbc_flag:
@@ -465,12 +462,12 @@ def _get_min_dist_rel_R_cart_jnp(
     (e.g. ``jnp.float32``) and cannot be traced as an abstract array.
     """
     if dtype is None:
-        dtype = get_dtype("io")
-    # Compute R - r in float64 to avoid catastrophic cancellation under float32 zones,
-    # then downcast.
-    _r_f64 = jnp.asarray(r_cart, dtype=jnp.float64)
-    _R_f64 = jnp.asarray(structure_data._positions_cart_jnp[i_atom], dtype=jnp.float64)
-    diff = (_R_f64 - _r_f64).astype(dtype)
+        dtype = jnp.float64
+    # Subtract in the passed dtype (the caller chain is responsible for keeping
+    # high precision up to this point — see Principle 3b in jqmc._precision)
+    # and cast only the *result* down to the local zone.
+    R_cart = structure_data._positions_cart_jnp[i_atom]
+    diff = (R_cart - r_cart).astype(dtype)
     if structure_data.pbc_flag:
         cell = jnp.array(structure_data.cell, dtype=dtype)
         inv_cell = jnp.linalg.inv(cell)

--- a/jqmc/structure.py
+++ b/jqmc/structure.py
@@ -1,4 +1,10 @@
-"""Structure module."""
+"""Structure module.
+
+Precision Zones:
+    - ``io``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -46,6 +52,8 @@ from jax import jit
 from jax import numpy as jnp
 from jax import typing as jnpt
 from numpy import linalg as LA
+
+from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -179,13 +187,14 @@ class Structure_data:
             logger.info(line)
 
     @property
-    def cell(self) -> npt.NDArray[np.float64]:
+    def cell(self) -> npt.NDArray:
         """Lattice vectors as a ``(3, 3)`` matrix in Bohr (``[a, b, c]``)."""
-        cell = np.array([self.vec_a, self.vec_b, self.vec_c])
+        dtype = get_dtype("io")
+        cell = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype)
         return cell
 
     @property
-    def recip_cell(self) -> npt.NDArray[np.float64]:
+    def recip_cell(self) -> npt.NDArray:
         r"""Reciprocal lattice vectors ``(3, 3)`` in Bohr^{-1}.
 
         Uses the standard definition
@@ -197,12 +206,16 @@ class Structure_data:
 
         and asserts the orthonormality condition :math:`T_i \cdot G_j = 2\pi\,\delta_{ij}`.
         """
-        recip_a = 2 * np.pi * (np.cross(self.vec_b, self.vec_c)) / (np.dot(self.vec_a, np.cross(self.vec_b, self.vec_c)))
-        recip_b = 2 * np.pi * (np.cross(self.vec_c, self.vec_a)) / (np.dot(self.vec_b, np.cross(self.vec_c, self.vec_a)))
-        recip_c = 2 * np.pi * (np.cross(self.vec_a, self.vec_b)) / (np.dot(self.vec_c, np.cross(self.vec_a, self.vec_b)))
+        dtype = get_dtype("io")
+        va = np.asarray(self.vec_a, dtype=dtype)
+        vb = np.asarray(self.vec_b, dtype=dtype)
+        vc = np.asarray(self.vec_c, dtype=dtype)
+        recip_a = 2 * np.pi * (np.cross(vb, vc)) / (np.dot(va, np.cross(vb, vc)))
+        recip_b = 2 * np.pi * (np.cross(vc, va)) / (np.dot(vb, np.cross(vc, va)))
+        recip_c = 2 * np.pi * (np.cross(va, vb)) / (np.dot(vc, np.cross(va, vb)))
 
         # check if the implementations are correct
-        lattice_vec_list = [self.vec_a, self.vec_b, self.vec_c]
+        lattice_vec_list = [va, vb, vc]
         recip_vec_list = [recip_a, recip_b, recip_c]
         for (lattice_vec_i, lattice_vec), (recip_vec_j, recip_vec) in itertools.product(
             enumerate(lattice_vec_list), enumerate(recip_vec_list)
@@ -212,7 +225,7 @@ class Structure_data:
             else:
                 np.testing.assert_almost_equal(np.dot(lattice_vec, recip_vec), 0.0, decimal=15)
 
-        recip_cell = np.array([recip_a, recip_b, recip_c])
+        recip_cell = np.array([recip_a, recip_b, recip_c], dtype=dtype)
         return recip_cell
 
     @property
@@ -306,20 +319,26 @@ class Structure_data:
         return LA.norm(self.vec_c)
 
     @property
-    def _positions_cart_np(self) -> npt.NDArray[np.float64]:
+    def _positions_cart_np(self) -> npt.NDArray:
         """Atomic positions as ``numpy.ndarray`` with shape ``(N, 3)`` in Bohr."""
-        return np.array(self.positions)
+        dtype = get_dtype("io")
+        return np.array(self.positions, dtype=dtype)
 
     @property
     def _positions_cart_jnp(self) -> jax.Array:
         """Atomic positions as ``jax.Array`` with shape ``(N, 3)`` in Bohr."""
-        return jnp.array(self.positions)
+        dtype = get_dtype("io")
+        return jnp.array(self.positions, dtype=dtype)
 
     @property
-    def _positions_frac_np(self) -> npt.NDArray[np.float64]:
+    def _positions_frac_np(self) -> npt.NDArray:
         """Fractional (crystal) coordinates as ``numpy.ndarray`` with shape ``(N, 3)``."""
-        h = np.array([self.vec_a, self.vec_b, self.vec_c])
-        positions_frac = np.array([np.dot(np.array(pos), np.linalg.inv(h)) for pos in self._positions_cart_np])
+        dtype = get_dtype("io")
+        h = np.array([self.vec_a, self.vec_b, self.vec_c], dtype=dtype)
+        positions_frac = np.array(
+            [np.dot(np.asarray(pos, dtype=dtype), np.linalg.inv(h)) for pos in self._positions_cart_np],
+            dtype=dtype,
+        )
         return positions_frac
 
     @property
@@ -375,8 +394,9 @@ def _find_nearest_index_jnp(structure: Structure_data, r_cart: list[float]) -> i
 
 def _find_nearest_nucleus_indices_np(structure_data: Structure_data, r_cart, N):
     """See find_nearest_index."""
+    dtype = get_dtype("io")
     positions = structure_data._positions_cart_np
-    r_cart = np.array(r_cart)
+    r_cart = np.array(r_cart, dtype=dtype)
     diffs = positions - r_cart
     if structure_data.pbc_flag:
         cell = structure_data.cell
@@ -393,11 +413,12 @@ def _find_nearest_nucleus_indices_np(structure_data: Structure_data, r_cart, N):
 @partial(jit, static_argnums=2)
 def _find_nearest_nucleus_indices_jnp(structure_data: Structure_data, r_cart, N):
     """See find_nearest_index."""
+    dtype = get_dtype("io")
     positions = structure_data._positions_cart_jnp
-    r_cart = jnp.array(r_cart)
+    r_cart = jnp.array(r_cart, dtype=dtype)
     diffs = positions - r_cart
     if structure_data.pbc_flag:
-        cell = jnp.array(structure_data.cell)
+        cell = jnp.array(structure_data.cell, dtype=dtype)
         inv_cell = jnp.linalg.inv(cell)
         diffs_frac = diffs @ inv_cell
         diffs_frac = diffs_frac - jnp.round(diffs_frac)
@@ -421,7 +442,8 @@ def _get_min_dist_rel_R_cart_np(structure_data: Structure_data, r_cart: list[flo
         with respect to the given r_cart in cartesian. The unit is Bohr
 
     """
-    r_cart = np.array(r_cart)
+    dtype = get_dtype("io")
+    r_cart = np.array(r_cart, dtype=dtype)
     R_cart = structure_data._positions_cart_np[i_atom]
     diff = R_cart - r_cart
     if structure_data.pbc_flag:
@@ -436,11 +458,12 @@ def _get_min_dist_rel_R_cart_np(structure_data: Structure_data, r_cart: list[flo
 @jit
 def _get_min_dist_rel_R_cart_jnp(structure_data: Structure_data, r_cart: list[float, float, float], i_atom: int) -> float:
     """See get_min_dist_rel_R_cart_np."""
-    r_cart = jnp.array(r_cart)
-    R_cart = jnp.array(structure_data._positions_cart_jnp[i_atom])
+    dtype = get_dtype("io")
+    r_cart = jnp.array(r_cart, dtype=dtype)
+    R_cart = jnp.array(structure_data._positions_cart_jnp[i_atom], dtype=dtype)
     diff = R_cart - r_cart
     if structure_data.pbc_flag:
-        cell = jnp.array(structure_data.cell)
+        cell = jnp.array(structure_data.cell, dtype=dtype)
         inv_cell = jnp.linalg.inv(cell)
         diff_frac = diff @ inv_cell
         diff_frac = diff_frac - jnp.round(diff_frac)

--- a/jqmc/structure.py
+++ b/jqmc/structure.py
@@ -455,10 +455,17 @@ def _get_min_dist_rel_R_cart_np(structure_data: Structure_data, r_cart: list[flo
     return diff
 
 
-@jit
-def _get_min_dist_rel_R_cart_jnp(structure_data: Structure_data, r_cart: list[float, float, float], i_atom: int) -> float:
-    """See get_min_dist_rel_R_cart_np."""
-    dtype = get_dtype("io")
+@partial(jit, static_argnames=("dtype",))
+def _get_min_dist_rel_R_cart_jnp(
+    structure_data: Structure_data, r_cart: list[float, float, float], i_atom: int, dtype=None
+) -> float:
+    """See get_min_dist_rel_R_cart_np.
+
+    ``dtype`` is marked static for ``jit`` because it is a Python scalar type
+    (e.g. ``jnp.float32``) and cannot be traced as an abstract array.
+    """
+    if dtype is None:
+        dtype = get_dtype("io")
     r_cart = jnp.array(r_cart, dtype=dtype)
     R_cart = jnp.array(structure_data._positions_cart_jnp[i_atom], dtype=dtype)
     diff = R_cart - r_cart

--- a/jqmc/swct.py
+++ b/jqmc/swct.py
@@ -48,10 +48,9 @@ import numpy as np
 import numpy.typing as npt
 from jax import jacrev, jit, vmap
 from jax import numpy as jnp
-from jax import typing as jnpt
 
 # jQMC modules
-from ._precision import get_dtype
+from ._precision import get_dtype_jnp, get_dtype_np
 from .structure import Structure_data
 
 # set logger
@@ -75,13 +74,18 @@ def evaluate_swct_omega(
     Returns:
         jax.Array: Normalized weights with shape ``(N_a, N_e)``, summing to 1 over atoms for each electron.
     """
-    dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
-    R_carts = jnp.asarray(structure_data._positions_cart_jnp, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("swct")
+    R_carts = structure_data._positions_cart_jnp  # fp64 storage accessor
 
     def compute_omega(R_cart, r_cart):
-        kappa = 1.0 / jnp.linalg.norm(r_cart - R_cart) ** 4
-        kappa_sum = jnp.sum(1.0 / jnp.linalg.norm(r_cart - R_carts, axis=1) ** 4)
+        # Reconstruct r - R in caller-supplied precision (fp64 from MCMC walker
+        # state) via JAX promotion, then downcast to the swct zone at the use
+        # site (Principle 3b — cast operands to this function's own zone
+        # immediately before consuming them as arithmetic operands).
+        diff_one = (r_cart - R_cart).astype(dtype_jnp)
+        diff_all = (r_cart - R_carts).astype(dtype_jnp)
+        kappa = 1.0 / jnp.linalg.norm(diff_one) ** 4
+        kappa_sum = jnp.sum(1.0 / jnp.linalg.norm(diff_all, axis=1) ** 4)
         return kappa / kappa_sum
 
     vmap_compute_omega = vmap(
@@ -100,18 +104,26 @@ def evaluate_swct_omega(
 def _evaluate_swct_omega_debug(
     structure_data: Structure_data,
     r_carts: npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
-    """NumPy fallback for ``evaluate_swct_omega`` used in debug paths."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_carts = np.asarray(r_carts, dtype=dtype_np)
-    R_carts = structure_data._positions_cart_np
+) -> np.ndarray:
+    """NumPy fallback for ``evaluate_swct_omega`` used in debug paths.
+
+    Return dtype matches the swct zone (selectable precision); declared as a
+    plain ``np.ndarray`` rather than ``npt.NDArray[np.float64]``.
+    """
+    dtype_np = get_dtype_np("swct")
+    R_carts = structure_data._positions_cart_np  # fp64 storage accessor
     omega = np.zeros((len(R_carts), len(r_carts)), dtype=dtype_np)
 
     for alpha in range(len(R_carts)):
         for i in range(len(r_carts)):
-            kappa = 1.0 / np.linalg.norm(r_carts[i] - R_carts[alpha]) ** 4
-            kappa_sum = np.sum([1.0 / np.linalg.norm(r_carts[i] - R_carts[beta]) ** 4 for beta in range(len(R_carts))])
+            # Reconstruct r - R in caller-supplied precision (fp64 from MCMC
+            # walker state), then downcast to the swct zone at the use site
+            # (Principle 3b).
+            diff_one = (r_carts[i] - R_carts[alpha]).astype(dtype_np)
+            kappa = 1.0 / np.linalg.norm(diff_one) ** 4
+            kappa_sum = np.sum(
+                [1.0 / np.linalg.norm((r_carts[i] - R_carts[beta]).astype(dtype_np)) ** 4 for beta in range(len(R_carts))]
+            )
             omega[alpha, i] = kappa / kappa_sum
 
     return omega
@@ -121,7 +133,7 @@ def _evaluate_swct_omega_debug(
 def evaluate_swct_domega(
     structure_data: Structure_data,
     r_carts: jax.Array,
-) -> npt.NDArray[np.float64]:
+) -> jax.Array:
     r"""Evaluate :math:`\sum_i \nabla_{r_i} \omega_{\alpha i}` for each atom.
 
     Args:
@@ -131,8 +143,8 @@ def evaluate_swct_domega(
     Returns:
         jax.Array: Sum of gradients per atom with shape ``(N_a, 3)``.
     """
-    dtype = get_dtype("kinetic")
-    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    # Forward r_carts as-is (Principle 3a — no parameter rebind). The inner
+    # `evaluate_swct_omega` performs its own use-site cast to the swct zone.
     domega = jnp.sum(jacrev(evaluate_swct_omega, argnums=1)(structure_data, r_carts), axis=(1, 2))
 
     return domega
@@ -141,17 +153,24 @@ def evaluate_swct_domega(
 def _evaluate_swct_domega_debug(
     structure_data: Structure_data,
     r_carts: npt.NDArray[np.float64],
-) -> npt.NDArray[np.float64]:
-    """NumPy fallback for ``evaluate_swct_domega`` used in debug paths."""
-    dtype = get_dtype("kinetic")
-    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
-    r_carts = np.asarray(r_carts, dtype=dtype_np)
-    R_carts = structure_data._positions_cart_np
+) -> np.ndarray:
+    """NumPy fallback for ``evaluate_swct_domega`` used in debug paths.
+
+    Return dtype matches the swct zone (selectable precision); declared as a
+    plain ``np.ndarray`` rather than ``npt.NDArray[np.float64]``.
+    """
+    dtype_np = get_dtype_np("swct")
+    R_carts = structure_data._positions_cart_np  # fp64 storage accessor
     domega = np.zeros((len(R_carts), 3), dtype=dtype_np)
 
     def compute_omega(R_cart, r_cart, R_carts):
-        kappa = 1.0 / np.linalg.norm(r_cart - R_cart) ** 4
-        kappa_sum = np.sum([1.0 / np.linalg.norm(r_cart - R_carts[beta]) ** 4 for beta in range(len(R_carts))])
+        # Reconstruct r - R in caller-supplied precision then downcast to the
+        # swct zone at the use site (Principle 3b).
+        diff_one = (r_cart - R_cart).astype(dtype_np)
+        kappa = 1.0 / np.linalg.norm(diff_one) ** 4
+        kappa_sum = np.sum(
+            [1.0 / np.linalg.norm((r_cart - R_carts[beta]).astype(dtype_np)) ** 4 for beta in range(len(R_carts))]
+        )
         omega = kappa / kappa_sum
         return omega
 

--- a/jqmc/swct.py
+++ b/jqmc/swct.py
@@ -1,4 +1,10 @@
-"""SWCT module."""
+"""SWCT module.
+
+Precision Zones:
+    - ``kinetic``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -45,6 +51,7 @@ from jax import numpy as jnp
 from jax import typing as jnpt
 
 # jQMC modules
+from ._precision import get_dtype
 from .structure import Structure_data
 
 # set logger
@@ -68,7 +75,9 @@ def evaluate_swct_omega(
     Returns:
         jax.Array: Normalized weights with shape ``(N_a, N_e)``, summing to 1 over atoms for each electron.
     """
-    R_carts = structure_data._positions_cart_jnp
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
+    R_carts = jnp.asarray(structure_data._positions_cart_jnp, dtype=dtype)
 
     def compute_omega(R_cart, r_cart):
         kappa = 1.0 / jnp.linalg.norm(r_cart - R_cart) ** 4
@@ -93,8 +102,11 @@ def _evaluate_swct_omega_debug(
     r_carts: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """NumPy fallback for ``evaluate_swct_omega`` used in debug paths."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_carts = np.asarray(r_carts, dtype=dtype_np)
     R_carts = structure_data._positions_cart_np
-    omega = np.zeros((len(R_carts), len(r_carts)))
+    omega = np.zeros((len(R_carts), len(r_carts)), dtype=dtype_np)
 
     for alpha in range(len(R_carts)):
         for i in range(len(r_carts)):
@@ -119,6 +131,8 @@ def evaluate_swct_domega(
     Returns:
         jax.Array: Sum of gradients per atom with shape ``(N_a, 3)``.
     """
+    dtype = get_dtype("kinetic")
+    r_carts = jnp.asarray(r_carts, dtype=dtype)
     domega = jnp.sum(jacrev(evaluate_swct_omega, argnums=1)(structure_data, r_carts), axis=(1, 2))
 
     return domega
@@ -129,8 +143,11 @@ def _evaluate_swct_domega_debug(
     r_carts: npt.NDArray[np.float64],
 ) -> npt.NDArray[np.float64]:
     """NumPy fallback for ``evaluate_swct_domega`` used in debug paths."""
+    dtype = get_dtype("kinetic")
+    dtype_np = np.float64 if dtype == jnp.float64 else np.float32
+    r_carts = np.asarray(r_carts, dtype=dtype_np)
     R_carts = structure_data._positions_cart_np
-    domega = np.zeros((len(R_carts), 3))
+    domega = np.zeros((len(R_carts), 3), dtype=dtype_np)
 
     def compute_omega(R_cart, r_cart, R_carts):
         kappa = 1.0 / np.linalg.norm(r_cart - R_cart) ** 4

--- a/jqmc/trexio_wrapper.py
+++ b/jqmc/trexio_wrapper.py
@@ -46,12 +46,9 @@ from logging import getLogger
 import numpy as np
 import scipy
 
-import jax.numpy as jnp
-
 # import trexio
 import trexio
 
-from ._precision import get_dtype
 from .atomic_orbital import AOs_cart_data, AOs_sphe_data
 from .coulomb_potential import Coulomb_potential_data
 from .determinant import Geminal_data
@@ -98,7 +95,7 @@ def read_trexio_file(
         >>> structure_data.atomic_labels[:3]
         ['O', 'H', 'H']
     """
-    dtype = get_dtype("io")
+    dtype_np = np.float64
 
     # read a trexio file
     file_r = trexio.File(
@@ -216,7 +213,7 @@ def read_trexio_file(
             atomic_numbers=tuple(_convert_from_atomic_labels_to_atomic_numbers(labels_r)),
             element_symbols=tuple(labels_r),
             atomic_labels=tuple(labels_r),
-            positions=np.array(coords_r, dtype=dtype),
+            positions=np.array(coords_r, dtype=dtype_np),
         )
     else:
         structure_data = Structure_data(
@@ -227,7 +224,7 @@ def read_trexio_file(
             atomic_numbers=list(_convert_from_atomic_labels_to_atomic_numbers(labels_r)),
             element_symbols=list(labels_r),
             atomic_labels=list(labels_r),
-            positions=np.array(coords_r, dtype=dtype),
+            positions=np.array(coords_r, dtype=dtype_np),
         )
 
     # ao spherical part check
@@ -339,8 +336,8 @@ def read_trexio_file(
                 polynominal_order_y=tuple(polynominal_order_y),
                 polynominal_order_z=tuple(polynominal_order_z),
                 orbital_indices=tuple(orbital_indices),
-                exponents=jnp.array(exponents, dtype=dtype),
-                coefficients=jnp.array(coefficients, dtype=dtype),
+                exponents=np.array(exponents, dtype=dtype_np),
+                coefficients=np.array(coefficients, dtype=dtype_np),
             )
         else:
             aos_data = AOs_cart_data(
@@ -353,8 +350,8 @@ def read_trexio_file(
                 polynominal_order_y=list(polynominal_order_y),
                 polynominal_order_z=list(polynominal_order_z),
                 orbital_indices=list(orbital_indices),
-                exponents=jnp.array(exponents, dtype=dtype),
-                coefficients=jnp.array(coefficients, dtype=dtype),
+                exponents=np.array(exponents, dtype=dtype_np),
+                coefficients=np.array(coefficients, dtype=dtype_np),
             )
     else:
         logger.debug("Spherical basis functions.")
@@ -435,8 +432,8 @@ def read_trexio_file(
                 angular_momentums=tuple(angular_momentums),
                 magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
                 orbital_indices=tuple(orbital_indices),
-                exponents=jnp.array(exponents, dtype=dtype),
-                coefficients=jnp.array(coefficients, dtype=dtype),
+                exponents=np.array(exponents, dtype=dtype_np),
+                coefficients=np.array(coefficients, dtype=dtype_np),
             )
         else:
             aos_data = AOs_sphe_data(
@@ -447,8 +444,8 @@ def read_trexio_file(
                 angular_momentums=list(angular_momentums),
                 magnetic_quantum_numbers=list(magnetic_quantum_numbers),
                 orbital_indices=list(orbital_indices),
-                exponents=jnp.array(exponents, dtype=dtype),
-                coefficients=jnp.array(coefficients, dtype=dtype),
+                exponents=np.array(exponents, dtype=dtype_np),
+                coefficients=np.array(coefficients, dtype=dtype_np),
             )
 
     # MOs_data instance
@@ -472,11 +469,11 @@ def read_trexio_file(
         num_ele_diff = num_ele_up - num_ele_dn
 
         mo_lambda_paired = np.pad(
-            np.eye(num_ele_dn, dtype=dtype), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
+            np.eye(num_ele_dn, dtype=dtype_np), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
         )
 
         mo_lambda_unpaired = np.pad(
-            np.eye(num_ele_diff, dtype=dtype), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
+            np.eye(num_ele_diff, dtype=dtype_np), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
         )
         mo_lambda_matrix = np.hstack([mo_lambda_paired, mo_lambda_unpaired])
 
@@ -508,11 +505,11 @@ def read_trexio_file(
         num_ele_diff = num_ele_up - num_ele_dn
 
         mo_lambda_paired = np.pad(
-            np.eye(num_ele_dn, dtype=dtype), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
+            np.eye(num_ele_dn, dtype=dtype_np), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
         )
 
         mo_lambda_unpaired = np.pad(
-            np.eye(num_ele_diff, dtype=dtype), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
+            np.eye(num_ele_diff, dtype=dtype_np), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
         )
         mo_lambda_matrix = np.hstack([mo_lambda_paired, mo_lambda_unpaired])
     else:

--- a/jqmc/trexio_wrapper.py
+++ b/jqmc/trexio_wrapper.py
@@ -1,4 +1,10 @@
-"""TREXIO wrapper modules."""
+"""TREXIO wrapper modules.
+
+Precision Zones:
+    - ``io``: all functions in this module.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -45,6 +51,7 @@ import jax.numpy as jnp
 # import trexio
 import trexio
 
+from ._precision import get_dtype
 from .atomic_orbital import AOs_cart_data, AOs_sphe_data
 from .coulomb_potential import Coulomb_potential_data
 from .determinant import Geminal_data
@@ -91,8 +98,7 @@ def read_trexio_file(
         >>> structure_data.atomic_labels[:3]
         ['O', 'H', 'H']
     """
-    # prefix and file names
-    # logger.info(f"TREXIO file = {trexio_file}")
+    dtype = get_dtype("io")
 
     # read a trexio file
     file_r = trexio.File(
@@ -210,7 +216,7 @@ def read_trexio_file(
             atomic_numbers=tuple(_convert_from_atomic_labels_to_atomic_numbers(labels_r)),
             element_symbols=tuple(labels_r),
             atomic_labels=tuple(labels_r),
-            positions=np.array(coords_r),
+            positions=np.array(coords_r, dtype=dtype),
         )
     else:
         structure_data = Structure_data(
@@ -221,7 +227,7 @@ def read_trexio_file(
             atomic_numbers=list(_convert_from_atomic_labels_to_atomic_numbers(labels_r)),
             element_symbols=list(labels_r),
             atomic_labels=list(labels_r),
-            positions=np.array(coords_r),
+            positions=np.array(coords_r, dtype=dtype),
         )
 
     # ao spherical part check
@@ -333,8 +339,8 @@ def read_trexio_file(
                 polynominal_order_y=tuple(polynominal_order_y),
                 polynominal_order_z=tuple(polynominal_order_z),
                 orbital_indices=tuple(orbital_indices),
-                exponents=jnp.array(exponents, dtype=jnp.float64),
-                coefficients=jnp.array(coefficients, dtype=jnp.float64),
+                exponents=jnp.array(exponents, dtype=dtype),
+                coefficients=jnp.array(coefficients, dtype=dtype),
             )
         else:
             aos_data = AOs_cart_data(
@@ -347,8 +353,8 @@ def read_trexio_file(
                 polynominal_order_y=list(polynominal_order_y),
                 polynominal_order_z=list(polynominal_order_z),
                 orbital_indices=list(orbital_indices),
-                exponents=jnp.array(exponents, dtype=jnp.float64),
-                coefficients=jnp.array(coefficients, dtype=jnp.float64),
+                exponents=jnp.array(exponents, dtype=dtype),
+                coefficients=jnp.array(coefficients, dtype=dtype),
             )
     else:
         logger.debug("Spherical basis functions.")
@@ -429,8 +435,8 @@ def read_trexio_file(
                 angular_momentums=tuple(angular_momentums),
                 magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
                 orbital_indices=tuple(orbital_indices),
-                exponents=jnp.array(exponents, dtype=jnp.float64),
-                coefficients=jnp.array(coefficients, dtype=jnp.float64),
+                exponents=jnp.array(exponents, dtype=dtype),
+                coefficients=jnp.array(coefficients, dtype=dtype),
             )
         else:
             aos_data = AOs_sphe_data(
@@ -441,8 +447,8 @@ def read_trexio_file(
                 angular_momentums=list(angular_momentums),
                 magnetic_quantum_numbers=list(magnetic_quantum_numbers),
                 orbital_indices=list(orbital_indices),
-                exponents=jnp.array(exponents, dtype=jnp.float64),
-                coefficients=jnp.array(coefficients, dtype=jnp.float64),
+                exponents=jnp.array(exponents, dtype=dtype),
+                coefficients=jnp.array(coefficients, dtype=dtype),
             )
 
     # MOs_data instance
@@ -466,11 +472,11 @@ def read_trexio_file(
         num_ele_diff = num_ele_up - num_ele_dn
 
         mo_lambda_paired = np.pad(
-            np.eye(num_ele_dn, dtype=np.float64), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
+            np.eye(num_ele_dn, dtype=dtype), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
         )
 
         mo_lambda_unpaired = np.pad(
-            np.eye(num_ele_diff, dtype=np.float64), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
+            np.eye(num_ele_diff, dtype=dtype), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
         )
         mo_lambda_matrix = np.hstack([mo_lambda_paired, mo_lambda_unpaired])
 
@@ -502,11 +508,11 @@ def read_trexio_file(
         num_ele_diff = num_ele_up - num_ele_dn
 
         mo_lambda_paired = np.pad(
-            np.eye(num_ele_dn, dtype=np.float64), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
+            np.eye(num_ele_dn, dtype=dtype), ((0, mo_considered_num - num_ele_dn), (0, mo_considered_num - num_ele_dn))
         )
 
         mo_lambda_unpaired = np.pad(
-            np.eye(num_ele_diff, dtype=np.float64), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
+            np.eye(num_ele_diff, dtype=dtype), ((num_ele_dn, mo_considered_num - num_ele_dn - num_ele_diff), (0, 0))
         )
         mo_lambda_matrix = np.hstack([mo_lambda_paired, mo_lambda_unpaired])
     else:

--- a/jqmc/wavefunction.py
+++ b/jqmc/wavefunction.py
@@ -1,4 +1,12 @@
-"""Wavefunction module."""
+"""Wavefunction module.
+
+Precision Zones:
+    - ``kinetic``: kinetic-energy evaluation (compute_kinetic_energy*).
+    - Zone-boundary casts when combining results from ``jastrow`` and
+      ``determinant`` zones.
+
+See :mod:`jqmc._precision` for details.
+"""
 
 # Copyright (C) 2024- Kosuke Nakano
 # All rights reserved.
@@ -64,6 +72,7 @@ from .jastrow_factor import (
     compute_Jastrow_part,
 )
 from .molecular_orbital import MOs_data
+from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -662,8 +671,8 @@ def evaluate_ln_wavefunction(
 
     This follows the original behavior: compute the Jastrow part, multiply the
     determinant part, and then take ``log(abs(det))`` while keeping the full
-    Jastrow contribution. The inputs are converted to float64 ``jax.Array`` for
-    downstream consistency.
+    Jastrow contribution. The inputs are converted to the determinant zone dtype
+    ``jax.Array`` for downstream consistency.
 
     Args:
         wavefunction_data: Wavefunction parameters (Jastrow + Geminal).
@@ -673,8 +682,9 @@ def evaluate_ln_wavefunction(
     Returns:
         Scalar log-value of the wavefunction magnitude.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype_det = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -688,7 +698,7 @@ def evaluate_ln_wavefunction(
         r_dn_carts=r_dn,
     )
 
-    return Jastrow_part + jnp.log(jnp.abs(Determinant_part))
+    return jnp.asarray(Jastrow_part, dtype=dtype_det) + jnp.log(jnp.abs(Determinant_part))
 
 
 def evaluate_ln_wavefunction_fast(
@@ -726,8 +736,9 @@ def evaluate_ln_wavefunction_fast(
         Passing an inverse from a different configuration silently produces
         incorrect parameter gradients (``O_matrix`` / SR).
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype_det = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -742,7 +753,7 @@ def evaluate_ln_wavefunction_fast(
         geminal_inv,
     )
 
-    return Jastrow_part + ln_det
+    return jnp.asarray(Jastrow_part, dtype=dtype_det) + ln_det
 
 
 @jit
@@ -754,8 +765,8 @@ def evaluate_wavefunction(
     """Evaluate the wavefunction ``Psi`` at given electron coordinates.
 
     The method is for evaluate wavefunction (Psi) at ``(r_up_carts, r_dn_carts)`` and
-    returns ``exp(Jastrow) * Determinant``. Inputs are coerced to float64
-    ``jax.Array`` to match other compute utilities.
+    returns ``exp(Jastrow) * Determinant``. Inputs are coerced to the determinant
+    zone dtype ``jax.Array`` to match other compute utilities.
 
     Args:
         wavefunction_data: Wavefunction parameters (Jastrow + Geminal).
@@ -765,8 +776,9 @@ def evaluate_wavefunction(
     Returns:
         Complex or real wavefunction value.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype_det = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -780,7 +792,7 @@ def evaluate_wavefunction(
         r_dn_carts=r_dn,
     )
 
-    return jnp.exp(Jastrow_part) * Determinant_part
+    return jnp.exp(jnp.asarray(Jastrow_part, dtype=dtype_det)) * Determinant_part
 
 
 def evaluate_jastrow(
@@ -802,8 +814,9 @@ def evaluate_jastrow(
     Returns:
         Real Jastrow factor ``exp(J)``.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("jastrow")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -829,8 +842,9 @@ def evaluate_determinant(
     Returns:
         Determinant value evaluated at the supplied coordinates.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     Determinant_part = compute_det_geminal_all_elements(
         geminal_data=wavefunction_data.geminal_data,
@@ -851,8 +865,8 @@ def compute_kinetic_energy(
 
     The method is for computing kinetic energy of the given WF at
     ``(r_up_carts, r_dn_carts)`` and fully exploits the JAX library for the
-    kinetic energy calculation. Inputs are converted to float64 ``jax.Array``
-    for consistency with other compute utilities.
+    kinetic energy calculation. Inputs are converted to the kinetic zone dtype
+    ``jax.Array`` for consistency with other compute utilities.
 
     Args:
         wavefunction_data: Wavefunction parameters (Jastrow + Geminal).
@@ -862,8 +876,9 @@ def compute_kinetic_energy(
     Returns:
         Kinetic energy evaluated for the supplied configuration.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     # grad_J_up, grad_J_dn, sum_laplacian_J = 0.0, 0.0, 0.0
     # """
@@ -917,8 +932,9 @@ def _compute_kinetic_energy_auto(
     Returns:
         The kinetic energy with the given wavefunction (float | complex)
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     kinetic_energy_all_elements_up, kinetic_energy_all_elements_dn = _compute_kinetic_energy_all_elements_auto(
         wavefunction_data=wavefunction_data, r_up_carts=r_up, r_dn_carts=r_dn
@@ -994,8 +1010,9 @@ def _compute_kinetic_energy_all_elements_auto(
     r_dn_carts: jax.Array,
 ) -> jax.Array:
     """See compute_kinetic_energy_api."""
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     # compute gradients
     grad_J_up = grad(compute_Jastrow_part, argnums=1)(wavefunction_data.jastrow_data, r_up, r_dn)
@@ -1047,8 +1064,9 @@ def compute_kinetic_energy_all_elements(
         Tuple of two ``jax.Array`` objects containing per-electron kinetic energies
         for spin-up and spin-down electrons, respectively.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     # --- Jastrow contributions (per-electron Laplacians) ---
     grad_J_up, grad_J_dn, lap_J_up, lap_J_dn = compute_grads_and_laplacian_Jastrow_part(
@@ -1108,8 +1126,9 @@ def compute_kinetic_energy_all_elements_fast_update(
     if geminal_inverse is None:
         raise ValueError("geminal_inverse must be provided for fast update")
 
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     grad_J_up, grad_J_dn, lap_J_up, lap_J_dn = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -1246,7 +1265,7 @@ def compute_discretized_kinetic_energy(
     Function for computing discretized kinetic grid points and their energies with a
     given lattice space (alat). This keeps the original semantics used by the LRDMC
     path: ratios are computed as ``exp(J_xp - J_x) * det_xp / det_x``. Inputs are
-    coerced to float64 ``jax.Array`` before evaluation.
+    coerced to the kinetic zone dtype ``jax.Array`` before evaluation.
 
     Args:
         alat: Hamiltonian discretization (bohr), which will be replaced with ``LRDMC_data``.
@@ -1260,9 +1279,10 @@ def compute_discretized_kinetic_energy(
         combined coordinate arrays have shapes ``(n_grid, n_up, 3)`` and ``(n_grid, n_dn, 3)``
         and ``elements_kinetic_part`` contains the kinetic prefactor-scaled ratios.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
-    rt = jnp.asarray(RT, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    rt = jnp.asarray(RT, dtype=dtype)
     # Define the shifts to apply (+/- alat in each coordinate direction)
     shifts = alat * jnp.array(
         [
@@ -1361,8 +1381,8 @@ def compute_discretized_kinetic_energy_fast_update(
 
     Function for computing discretized kinetic grid points and their energies with
     a given lattice space (alat). Uses precomputed ``A_old_inv`` to evaluate
-    determinant ratios efficiently. Inputs are converted to float64 ``jax.Array``
-    before use.
+    determinant ratios efficiently. Inputs are converted to the kinetic zone dtype
+    ``jax.Array`` before use.
 
     Args:
         alat: Hamiltonian discretization (bohr), which will be replaced with ``LRDMC_data``.
@@ -1377,9 +1397,10 @@ def compute_discretized_kinetic_energy_fast_update(
         coordinate arrays of shapes ``(n_grid, n_up, 3)`` and ``(n_grid, n_dn, 3)``, and kinetic
         prefactor-scaled ratios ``elements_kinetic_part``.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
-    rt = jnp.asarray(RT, dtype=jnp.float64)
+    dtype = get_dtype("kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    rt = jnp.asarray(RT, dtype=dtype)
     # Define the shifts to apply (+/- alat in each coordinate direction)
     shifts = alat * jnp.array(
         [
@@ -1516,8 +1537,9 @@ def compute_nodal_distance(
     Returns:
         Scalar nodal distance value.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     grad_J_up, grad_J_dn, _, _ = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
@@ -1564,8 +1586,9 @@ def _compute_nodal_distance_debug(
     Returns:
         Scalar nodal distance value.
     """
-    r_up = jnp.asarray(r_up_carts, dtype=jnp.float64)
-    r_dn = jnp.asarray(r_dn_carts, dtype=jnp.float64)
+    dtype = get_dtype("determinant")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
 
     Psi = evaluate_wavefunction(wavefunction_data, r_up, r_dn)
 

--- a/jqmc/wavefunction.py
+++ b/jqmc/wavefunction.py
@@ -54,10 +54,10 @@ from jax import grad, hessian, jit, tree_util, vmap
 from jax import typing as jnpt
 
 from ._diff_mask import DiffMask, apply_diff_mask
+from ._precision import get_dtype_jnp
 from .atomic_orbital import AOs_cart_data, AOs_sphe_data, ShellPrimMap
 from .determinant import (
     Geminal_data,
-    _compute_ratio_determinant_part_rank1_update,
     _compute_ratio_determinant_part_split_spin,
     compute_det_geminal_all_elements,
     compute_grads_and_laplacian_ln_Det,
@@ -72,7 +72,6 @@ from .jastrow_factor import (
     compute_Jastrow_part,
 )
 from .molecular_orbital import MOs_data
-from ._precision import get_dtype
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
@@ -682,23 +681,29 @@ def evaluate_ln_wavefunction(
     Returns:
         Scalar log-value of the wavefunction magnitude.
     """
-    dtype_det = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
+    # NOTE: do not pre-cast r_*_carts. They are forwarded unchanged to
+    # ``compute_Jastrow_part`` and ``compute_det_geminal_all_elements`` (which
+    # ultimately reach the AO kernels that reconstruct ``r - R`` in float64);
+    # a wrapper-level downcast would defeat that precision guard. The scalar
+    # arithmetic below uses ``Jastrow_part`` and ``Determinant_part`` which
+    # are explicitly cast to ``wf_eval``.
+    dtype_wf_jnp = get_dtype_jnp("wf_eval")
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     Determinant_part = compute_det_geminal_all_elements(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
-    return jnp.asarray(Jastrow_part, dtype=dtype_det) + jnp.log(jnp.abs(Determinant_part))
+    # Consumer-zone explicit cast: both terms cast to wf_eval before addition,
+    # never relying on implicit fp32 + fp64 -> fp64 promotion.
+    return jnp.asarray(Jastrow_part, dtype=dtype_wf_jnp) + jnp.asarray(jnp.log(jnp.abs(Determinant_part)), dtype=dtype_wf_jnp)
 
 
 def evaluate_ln_wavefunction_fast(
@@ -736,24 +741,24 @@ def evaluate_ln_wavefunction_fast(
         Passing an inverse from a different configuration silently produces
         incorrect parameter gradients (``O_matrix`` / SR).
     """
-    dtype_det = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_wf_jnp = get_dtype_jnp("wf_eval")
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     ln_det = compute_ln_det_geminal_all_elements_fast(
         wavefunction_data.geminal_data,
-        r_up,
-        r_dn,
+        r_up_carts,
+        r_dn_carts,
         geminal_inv,
     )
 
-    return jnp.asarray(Jastrow_part, dtype=dtype_det) + ln_det
+    # Consumer-zone explicit cast: both terms cast to wf_eval before addition.
+    return jnp.asarray(Jastrow_part, dtype=dtype_wf_jnp) + jnp.asarray(ln_det, dtype=dtype_wf_jnp)
 
 
 @jit
@@ -776,23 +781,23 @@ def evaluate_wavefunction(
     Returns:
         Complex or real wavefunction value.
     """
-    dtype_det = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype_det)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_det)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_wf_jnp = get_dtype_jnp("wf_eval")
 
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     Determinant_part = compute_det_geminal_all_elements(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
-    return jnp.exp(jnp.asarray(Jastrow_part, dtype=dtype_det)) * Determinant_part
+    # Consumer-zone explicit cast: both factors cast to wf_eval before multiplication.
+    return jnp.exp(jnp.asarray(Jastrow_part, dtype=dtype_wf_jnp)) * jnp.asarray(Determinant_part, dtype=dtype_wf_jnp)
 
 
 def evaluate_jastrow(
@@ -814,14 +819,11 @@ def evaluate_jastrow(
     Returns:
         Real Jastrow factor ``exp(J)``.
     """
-    dtype = get_dtype("jastrow")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
-
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
     Jastrow_part = compute_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     return jnp.exp(Jastrow_part)
@@ -842,14 +844,11 @@ def evaluate_determinant(
     Returns:
         Determinant value evaluated at the supplied coordinates.
     """
-    dtype = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
-
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
     Determinant_part = compute_det_geminal_all_elements(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     return Determinant_part
@@ -876,16 +875,15 @@ def compute_kinetic_energy(
     Returns:
         Kinetic energy evaluated for the supplied configuration.
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
 
     # grad_J_up, grad_J_dn, sum_laplacian_J = 0.0, 0.0, 0.0
     # """
     grad_J_up, grad_J_dn, lap_J_up, lap_J_dn = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
     # """
 
@@ -893,10 +891,21 @@ def compute_kinetic_energy(
     # """
     grad_ln_D_up, grad_ln_D_dn, lap_ln_D_up, lap_ln_D_dn = compute_grads_and_laplacian_ln_Det(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
     # """
+
+    # Explicitly cast jastrow_grad_lap and det_grad_lap zone values to wf_kinetic
+    # zone dtype before assembling T_L; do not rely on JAX implicit promotion.
+    grad_J_up = jnp.asarray(grad_J_up, dtype=dtype_jnp)
+    grad_J_dn = jnp.asarray(grad_J_dn, dtype=dtype_jnp)
+    lap_J_up = jnp.asarray(lap_J_up, dtype=dtype_jnp)
+    lap_J_dn = jnp.asarray(lap_J_dn, dtype=dtype_jnp)
+    grad_ln_D_up = jnp.asarray(grad_ln_D_up, dtype=dtype_jnp)
+    grad_ln_D_dn = jnp.asarray(grad_ln_D_dn, dtype=dtype_jnp)
+    lap_ln_D_up = jnp.asarray(lap_ln_D_up, dtype=dtype_jnp)
+    lap_ln_D_dn = jnp.asarray(lap_ln_D_dn, dtype=dtype_jnp)
 
     # compute kinetic energy
     L = (
@@ -932,9 +941,9 @@ def _compute_kinetic_energy_auto(
     Returns:
         The kinetic energy with the given wavefunction (float | complex)
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
 
     kinetic_energy_all_elements_up, kinetic_energy_all_elements_dn = _compute_kinetic_energy_all_elements_auto(
         wavefunction_data=wavefunction_data, r_up_carts=r_up, r_dn_carts=r_dn
@@ -1010,15 +1019,21 @@ def _compute_kinetic_energy_all_elements_auto(
     r_dn_carts: jax.Array,
 ) -> jax.Array:
     """See compute_kinetic_energy_api."""
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
 
     # compute gradients
     grad_J_up = grad(compute_Jastrow_part, argnums=1)(wavefunction_data.jastrow_data, r_up, r_dn)
     grad_J_dn = grad(compute_Jastrow_part, argnums=2)(wavefunction_data.jastrow_data, r_up, r_dn)
     grad_ln_Det_up = grad(compute_ln_det_geminal_all_elements, argnums=1)(wavefunction_data.geminal_data, r_up, r_dn)
     grad_ln_Det_dn = grad(compute_ln_det_geminal_all_elements, argnums=2)(wavefunction_data.geminal_data, r_up, r_dn)
+
+    # Cast jastrow/det grad/lap zone values to wf_kinetic dtype before combining.
+    grad_J_up = jnp.asarray(grad_J_up, dtype=dtype_jnp)
+    grad_J_dn = jnp.asarray(grad_J_dn, dtype=dtype_jnp)
+    grad_ln_Det_up = jnp.asarray(grad_ln_Det_up, dtype=dtype_jnp)
+    grad_ln_Det_dn = jnp.asarray(grad_ln_Det_dn, dtype=dtype_jnp)
 
     grad_ln_Psi_up = grad_J_up + grad_ln_Det_up
     grad_ln_Psi_dn = grad_J_dn + grad_ln_Det_dn
@@ -1033,6 +1048,11 @@ def _compute_kinetic_energy_all_elements_auto(
     laplacian_ln_Det_up = jnp.einsum("ijij->i", hessian_ln_Det_up)
     hessian_ln_Det_dn = hessian(compute_ln_det_geminal_all_elements, argnums=2)(wavefunction_data.geminal_data, r_up, r_dn)
     laplacian_ln_Det_dn = jnp.einsum("ijij->i", hessian_ln_Det_dn)
+
+    laplacian_J_up = jnp.asarray(laplacian_J_up, dtype=dtype_jnp)
+    laplacian_J_dn = jnp.asarray(laplacian_J_dn, dtype=dtype_jnp)
+    laplacian_ln_Det_up = jnp.asarray(laplacian_ln_Det_up, dtype=dtype_jnp)
+    laplacian_ln_Det_dn = jnp.asarray(laplacian_ln_Det_dn, dtype=dtype_jnp)
 
     laplacian_Psi_up = laplacian_J_up + laplacian_ln_Det_up
     laplacian_Psi_dn = laplacian_J_dn + laplacian_ln_Det_dn
@@ -1064,23 +1084,32 @@ def compute_kinetic_energy_all_elements(
         Tuple of two ``jax.Array`` objects containing per-electron kinetic energies
         for spin-up and spin-down electrons, respectively.
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
 
     # --- Jastrow contributions (per-electron Laplacians) ---
     grad_J_up, grad_J_dn, lap_J_up, lap_J_dn = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     # --- Determinant contributions (per-electron Laplacians) ---
     grad_ln_D_up, grad_ln_D_dn, lap_ln_D_up, lap_ln_D_dn = compute_grads_and_laplacian_ln_Det(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
+
+    # Cast jastrow_grad_lap / det_grad_lap zone values to wf_kinetic dtype.
+    grad_J_up = jnp.asarray(grad_J_up, dtype=dtype_jnp)
+    grad_J_dn = jnp.asarray(grad_J_dn, dtype=dtype_jnp)
+    lap_J_up = jnp.asarray(lap_J_up, dtype=dtype_jnp)
+    lap_J_dn = jnp.asarray(lap_J_dn, dtype=dtype_jnp)
+    grad_ln_D_up = jnp.asarray(grad_ln_D_up, dtype=dtype_jnp)
+    grad_ln_D_dn = jnp.asarray(grad_ln_D_dn, dtype=dtype_jnp)
+    lap_ln_D_up = jnp.asarray(lap_ln_D_up, dtype=dtype_jnp)
+    lap_ln_D_dn = jnp.asarray(lap_ln_D_dn, dtype=dtype_jnp)
 
     # --- Assemble kinetic energy per electron ---
     grad_ln_Psi_up = grad_J_up + grad_ln_D_up
@@ -1126,22 +1155,31 @@ def compute_kinetic_energy_all_elements_fast_update(
     if geminal_inverse is None:
         raise ValueError("geminal_inverse must be provided for fast update")
 
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
 
     grad_J_up, grad_J_dn, lap_J_up, lap_J_dn = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     grad_ln_D_up, grad_ln_D_dn, lap_ln_D_up, lap_ln_D_dn = compute_grads_and_laplacian_ln_Det_fast(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
         geminal_inverse=geminal_inverse,
     )
+
+    # Cast jastrow_grad_lap / det_grad_lap zone values to wf_kinetic dtype.
+    grad_J_up = jnp.asarray(grad_J_up, dtype=dtype_jnp)
+    grad_J_dn = jnp.asarray(grad_J_dn, dtype=dtype_jnp)
+    lap_J_up = jnp.asarray(lap_J_up, dtype=dtype_jnp)
+    lap_J_dn = jnp.asarray(lap_J_dn, dtype=dtype_jnp)
+    grad_ln_D_up = jnp.asarray(grad_ln_D_up, dtype=dtype_jnp)
+    grad_ln_D_dn = jnp.asarray(grad_ln_D_dn, dtype=dtype_jnp)
+    lap_ln_D_up = jnp.asarray(lap_ln_D_up, dtype=dtype_jnp)
+    lap_ln_D_dn = jnp.asarray(lap_ln_D_dn, dtype=dtype_jnp)
 
     grad_ln_Psi_up = grad_J_up + grad_ln_D_up
     grad_ln_Psi_dn = grad_J_dn + grad_ln_D_dn
@@ -1279,10 +1317,10 @@ def compute_discretized_kinetic_energy(
         combined coordinate arrays have shapes ``(n_grid, n_up, 3)`` and ``(n_grid, n_dn, 3)``
         and ``elements_kinetic_part`` contains the kinetic prefactor-scaled ratios.
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
-    rt = jnp.asarray(RT, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
+    rt = jnp.asarray(RT, dtype=dtype_jnp)
     # Define the shifts to apply (+/- alat in each coordinate direction)
     shifts = alat * jnp.array(
         [
@@ -1359,6 +1397,14 @@ def compute_discretized_kinetic_energy(
     det_xp = vmap(compute_det_geminal_all_elements, in_axes=(None, 0, 0))(
         wavefunction_data.geminal_data, r_up_carts_combined, r_dn_carts_combined
     )
+    # Explicitly cast both jastrow (jastrow_eval zone, possibly fp32) and det
+    # values to the wf_ratio zone dtype so that exp() and the wf_ratio arithmetic
+    # do not rely on JAX implicit fp32 x fp64 -> fp64 promotion.
+    dtype_wf_ratio_jnp = get_dtype_jnp("wf_ratio")
+    jastrow_x = jnp.asarray(jastrow_x, dtype=dtype_wf_ratio_jnp)
+    jastrow_xp = jnp.asarray(jastrow_xp, dtype=dtype_wf_ratio_jnp)
+    det_x = jnp.asarray(det_x, dtype=dtype_wf_ratio_jnp)
+    det_xp = jnp.asarray(det_xp, dtype=dtype_wf_ratio_jnp)
     wf_ratio = jnp.exp(jastrow_xp - jastrow_x) * det_xp / det_x
 
     # Compute the kinetic part elements
@@ -1397,10 +1443,10 @@ def compute_discretized_kinetic_energy_fast_update(
         coordinate arrays of shapes ``(n_grid, n_up, 3)`` and ``(n_grid, n_dn, 3)``, and kinetic
         prefactor-scaled ratios ``elements_kinetic_part``.
     """
-    dtype = get_dtype("kinetic")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
-    rt = jnp.asarray(RT, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("wf_kinetic")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
+    rt = jnp.asarray(RT, dtype=dtype_jnp)
     # Define the shifts to apply (+/- alat in each coordinate direction)
     shifts = alat * jnp.array(
         [
@@ -1450,21 +1496,32 @@ def compute_discretized_kinetic_energy_fast_update(
     r_up_carts_combined = jnp.concatenate([r_up_carts_shifted, r_up_carts_repeated_dn], axis=0)  # Shape: (N_configs, N_up, 3)
     r_dn_carts_combined = jnp.concatenate([r_dn_carts_repeated_up, r_dn_carts_shifted], axis=0)  # Shape: (N_configs, N_dn, 3)
 
-    # Evaluate the ratios of wavefunctions between the shifted positions and the original position
-    wf_ratio = _compute_ratio_determinant_part_split_spin(
-        geminal_data=wavefunction_data.geminal_data,
-        A_old_inv=A_old_inv,
-        old_r_up_carts=r_up,
-        old_r_dn_carts=r_dn,
-        new_r_up_shifted=r_up_carts_shifted,
-        new_r_dn_shifted=r_dn_carts_shifted,
-    ) * _compute_ratio_Jastrow_part_rank1_update(
-        jastrow_data=wavefunction_data.jastrow_data,
-        old_r_up_carts=r_up,
-        old_r_dn_carts=r_dn,
-        new_r_up_carts_arr=r_up_carts_combined,
-        new_r_dn_carts_arr=r_dn_carts_combined,
+    # Evaluate the ratios of wavefunctions between the shifted positions and the original position.
+    # det_ratio (det_ratio zone) and jastrow_ratio (jastrow_ratio zone) are explicitly cast to
+    # the wf_ratio zone dtype to avoid relying on JAX implicit promotion.
+    dtype_wf_ratio_jnp = get_dtype_jnp("wf_ratio")
+    det_ratio = jnp.asarray(
+        _compute_ratio_determinant_part_split_spin(
+            geminal_data=wavefunction_data.geminal_data,
+            A_old_inv=A_old_inv,
+            old_r_up_carts=r_up,
+            old_r_dn_carts=r_dn,
+            new_r_up_shifted=r_up_carts_shifted,
+            new_r_dn_shifted=r_dn_carts_shifted,
+        ),
+        dtype=dtype_wf_ratio_jnp,
     )
+    jastrow_ratio = jnp.asarray(
+        _compute_ratio_Jastrow_part_rank1_update(
+            jastrow_data=wavefunction_data.jastrow_data,
+            old_r_up_carts=r_up,
+            old_r_dn_carts=r_dn,
+            new_r_up_carts_arr=r_up_carts_combined,
+            new_r_dn_carts_arr=r_dn_carts_combined,
+        ),
+        dtype=dtype_wf_ratio_jnp,
+    )
+    wf_ratio = det_ratio * jastrow_ratio
 
     # Compute the kinetic part elements
     elements_kinetic_part = -1.0 / (2.0 * alat**2) * wf_ratio
@@ -1537,21 +1594,26 @@ def compute_nodal_distance(
     Returns:
         Scalar nodal distance value.
     """
-    dtype = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    # r_*_carts forwarded unchanged (see ``evaluate_ln_wavefunction`` for rationale).
+    dtype_jnp = get_dtype_jnp("wf_eval")
 
     grad_J_up, grad_J_dn, _, _ = compute_grads_and_laplacian_Jastrow_part(
         jastrow_data=wavefunction_data.jastrow_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
 
     grad_ln_D_up, grad_ln_D_dn, _, _ = compute_grads_and_laplacian_ln_Det(
         geminal_data=wavefunction_data.geminal_data,
-        r_up_carts=r_up,
-        r_dn_carts=r_dn,
+        r_up_carts=r_up_carts,
+        r_dn_carts=r_dn_carts,
     )
+
+    # Cast jastrow_grad_lap / det_grad_lap zone values to wf_eval dtype.
+    grad_J_up = jnp.asarray(grad_J_up, dtype=dtype_jnp)
+    grad_J_dn = jnp.asarray(grad_J_dn, dtype=dtype_jnp)
+    grad_ln_D_up = jnp.asarray(grad_ln_D_up, dtype=dtype_jnp)
+    grad_ln_D_dn = jnp.asarray(grad_ln_D_dn, dtype=dtype_jnp)
 
     grad_ln_Psi_up = grad_J_up + grad_ln_D_up  # (n_up, 3)
     grad_ln_Psi_dn = grad_J_dn + grad_ln_D_dn  # (n_dn, 3)
@@ -1586,9 +1648,9 @@ def _compute_nodal_distance_debug(
     Returns:
         Scalar nodal distance value.
     """
-    dtype = get_dtype("determinant")
-    r_up = jnp.asarray(r_up_carts, dtype=dtype)
-    r_dn = jnp.asarray(r_dn_carts, dtype=dtype)
+    dtype_jnp = get_dtype_jnp("wf_eval")
+    r_up = jnp.asarray(r_up_carts, dtype=dtype_jnp)
+    r_dn = jnp.asarray(r_dn_carts, dtype=dtype_jnp)
 
     Psi = evaluate_wavefunction(wavefunction_data, r_up, r_dn)
 

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -325,7 +325,7 @@ class LRDMC_Workflow(Workflow):
         max_continuation: int = 1,
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
-        precision_mode: Optional[str] = None,
+        precision_mode: str = "full",
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -462,9 +462,8 @@ class LRDMC_Workflow(Workflow):
             "control": control_ov,
             jt: section_ov,
         }
-        # Add [precision] section if configured
-        if self.precision_mode is not None:
-            overrides["precision"] = {"mode": self.precision_mode}
+        # Add [precision] section
+        overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type=jt,
             overrides=overrides,

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -324,6 +324,9 @@ class LRDMC_Workflow(Workflow):
         pilot_queue_label: Optional[str] = None,
         max_continuation: int = 1,
         cleanup_patterns: Optional[list] = None,
+        # -- [precision] section --
+        precision_mode: Optional[str] = None,
+        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -370,6 +373,9 @@ class LRDMC_Workflow(Workflow):
         self.num_gfmc_projections = num_gfmc_projections
         self.pilot_queue_label = pilot_queue_label or queue_label
         self.max_continuation = max_continuation
+        # [precision] section
+        self.precision_mode = precision_mode
+        self.precision_overrides = precision_overrides
 
     @property
     def job_type(self) -> str:
@@ -458,6 +464,14 @@ class LRDMC_Workflow(Workflow):
             "control": control_ov,
             jt: section_ov,
         }
+        # Add [precision] section if configured
+        if self.precision_mode is not None or self.precision_overrides:
+            precision_ov = {}
+            if self.precision_mode is not None:
+                precision_ov["mode"] = self.precision_mode
+            if self.precision_overrides:
+                precision_ov.update(self.precision_overrides)
+            overrides["precision"] = precision_ov
         generate_input_toml(
             job_type=jt,
             overrides=overrides,

--- a/jqmc_workflow/lrdmc_workflow.py
+++ b/jqmc_workflow/lrdmc_workflow.py
@@ -326,7 +326,6 @@ class LRDMC_Workflow(Workflow):
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
         precision_mode: Optional[str] = None,
-        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -375,7 +374,6 @@ class LRDMC_Workflow(Workflow):
         self.max_continuation = max_continuation
         # [precision] section
         self.precision_mode = precision_mode
-        self.precision_overrides = precision_overrides
 
     @property
     def job_type(self) -> str:
@@ -465,13 +463,8 @@ class LRDMC_Workflow(Workflow):
             jt: section_ov,
         }
         # Add [precision] section if configured
-        if self.precision_mode is not None or self.precision_overrides:
-            precision_ov = {}
-            if self.precision_mode is not None:
-                precision_ov["mode"] = self.precision_mode
-            if self.precision_overrides:
-                precision_ov.update(self.precision_overrides)
-            overrides["precision"] = precision_ov
+        if self.precision_mode is not None:
+            overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type=jt,
             overrides=overrides,

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -248,7 +248,7 @@ class MCMC_Workflow(Workflow):
         max_continuation: int = 1,
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
-        precision_mode: Optional[str] = None,
+        precision_mode: str = "full",
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -320,9 +320,8 @@ class MCMC_Workflow(Workflow):
             "control": control_ov,
             "mcmc": mcmc_ov,
         }
-        # Add [precision] section if configured
-        if self.precision_mode is not None:
-            overrides["precision"] = {"mode": self.precision_mode}
+        # Add [precision] section
+        overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type="mcmc",
             overrides=overrides,

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -249,7 +249,6 @@ class MCMC_Workflow(Workflow):
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
         precision_mode: Optional[str] = None,
-        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -279,7 +278,6 @@ class MCMC_Workflow(Workflow):
         self.max_continuation = max_continuation
         # [precision] section
         self.precision_mode = precision_mode
-        self.precision_overrides = precision_overrides
 
     # ── Input generation ──────────────────────────────────────────
 
@@ -323,13 +321,8 @@ class MCMC_Workflow(Workflow):
             "mcmc": mcmc_ov,
         }
         # Add [precision] section if configured
-        if self.precision_mode is not None or self.precision_overrides:
-            precision_ov = {}
-            if self.precision_mode is not None:
-                precision_ov["mode"] = self.precision_mode
-            if self.precision_overrides:
-                precision_ov.update(self.precision_overrides)
-            overrides["precision"] = precision_ov
+        if self.precision_mode is not None:
+            overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type="mcmc",
             overrides=overrides,

--- a/jqmc_workflow/mcmc_workflow.py
+++ b/jqmc_workflow/mcmc_workflow.py
@@ -247,6 +247,9 @@ class MCMC_Workflow(Workflow):
         pilot_queue_label: Optional[str] = None,
         max_continuation: int = 1,
         cleanup_patterns: Optional[list] = None,
+        # -- [precision] section --
+        precision_mode: Optional[str] = None,
+        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -274,6 +277,9 @@ class MCMC_Workflow(Workflow):
         self.pilot_steps = pilot_steps
         self.pilot_queue_label = pilot_queue_label or queue_label
         self.max_continuation = max_continuation
+        # [precision] section
+        self.precision_mode = precision_mode
+        self.precision_overrides = precision_overrides
 
     # ── Input generation ──────────────────────────────────────────
 
@@ -316,6 +322,14 @@ class MCMC_Workflow(Workflow):
             "control": control_ov,
             "mcmc": mcmc_ov,
         }
+        # Add [precision] section if configured
+        if self.precision_mode is not None or self.precision_overrides:
+            precision_ov = {}
+            if self.precision_mode is not None:
+                precision_ov["mode"] = self.precision_mode
+            if self.precision_overrides:
+                precision_ov.update(self.precision_overrides)
+            overrides["precision"] = precision_ov
         generate_input_toml(
             job_type="mcmc",
             overrides=overrides,

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -312,7 +312,7 @@ class VMC_Workflow(Workflow):
         energy_slope_window_size: int = 5,
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
-        precision_mode: Optional[str] = None,
+        precision_mode: str = "full",
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -424,9 +424,8 @@ class VMC_Workflow(Workflow):
             "control": control_ov,
             "vmc": vmc_ov,
         }
-        # Add [precision] section if configured
-        if self.precision_mode is not None:
-            overrides["precision"] = {"mode": self.precision_mode}
+        # Add [precision] section
+        overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type="vmc",
             overrides=overrides,

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -311,6 +311,9 @@ class VMC_Workflow(Workflow):
         energy_slope_sigma_threshold: Optional[float] = None,
         energy_slope_window_size: int = 5,
         cleanup_patterns: Optional[list] = None,
+        # -- [precision] section --
+        precision_mode: Optional[str] = None,
+        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -353,6 +356,9 @@ class VMC_Workflow(Workflow):
         self.snr_avg_window = snr_avg_window
         self.energy_slope_sigma_threshold = energy_slope_sigma_threshold
         self.energy_slope_window_size = energy_slope_window_size
+        # [precision] section
+        self.precision_mode = precision_mode
+        self.precision_overrides = precision_overrides
 
     # ── Input generation ──────────────────────────────────────────
 
@@ -420,6 +426,14 @@ class VMC_Workflow(Workflow):
             "control": control_ov,
             "vmc": vmc_ov,
         }
+        # Add [precision] section if configured
+        if self.precision_mode is not None or self.precision_overrides:
+            precision_ov = {}
+            if self.precision_mode is not None:
+                precision_ov["mode"] = self.precision_mode
+            if self.precision_overrides:
+                precision_ov.update(self.precision_overrides)
+            overrides["precision"] = precision_ov
         generate_input_toml(
             job_type="vmc",
             overrides=overrides,

--- a/jqmc_workflow/vmc_workflow.py
+++ b/jqmc_workflow/vmc_workflow.py
@@ -313,7 +313,6 @@ class VMC_Workflow(Workflow):
         cleanup_patterns: Optional[list] = None,
         # -- [precision] section --
         precision_mode: Optional[str] = None,
-        precision_overrides: Optional[dict] = None,
     ):
         super().__init__(cleanup_patterns=cleanup_patterns)
         self.server_machine_name = server_machine_name
@@ -358,7 +357,6 @@ class VMC_Workflow(Workflow):
         self.energy_slope_window_size = energy_slope_window_size
         # [precision] section
         self.precision_mode = precision_mode
-        self.precision_overrides = precision_overrides
 
     # ── Input generation ──────────────────────────────────────────
 
@@ -427,13 +425,8 @@ class VMC_Workflow(Workflow):
             "vmc": vmc_ov,
         }
         # Add [precision] section if configured
-        if self.precision_mode is not None or self.precision_overrides:
-            precision_ov = {}
-            if self.precision_mode is not None:
-                precision_ov["mode"] = self.precision_mode
-            if self.precision_overrides:
-                precision_ov.update(self.precision_overrides)
-            overrides["precision"] = precision_ov
+        if self.precision_mode is not None:
+            overrides["precision"] = {"mode": self.precision_mode}
         generate_input_toml(
             job_type="vmc",
             overrides=overrides,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,12 @@ def pytest_addoption(parser):
     """Add options for pytests."""
     parser.addoption("--disable-jit", action="store_true", default=False, help="Disable jax.jit for pytests")
     parser.addoption("--skip-heavy", action="store_true", default=False, help="Skip heavy calculations for pytests")
+    parser.addoption(
+        "--precision-mode",
+        default="full",
+        choices=["full", "mixed"],
+        help="Precision mode for tests (default: full)",
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +29,15 @@ def enable_jit(request):
     jax.config.update("jax_disable_jit", False)
 
 
+@pytest.fixture(autouse=True)
+def configure_precision(request):
+    """Configure precision mode before each test."""
+    from jqmc._precision import configure
+
+    mode = request.config.getoption("--precision-mode")
+    configure({"mode": mode})
+
+
 def pytest_itemcollected(item):
     """Show reason for obsolete tests."""
     obsolete_marker = item.get_closest_marker("obsolete")
@@ -37,13 +52,36 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "activate_if_disable_jit: activate test if --disable-jit is set")
     config.addinivalue_line("markers", "activate_if_skip_heavy: skip test if --skip-heavy is set")
     config.addinivalue_line("markers", "obsolete: tests that are obsolete and should be removed in the future")
+    config.addinivalue_line(
+        "markers",
+        "numerical_diff: test compares analytic or autodiff results "
+        "against finite-difference derivatives or numerical quadrature. "
+        "Skipped automatically when --precision-mode=mixed because "
+        "float32 round-off dominates the FD / quadrature error.",
+    )
+    config.addinivalue_line(
+        "markers",
+        "external_reference: test compares against an external reference "
+        "(e.g. TurboRVB). Validated only in --precision-mode=full; "
+        "skipped in mixed mode.",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
-    """Skip tests marked with activate_if_skip_heavy when --skip-heavy is set."""
-    if not config.getoption("--skip-heavy"):
-        return
-    skip_marker = pytest.mark.skip(reason="skipped by --skip-heavy")
-    for item in items:
-        if item.get_closest_marker("activate_if_skip_heavy"):
-            item.add_marker(skip_marker)
+    """Skip tests based on CLI options (--skip-heavy, --precision-mode)."""
+    if config.getoption("--skip-heavy"):
+        skip_marker = pytest.mark.skip(reason="skipped by --skip-heavy")
+        for item in items:
+            if item.get_closest_marker("activate_if_skip_heavy"):
+                item.add_marker(skip_marker)
+
+    if config.getoption("--precision-mode") == "mixed":
+        skip_fd = pytest.mark.skip(
+            reason="FD / numerical-quadrature comparison is invalid under mixed precision (float32 round-off dominates)."
+        )
+        skip_extref = pytest.mark.skip(reason="External-reference comparison validated only in mode=full.")
+        for item in items:
+            if "numerical_diff" in item.keywords:
+                item.add_marker(skip_fd)
+            if "external_reference" in item.keywords:
+                item.add_marker(skip_extref)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def configure_precision(request):
     from jqmc._precision import configure
 
     mode = request.config.getoption("--precision-mode")
-    configure({"mode": mode})
+    configure(mode)
 
 
 def pytest_itemcollected(item):

--- a/tests/test_AOs.py
+++ b/tests/test_AOs.py
@@ -68,18 +68,7 @@ from jqmc.atomic_orbital import (  # noqa: E402
     compute_AOs_laplacian,
     compute_overlap_matrix,
 )
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    rtol_auto_vs_analytic_deriv,
-    atol_auto_vs_numerical_deriv,
-    rtol_auto_vs_numerical_deriv,
-    atol_consistency,
-    rtol_consistency,
-    atol_debug_vs_production,
-    rtol_debug_vs_production,
-    atol_numerical_vs_analytic_deriv,
-    rtol_numerical_vs_analytic_deriv,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.structure import Structure_data  # noqa: E402
 
 # JAX float64
@@ -220,6 +209,7 @@ def test_spherical_harmonics_debug_vs_production(l, m):
     r_y_rand = (r_cart_max - r_cart_min) * np.random.rand(num_samples) + r_cart_min
     r_z_rand = (r_cart_max - r_cart_min) * np.random.rand(num_samples) + r_cart_min
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     for r_cart in zip(r_x_rand, r_y_rand, r_z_rand, strict=True):
         r_norm = LA.norm(np.array(R_cart) - np.array(r_cart))
         r_cart_rel = np.array(r_cart) - np.array(R_cart)
@@ -232,7 +222,7 @@ def test_spherical_harmonics_debug_vs_production(l, m):
         ref_S_lm = np.sqrt((4 * np.pi) / (2 * l + 1)) * r_norm**l * Y_l_m_ref(l=l, m=m, r_cart_rel=r_cart_rel)
         assert not np.any(np.isnan(np.asarray(test_S_lm))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(ref_S_lm))), "NaN detected in second argument"
-        assert_allclose(test_S_lm, ref_S_lm, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        assert_allclose(test_S_lm, ref_S_lm, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -273,9 +263,10 @@ def test_solid_harmonics_debug_vs_production():
 
     # print(f"batch_S_l_m.shape = {batch_S_l_m.shape}.")
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(S_l_m_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(S_l_m_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(S_l_m_debug, S_l_m_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(S_l_m_debug, S_l_m_jax, atol=atol, rtol=rtol)
     jax.clear_caches()
 
 
@@ -326,12 +317,14 @@ def test_AOs_sphe_debug_vs_production():
     )
     aos_data.sanity_check()
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
+
     aos_jax = _compute_AOs_sphe(aos_data=aos_data, r_carts=r_carts)
     aos_debug = _compute_AOs_sphe_debug(aos_data=aos_data, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(aos_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(aos_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol, rtol=rtol)
 
     num_el = 150
     num_ao = len(ml_list)
@@ -382,7 +375,7 @@ def test_AOs_sphe_debug_vs_production():
 
     assert not np.any(np.isnan(np.asarray(aos_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(aos_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -451,12 +444,14 @@ def test_AOs_cart_debug_vs_production():
     )
     aos_data.sanity_check()
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
+
     aos_jax = _compute_AOs_cart(aos_data=aos_data, r_carts=r_carts)
     aos_debug = _compute_AOs_cart_debug(aos_data=aos_data, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(aos_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(aos_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(aos_jax, aos_debug, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -509,20 +504,22 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_auto():
     gx_auto, gy_auto, gz_auto = _compute_AOs_grad_autodiff(aos_data=aos_data, r_carts=r_carts)
     gx_an, gy_an, gz_an = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(gx_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(gx_an, gx_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(gx_an, gx_auto, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(gy_an, gy_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(gy_an, gy_auto, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gz_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(gz_an, gz_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(gz_an, gz_auto, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     """Test the grad AOs computation, comparing the JAX and debug implementations."""
     # Cartesian case
@@ -570,15 +567,16 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     gx_auto_cart, gy_auto_cart, gz_auto_cart = _compute_AOs_grad_autodiff(aos_data=aos_data_cart, r_carts=r_carts)
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data_cart, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(gx_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(gx_auto_cart, gx_num_cart, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gx_auto_cart, gx_num_cart, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(gy_auto_cart, gy_num_cart, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gy_auto_cart, gy_num_cart, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gz_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(gz_auto_cart, gz_num_cart, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gz_auto_cart, gz_num_cart, atol=atol, rtol=rtol)
 
     # Spherical case
     num_r_cart_samples = 10
@@ -634,14 +632,14 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(gx_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gx_auto_sphe, gx_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gx_auto_sphe, gx_num_sphe, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gy_auto_sphe, gy_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gy_auto_sphe, gy_num_sphe, atol=atol, rtol=rtol)
 
     assert not np.any(np.isnan(np.asarray(gz_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gz_auto_sphe, gz_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gz_auto_sphe, gz_num_sphe, atol=atol, rtol=rtol)
 
     # Spherical case (additional coverage)
     num_r_cart_samples = 2
@@ -697,17 +695,18 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(gx_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gx_auto_sphe, gx_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gx_auto_sphe, gx_num_sphe, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gy_auto_sphe, gy_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gy_auto_sphe, gy_num_sphe, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gz_auto_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(gz_auto_sphe, gz_num_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv)
+    np.testing.assert_allclose(gz_auto_sphe, gz_num_sphe, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
+@pytest.mark.numerical_diff
 def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     """Analytic AO gradients match numerical finite-difference implementation."""
     seed = 2028
@@ -756,21 +755,16 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data, r_carts=r_carts)
     gx_an_cart, gy_an_cart, gz_an_cart = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(gx_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gx_an_cart, gx_num_cart, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gx_an_cart, gx_num_cart, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gy_an_cart, gy_num_cart, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gy_an_cart, gy_num_cart, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gz_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gz_an_cart, gz_num_cart, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gz_an_cart, gz_num_cart, atol=atol, rtol=rtol)
 
     # Spherical case
     num_r_cart_samples = 3
@@ -813,19 +807,13 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(gx_an_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gx_an_sphe, gx_num_sphe, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gx_an_sphe, gx_num_sphe, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gy_an_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gy_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gy_an_sphe, gy_num_sphe, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gy_an_sphe, gy_num_sphe, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(gz_an_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gz_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        gz_an_sphe, gz_num_sphe, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(gz_an_sphe, gz_num_sphe, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -879,9 +867,10 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
     lap_auto_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_an_cart, lap_auto_cart, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(lap_an_cart, lap_auto_cart, atol=atol, rtol=rtol)
 
     # Spherical case
     num_r_cart_samples = 3
@@ -924,9 +913,10 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
 
     assert not np.any(np.isnan(np.asarray(lap_an_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_an_sphe, lap_auto_sphe, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(lap_an_sphe, lap_auto_sphe, atol=atol, rtol=rtol)
 
 
+@pytest.mark.numerical_diff
 def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     """Analytic Laplacians match numerical finite-difference implementation."""
     seed = 2027
@@ -975,11 +965,10 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        lap_an_cart, lap_num_cart, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(lap_an_cart, lap_num_cart, atol=atol, rtol=rtol)
 
     # Spherical case
     num_r_cart_samples = 3
@@ -1022,14 +1011,13 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(lap_an_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        lap_an_sphe, lap_num_sphe, atol=atol_numerical_vs_analytic_deriv, rtol=rtol_numerical_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(lap_an_sphe, lap_num_sphe, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     """Test the laplacian AOs computation, comparing the JAX and debug implementations."""
     # Cartesian case
@@ -1077,11 +1065,10 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_auto_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        lap_auto_cart, lap_num_cart, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(lap_auto_cart, lap_num_cart, atol=atol, rtol=rtol)
 
     # Spherical cases
     num_r_cart_samples = 10
@@ -1133,9 +1120,7 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(lap_num_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        lap_num_sphe, lap_auto_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(lap_num_sphe, lap_auto_sphe, atol=atol, rtol=rtol)
 
     num_r_cart_samples = 2
     num_R_cart_samples = 3
@@ -1186,13 +1171,12 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
 
     assert not np.any(np.isnan(np.asarray(lap_num_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        lap_num_sphe, lap_auto_sphe, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(lap_num_sphe, lap_auto_sphe, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
+@pytest.mark.numerical_diff
 def test_overlap_matrix_cart_analytic_vs_numerical_debug():
     """Cartesian AO overlap matrix from analytic formula matches numerical integration."""
     centers = np.array([[-0.45, 0.0, 0.0], [0.45, 0.0, 0.0]], dtype=np.float64)
@@ -1224,19 +1208,19 @@ def test_overlap_matrix_cart_analytic_vs_numerical_debug():
     overlap_analytic = np.asarray(compute_overlap_matrix(aos_data=aos_data), dtype=np.float64)
     overlap_numerical = _compute_overlap_matrix_debug(aos_data=aos_data, num_grid_points=41, tail_tolerance=1.0e-12)
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        overlap_analytic, overlap_numerical, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(overlap_analytic, overlap_numerical, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_analytic.T))), "NaN detected in second argument"
-    np.testing.assert_allclose(overlap_analytic, overlap_analytic.T, atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(overlap_analytic, overlap_analytic.T, atol=atol, rtol=rtol)
     assert np.all(np.diag(overlap_analytic) > 0.0)
 
     jax.clear_caches()
 
 
+@pytest.mark.numerical_diff
 def test_overlap_matrix_sphe_analytic_vs_numerical_debug():
     """Spherical AO overlap matrix from analytic formula matches numerical integration."""
     centers = np.array([[-0.35, 0.0, 0.0], [0.35, 0.0, 0.0]], dtype=np.float64)
@@ -1266,14 +1250,14 @@ def test_overlap_matrix_sphe_analytic_vs_numerical_debug():
     overlap_analytic = np.asarray(compute_overlap_matrix(aos_data=aos_data), dtype=np.float64)
     overlap_numerical = _compute_overlap_matrix_debug(aos_data=aos_data, num_grid_points=41, tail_tolerance=1.0e-12)
 
+    atol_l, rtol_l = get_tolerance("orb_eval", "loose")
+    atol_s, rtol_s = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        overlap_analytic, overlap_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(overlap_analytic, overlap_numerical, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_analytic.T))), "NaN detected in second argument"
-    np.testing.assert_allclose(overlap_analytic, overlap_analytic.T, atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(overlap_analytic, overlap_analytic.T, atol=atol_s, rtol=rtol_s)
     assert np.all(np.diag(overlap_analytic) > 0.0)
 
     jax.clear_caches()

--- a/tests/test_AOs.py
+++ b/tests/test_AOs.py
@@ -504,7 +504,7 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_auto():
     gx_auto, gy_auto, gz_auto = _compute_AOs_grad_autodiff(aos_data=aos_data, r_carts=r_carts)
     gx_an, gy_an, gz_an = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "strict")
+    atol, rtol = get_tolerance("ao_grad", "strict")
     assert not np.any(np.isnan(np.asarray(gx_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_an, gx_auto, atol=atol, rtol=rtol)
@@ -567,7 +567,7 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     gx_auto_cart, gy_auto_cart, gz_auto_cart = _compute_AOs_grad_autodiff(aos_data=aos_data_cart, r_carts=r_carts)
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data_cart, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "loose")
+    atol, rtol = get_tolerance("ao_grad", "loose")
     assert not np.any(np.isnan(np.asarray(gx_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_auto_cart, gx_num_cart, atol=atol, rtol=rtol)
@@ -755,7 +755,7 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data, r_carts=r_carts)
     gx_an_cart, gy_an_cart, gz_an_cart = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "loose")
+    atol, rtol = get_tolerance("ao_grad", "loose")
     assert not np.any(np.isnan(np.asarray(gx_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_an_cart, gx_num_cart, atol=atol, rtol=rtol)
@@ -867,7 +867,7 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
     lap_auto_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "strict")
+    atol, rtol = get_tolerance("ao_lap", "strict")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_an_cart, lap_auto_cart, atol=atol, rtol=rtol)
@@ -965,7 +965,7 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "loose")
+    atol, rtol = get_tolerance("ao_lap", "loose")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_an_cart, lap_num_cart, atol=atol, rtol=rtol)
@@ -1065,7 +1065,7 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_auto_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("ao_grad_lap", "loose")
+    atol, rtol = get_tolerance("ao_lap", "loose")
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_auto_cart, lap_num_cart, atol=atol, rtol=rtol)

--- a/tests/test_AOs.py
+++ b/tests/test_AOs.py
@@ -209,7 +209,7 @@ def test_spherical_harmonics_debug_vs_production(l, m):
     r_y_rand = (r_cart_max - r_cart_min) * np.random.rand(num_samples) + r_cart_min
     r_z_rand = (r_cart_max - r_cart_min) * np.random.rand(num_samples) + r_cart_min
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    atol, rtol = get_tolerance("ao_eval", "strict")
     for r_cart in zip(r_x_rand, r_y_rand, r_z_rand, strict=True):
         r_norm = LA.norm(np.array(R_cart) - np.array(r_cart))
         r_cart_rel = np.array(r_cart) - np.array(R_cart)
@@ -263,7 +263,7 @@ def test_solid_harmonics_debug_vs_production():
 
     # print(f"batch_S_l_m.shape = {batch_S_l_m.shape}.")
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    atol, rtol = get_tolerance("ao_eval", "strict")
     assert not np.any(np.isnan(np.asarray(S_l_m_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(S_l_m_jax))), "NaN detected in second argument"
     np.testing.assert_allclose(S_l_m_debug, S_l_m_jax, atol=atol, rtol=rtol)
@@ -283,8 +283,8 @@ def test_AOs_sphe_debug_vs_production():
     magnetic_quantum_numbers = [m for _, m in ml_list]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -317,7 +317,7 @@ def test_AOs_sphe_debug_vs_production():
     )
     aos_data.sanity_check()
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    atol, rtol = get_tolerance("ao_eval", "strict")
 
     aos_jax = _compute_AOs_sphe(aos_data=aos_data, r_carts=r_carts)
     aos_debug = _compute_AOs_sphe_debug(aos_data=aos_data, r_carts=r_carts)
@@ -336,8 +336,8 @@ def test_AOs_sphe_debug_vs_production():
     magnetic_quantum_numbers = magnetic_quantum_numbers
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -406,8 +406,8 @@ def test_AOs_cart_debug_vs_production():
     coefficients = [1.0] * num_ao
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     polynominal_order_x = tuple(polynominal_order_x)
     polynominal_order_y = tuple(polynominal_order_y)
@@ -444,7 +444,7 @@ def test_AOs_cart_debug_vs_production():
     )
     aos_data.sanity_check()
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    atol, rtol = get_tolerance("ao_eval", "strict")
 
     aos_jax = _compute_AOs_cart(aos_data=aos_data, r_carts=r_carts)
     aos_debug = _compute_AOs_cart_debug(aos_data=aos_data, r_carts=r_carts)
@@ -470,8 +470,8 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_auto():
     num_ao = 3
     num_ao_prim = 3
     orbital_indices = tuple(range(num_ao))
-    exponents = tuple([0.8, 1.1, 0.6])
-    coefficients = tuple([1.0, 0.7, 1.3])
+    exponents = np.array([0.8, 1.1, 0.6], dtype=np.float64)
+    coefficients = np.array([1.0, 0.7, 1.3], dtype=np.float64)
     angular_momentums = tuple([0, 1, 2])
     polynominal_order_x = tuple([0, 1, 2])
     polynominal_order_y = tuple([0, 0, 0])
@@ -504,7 +504,7 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_auto():
     gx_auto, gy_auto, gz_auto = _compute_AOs_grad_autodiff(aos_data=aos_data, r_carts=r_carts)
     gx_an, gy_an, gz_an = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("ao_grad_lap", "strict")
     assert not np.any(np.isnan(np.asarray(gx_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_an, gx_auto, atol=atol, rtol=rtol)
@@ -533,8 +533,8 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     num_ao = 3
     num_ao_prim = 3
     orbital_indices = tuple(range(num_ao))
-    exponents = tuple([1.2, 0.9, 0.7])
-    coefficients = tuple([1.0, 0.8, 0.6])
+    exponents = np.array([1.2, 0.9, 0.7], dtype=np.float64)
+    coefficients = np.array([1.0, 0.8, 0.6], dtype=np.float64)
     angular_momentums = tuple([0, 1, 2])
     polynominal_order_x = tuple([0, 1, 2])
     polynominal_order_y = tuple([0, 0, 0])
@@ -567,7 +567,7 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     gx_auto_cart, gy_auto_cart, gz_auto_cart = _compute_AOs_grad_autodiff(aos_data=aos_data_cart, r_carts=r_carts)
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data_cart, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("ao_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(gx_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_auto_cart, gx_num_cart, atol=atol, rtol=rtol)
@@ -595,8 +595,8 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     magnetic_quantum_numbers = [0, 0, 0, 0]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -658,8 +658,8 @@ def test_AOs_sphe_and_cart_grads_auto_vs_numerical():
     magnetic_quantum_numbers = [0, 0, 0, 0]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -721,8 +721,8 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     num_ao = 3
     num_ao_prim = 3
     orbital_indices = tuple(range(num_ao))
-    exponents = tuple([0.9, 1.3, 0.7])
-    coefficients = tuple([1.0, 0.8, 1.2])
+    exponents = np.array([0.9, 1.3, 0.7], dtype=np.float64)
+    coefficients = np.array([1.0, 0.8, 1.2], dtype=np.float64)
     angular_momentums = tuple([0, 1, 2])
     polynominal_order_x = tuple([0, 1, 2])
     polynominal_order_y = tuple([0, 0, 0])
@@ -755,7 +755,7 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     gx_num_cart, gy_num_cart, gz_num_cart = _compute_AOs_grad_debug(aos_data=aos_data, r_carts=r_carts)
     gx_an_cart, gy_an_cart, gz_an_cart = compute_AOs_grad(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("ao_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(gx_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(gx_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(gx_an_cart, gx_num_cart, atol=atol, rtol=rtol)
@@ -775,8 +775,8 @@ def test_AOs_sphe_and_cart_grads_analytic_vs_numerical():
     num_ao = 4
     num_ao_prim = 5
     orbital_indices = tuple([0, 1, 2, 2, 3])
-    exponents = tuple([3.0, 1.6, 0.9, 0.9, 2.2])
-    coefficients = tuple([1.0, 0.9, 1.1, 0.7, 1.0])
+    exponents = np.array([3.0, 1.6, 0.9, 0.9, 2.2], dtype=np.float64)
+    coefficients = np.array([1.0, 0.9, 1.1, 0.7, 1.0], dtype=np.float64)
     angular_momentums = tuple([0, 1, 1, 2])
     magnetic_quantum_numbers = tuple([0, -1, 1, 0])
 
@@ -833,8 +833,8 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
     num_ao = 3
     num_ao_prim = 3
     orbital_indices = tuple(range(num_ao))
-    exponents = tuple([0.9, 1.2, 0.7])
-    coefficients = tuple([1.0, 0.8, 1.1])
+    exponents = np.array([0.9, 1.2, 0.7], dtype=np.float64)
+    coefficients = np.array([1.0, 0.8, 1.1], dtype=np.float64)
     angular_momentums = tuple([0, 1, 2])
     polynominal_order_x = tuple([0, 1, 2])
     polynominal_order_y = tuple([0, 0, 0])
@@ -867,7 +867,7 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
     lap_auto_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("ao_grad_lap", "strict")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_an_cart, lap_auto_cart, atol=atol, rtol=rtol)
@@ -881,8 +881,8 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_auto():
     num_ao = 4
     num_ao_prim = 5
     orbital_indices = tuple([0, 1, 2, 2, 3])
-    exponents = tuple([3.0, 1.5, 0.8, 0.8, 2.2])
-    coefficients = tuple([1.0, 0.9, 1.1, 0.7, 1.0])
+    exponents = np.array([3.0, 1.5, 0.8, 0.8, 2.2], dtype=np.float64)
+    coefficients = np.array([1.0, 0.9, 1.1, 0.7, 1.0], dtype=np.float64)
     angular_momentums = tuple([0, 1, 1, 2])
     magnetic_quantum_numbers = tuple([0, -1, 1, 0])
 
@@ -931,8 +931,8 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     num_ao = 2
     num_ao_prim = 3
     orbital_indices = tuple([0, 0, 1])
-    exponents = tuple([1.4, 0.9, 1.1])
-    coefficients = tuple([1.0, 0.7, 0.9])
+    exponents = np.array([1.4, 0.9, 1.1], dtype=np.float64)
+    coefficients = np.array([1.0, 0.7, 0.9], dtype=np.float64)
     angular_momentums = tuple([0, 1])
     polynominal_order_x = tuple([0, 1])
     polynominal_order_y = tuple([0, 0])
@@ -965,7 +965,7 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
     lap_an_cart = compute_AOs_laplacian(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("ao_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(lap_an_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_an_cart, lap_num_cart, atol=atol, rtol=rtol)
@@ -979,8 +979,8 @@ def test_AOs_shpe_and_cart_laplacians_analytic_vs_numerical():
     num_ao = 3
     num_ao_prim = 4
     orbital_indices = tuple([0, 1, 1, 2])
-    exponents = tuple([2.0, 1.6, 1.1, 0.9])
-    coefficients = tuple([1.0, 0.8, 1.2, 0.7])
+    exponents = np.array([2.0, 1.6, 1.1, 0.9], dtype=np.float64)
+    coefficients = np.array([1.0, 0.8, 1.2, 0.7], dtype=np.float64)
     angular_momentums = tuple([0, 1, 1])
     magnetic_quantum_numbers = tuple([0, 0, 1])
 
@@ -1053,8 +1053,8 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
         num_ao=num_ao,
         num_ao_prim=num_ao_prim,
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         polynominal_order_x=tuple(polynominal_order_x),
         polynominal_order_y=tuple(polynominal_order_y),
@@ -1065,7 +1065,7 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     lap_num_cart = _compute_AOs_laplacian_autodiff(aos_data=aos_data, r_carts=r_carts)
     lap_auto_cart = _compute_AOs_laplacian_debug(aos_data=aos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("ao_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(lap_auto_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_num_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(lap_auto_cart, lap_num_cart, atol=atol, rtol=rtol)
@@ -1087,8 +1087,8 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     magnetic_quantum_numbers = [0, 0, 0]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -1138,8 +1138,8 @@ def test_AOs_shpe_and_cart_laplacians_auto_vs_numerical():
     magnetic_quantum_numbers = [0, 1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -1196,8 +1196,8 @@ def test_overlap_matrix_cart_analytic_vs_numerical_debug():
         num_ao=2,
         num_ao_prim=2,
         orbital_indices=(0, 1),
-        exponents=(1.20, 1.20),
-        coefficients=(1.0, 1.0),
+        exponents=np.array([1.20, 1.20], dtype=np.float64),
+        coefficients=np.array([1.0, 1.0], dtype=np.float64),
         angular_momentums=(0, 0),
         polynominal_order_x=(0, 0),
         polynominal_order_y=(0, 0),
@@ -1208,7 +1208,7 @@ def test_overlap_matrix_cart_analytic_vs_numerical_debug():
     overlap_analytic = np.asarray(compute_overlap_matrix(aos_data=aos_data), dtype=np.float64)
     overlap_numerical = _compute_overlap_matrix_debug(aos_data=aos_data, num_grid_points=41, tail_tolerance=1.0e-12)
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    atol, rtol = get_tolerance("ao_eval", "strict")
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(overlap_analytic, overlap_numerical, atol=atol, rtol=rtol)
@@ -1240,8 +1240,8 @@ def test_overlap_matrix_sphe_analytic_vs_numerical_debug():
         num_ao=2,
         num_ao_prim=2,
         orbital_indices=(0, 1),
-        exponents=(1.10, 1.10),
-        coefficients=(1.0, 1.0),
+        exponents=np.array([1.10, 1.10], dtype=np.float64),
+        coefficients=np.array([1.0, 1.0], dtype=np.float64),
         angular_momentums=(0, 0),
         magnetic_quantum_numbers=(0, 0),
     )
@@ -1250,8 +1250,8 @@ def test_overlap_matrix_sphe_analytic_vs_numerical_debug():
     overlap_analytic = np.asarray(compute_overlap_matrix(aos_data=aos_data), dtype=np.float64)
     overlap_numerical = _compute_overlap_matrix_debug(aos_data=aos_data, num_grid_points=41, tail_tolerance=1.0e-12)
 
-    atol_l, rtol_l = get_tolerance("orb_eval", "loose")
-    atol_s, rtol_s = get_tolerance("orb_eval", "strict")
+    atol_l, rtol_l = get_tolerance("ao_eval", "loose")
+    atol_s, rtol_s = get_tolerance("ao_eval", "strict")
     assert not np.any(np.isnan(np.asarray(overlap_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(overlap_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(overlap_analytic, overlap_numerical, atol=atol_l, rtol=rtol_l)

--- a/tests/test_MOs.py
+++ b/tests/test_MOs.py
@@ -62,14 +62,7 @@ from jqmc.molecular_orbital import (  # noqa: E402
     compute_MOs_grad,
     compute_MOs_laplacian,
 )
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    rtol_auto_vs_analytic_deriv,
-    atol_auto_vs_numerical_deriv,
-    rtol_auto_vs_numerical_deriv,
-    atol_debug_vs_production,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.structure import Structure_data  # noqa: E402
 
 # JAX float64
@@ -132,9 +125,10 @@ def test_MOs_comparing_jax_and_debug_implemenetations():
 
     mo_ans_all_debug = _compute_MOs_debug(mos_data=mos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(mo_ans_all_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_ans_all_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(mo_ans_all_debug, mo_ans_all_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(mo_ans_all_debug, mo_ans_all_jax, atol=atol, rtol=rtol)
 
     num_el = 10
     num_mo = 5
@@ -190,12 +184,13 @@ def test_MOs_comparing_jax_and_debug_implemenetations():
 
     assert not np.any(np.isnan(np.asarray(mo_ans_all_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_ans_all_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(mo_ans_all_debug, mo_ans_all_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(mo_ans_all_debug, mo_ans_all_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_MOs_comparing_auto_and_numerical_grads():
     """Test the MO gradient computation, comparing JAX and debug implementations."""
     num_el = 10
@@ -254,22 +249,17 @@ def test_MOs_comparing_auto_and_numerical_grads():
         mo_matrix_grad_z_numerical,
     ) = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_y_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_y_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_y_auto, mo_matrix_grad_y_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_y_auto, mo_matrix_grad_y_numerical, atol=atol, rtol=rtol)
 
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_z_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_z_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_z_auto, mo_matrix_grad_z_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_z_auto, mo_matrix_grad_z_numerical, atol=atol, rtol=rtol)
 
     num_el = 10
     num_mo = 5
@@ -329,24 +319,19 @@ def test_MOs_comparing_auto_and_numerical_grads():
 
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_y_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_y_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_y_auto, mo_matrix_grad_y_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_y_auto, mo_matrix_grad_y_numerical, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_z_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_z_numerical))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        mo_matrix_grad_z_auto, mo_matrix_grad_z_numerical, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(mo_matrix_grad_z_auto, mo_matrix_grad_z_numerical, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_MOs_comparing_auto_and_numerical_laplacians():
     """Test the MO Laplacian computation, comparing JAX and debug implementations."""
     num_el = 10
@@ -401,13 +386,14 @@ def test_MOs_comparing_auto_and_numerical_laplacians():
 
     mo_matrix_laplacian_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mo_matrix_laplacian_auto,
         mo_matrix_laplacian_numerical,
-        atol=atol_auto_vs_numerical_deriv,
-        rtol=rtol_auto_vs_numerical_deriv,
+        atol=atol,
+        rtol=rtol,
     )
 
     jax.clear_caches()
@@ -466,15 +452,16 @@ def test_MOs_comparing_analytic_and_auto_grads():
 
     grad_x_auto, grad_y_auto, grad_z_auto = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(grad_x_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_x_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(grad_x_an, grad_x_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(grad_x_an, grad_x_auto, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(grad_y_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_y_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(grad_y_an, grad_y_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(grad_y_an, grad_y_auto, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(grad_z_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_z_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(grad_z_an, grad_z_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(grad_z_an, grad_z_auto, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -532,9 +519,10 @@ def test_MOs_comparing_analytic_and_auto_laplacians():
 
     mo_lap_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(mo_lap_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_lap_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(mo_lap_an, mo_lap_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(mo_lap_an, mo_lap_auto, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -602,9 +590,10 @@ def test_MOs_sphe_to_cart():
     mo_sphe = compute_MOs(mos_data=mos_sphe, r_carts=r_carts)
     mo_cart = compute_MOs(mos_data=mos_cart, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(mo_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(mo_cart, mo_sphe, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(mo_cart, mo_sphe, atol=atol, rtol=rtol)
 
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
@@ -612,14 +601,14 @@ def test_MOs_sphe_to_cart():
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_cart, g_sphe, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(g_cart, g_sphe, atol=atol, rtol=rtol)
 
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -703,9 +692,10 @@ def test_MOs_cart_to_sphe():
     mo_cart = compute_MOs(mos_data=mos_cart, r_carts=r_carts)
     mo_sphe = compute_MOs(mos_data=mos_sphe, r_carts=r_carts)
 
+    atol, rtol = get_tolerance("orb_eval", "strict")
     assert not np.any(np.isnan(np.asarray(mo_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(mo_sphe, mo_cart, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(mo_sphe, mo_cart, atol=atol, rtol=rtol)
 
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
@@ -713,14 +703,14 @@ def test_MOs_cart_to_sphe():
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_sphe, g_cart, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(g_sphe, g_cart, atol=atol, rtol=rtol)
 
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_MOs.py
+++ b/tests/test_MOs.py
@@ -62,7 +62,7 @@ from jqmc.molecular_orbital import (  # noqa: E402
     compute_MOs_grad,
     compute_MOs_laplacian,
 )
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.structure import Structure_data  # noqa: E402
 
 # JAX float64
@@ -83,8 +83,8 @@ def test_MOs_comparing_jax_and_debug_implemenetations():
     magnetic_quantum_numbers = [0, 0, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -125,7 +125,9 @@ def test_MOs_comparing_jax_and_debug_implemenetations():
 
     mo_ans_all_debug = _compute_MOs_debug(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    # Path crosses ao_eval (fp32 in mixed) -> mo_eval (fp64); use the looser
+    # of the two so the test reflects the achievable agreement.
+    atol, rtol = get_tolerance_min(["ao_eval", "mo_eval"], "strict")
     assert not np.any(np.isnan(np.asarray(mo_ans_all_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_ans_all_jax))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_ans_all_debug, mo_ans_all_jax, atol=atol, rtol=rtol)
@@ -141,8 +143,8 @@ def test_MOs_comparing_jax_and_debug_implemenetations():
     magnetic_quantum_numbers = [0, 1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -204,8 +206,8 @@ def test_MOs_comparing_auto_and_numerical_grads():
     magnetic_quantum_numbers = [0, 0, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -249,7 +251,7 @@ def test_MOs_comparing_auto_and_numerical_grads():
         mo_matrix_grad_z_numerical,
     ) = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("mo_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol, rtol=rtol)
@@ -272,8 +274,8 @@ def test_MOs_comparing_auto_and_numerical_grads():
     magnetic_quantum_numbers = [0, 1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -345,8 +347,8 @@ def test_MOs_comparing_auto_and_numerical_laplacians():
     magnetic_quantum_numbers = [0, 0, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -386,7 +388,7 @@ def test_MOs_comparing_auto_and_numerical_laplacians():
 
     mo_matrix_laplacian_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("mo_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -413,8 +415,8 @@ def test_MOs_comparing_analytic_and_auto_grads():
     magnetic_quantum_numbers = [0, 1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -452,7 +454,8 @@ def test_MOs_comparing_analytic_and_auto_grads():
 
     grad_x_auto, grad_y_auto, grad_z_auto = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    # Path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap (fp64); use min.
+    atol, rtol = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
     assert not np.any(np.isnan(np.asarray(grad_x_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_x_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(grad_x_an, grad_x_auto, atol=atol, rtol=rtol)
@@ -480,8 +483,8 @@ def test_MOs_comparing_analytic_and_auto_laplacians():
     magnetic_quantum_numbers = [0, 1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -519,7 +522,8 @@ def test_MOs_comparing_analytic_and_auto_laplacians():
 
     mo_lap_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    # Path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap (fp64); use min.
+    atol, rtol = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
     assert not np.any(np.isnan(np.asarray(mo_lap_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_lap_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_lap_an, mo_lap_auto, atol=atol, rtol=rtol)
@@ -574,8 +578,8 @@ def test_MOs_sphe_to_cart():
         num_ao=num_ao,
         num_ao_prim=num_ao_prim,
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -590,7 +594,8 @@ def test_MOs_sphe_to_cart():
     mo_sphe = compute_MOs(mos_data=mos_sphe, r_carts=r_carts)
     mo_cart = compute_MOs(mos_data=mos_cart, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    # Path crosses ao_eval (fp32 in mixed) -> mo_eval; use min for value cmp.
+    atol, rtol = get_tolerance_min(["ao_eval", "mo_eval"], "strict")
     assert not np.any(np.isnan(np.asarray(mo_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_sphe))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_cart, mo_sphe, atol=atol, rtol=rtol)
@@ -598,17 +603,19 @@ def test_MOs_sphe_to_cart():
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
 
+    # grad/lap path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap.
+    atol_gl, rtol_gl = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_cart, g_sphe, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(g_cart, g_sphe, atol=atol_gl, rtol=rtol_gl)
 
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol_gl, rtol=rtol_gl)
 
     jax.clear_caches()
 
@@ -674,8 +681,8 @@ def test_MOs_cart_to_sphe():
         num_ao=num_ao,
         num_ao_prim=num_ao_prim,
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         polynominal_order_x=tuple(polynominal_order_x),
         polynominal_order_y=tuple(polynominal_order_y),
@@ -692,7 +699,8 @@ def test_MOs_cart_to_sphe():
     mo_cart = compute_MOs(mos_data=mos_cart, r_carts=r_carts)
     mo_sphe = compute_MOs(mos_data=mos_sphe, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("orb_eval", "strict")
+    # Path crosses ao_eval (fp32 in mixed) -> mo_eval; use min for value cmp.
+    atol, rtol = get_tolerance_min(["ao_eval", "mo_eval"], "strict")
     assert not np.any(np.isnan(np.asarray(mo_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_cart))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_sphe, mo_cart, atol=atol, rtol=rtol)
@@ -700,17 +708,19 @@ def test_MOs_cart_to_sphe():
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
 
+    # grad/lap path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap.
+    atol_gl, rtol_gl = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_sphe, g_cart, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(g_sphe, g_cart, atol=atol_gl, rtol=rtol_gl)
 
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
 
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol_gl, rtol=rtol_gl)
 
     jax.clear_caches()
 

--- a/tests/test_MOs.py
+++ b/tests/test_MOs.py
@@ -251,7 +251,7 @@ def test_MOs_comparing_auto_and_numerical_grads():
         mo_matrix_grad_z_numerical,
     ) = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("mo_grad_lap", "loose")
+    atol, rtol = get_tolerance("mo_grad", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_grad_x_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_matrix_grad_x_auto, mo_matrix_grad_x_numerical, atol=atol, rtol=rtol)
@@ -388,7 +388,7 @@ def test_MOs_comparing_auto_and_numerical_laplacians():
 
     mo_matrix_laplacian_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    atol, rtol = get_tolerance("mo_grad_lap", "loose")
+    atol, rtol = get_tolerance("mo_lap", "loose")
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_matrix_laplacian_numerical))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -454,8 +454,8 @@ def test_MOs_comparing_analytic_and_auto_grads():
 
     grad_x_auto, grad_y_auto, grad_z_auto = _compute_MOs_grad_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    # Path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap (fp64); use min.
-    atol, rtol = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
+    # Path crosses ao_grad (fp32 in mixed) -> mo_grad (fp64); use min.
+    atol, rtol = get_tolerance_min(["ao_grad", "mo_grad"], "strict")
     assert not np.any(np.isnan(np.asarray(grad_x_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_x_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(grad_x_an, grad_x_auto, atol=atol, rtol=rtol)
@@ -522,8 +522,8 @@ def test_MOs_comparing_analytic_and_auto_laplacians():
 
     mo_lap_auto = _compute_MOs_laplacian_autodiff(mos_data=mos_data, r_carts=r_carts)
 
-    # Path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap (fp64); use min.
-    atol, rtol = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
+    # Path crosses ao_lap (fp64) -> mo_lap (fp64); use min.
+    atol, rtol = get_tolerance_min(["ao_lap", "mo_lap"], "strict")
     assert not np.any(np.isnan(np.asarray(mo_lap_an))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mo_lap_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(mo_lap_an, mo_lap_auto, atol=atol, rtol=rtol)
@@ -603,19 +603,21 @@ def test_MOs_sphe_to_cart():
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
 
-    # grad/lap path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap.
-    atol_gl, rtol_gl = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
+    # grad path crosses ao_grad (fp32 in mixed) -> mo_grad.
+    atol_g, rtol_g = get_tolerance_min(["ao_grad", "mo_grad"], "strict")
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_cart, g_sphe, atol=atol_gl, rtol=rtol_gl)
+        np.testing.assert_allclose(g_cart, g_sphe, atol=atol_g, rtol=rtol_g)
 
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
 
+    # lap path crosses ao_lap (fp64) -> mo_lap (fp64).
+    atol_l, rtol_l = get_tolerance_min(["ao_lap", "mo_lap"], "strict")
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol_gl, rtol=rtol_gl)
+    np.testing.assert_allclose(lap_cart, lap_sphe, atol=atol_l, rtol=rtol_l)
 
     jax.clear_caches()
 
@@ -708,19 +710,21 @@ def test_MOs_cart_to_sphe():
     grad_cart = compute_MOs_grad(mos_data=mos_cart, r_carts=r_carts)
     grad_sphe = compute_MOs_grad(mos_data=mos_sphe, r_carts=r_carts)
 
-    # grad/lap path crosses ao_grad_lap (fp32 in mixed) -> mo_grad_lap.
-    atol_gl, rtol_gl = get_tolerance_min(["ao_grad_lap", "mo_grad_lap"], "strict")
+    # grad path crosses ao_grad (fp32 in mixed) -> mo_grad.
+    atol_g, rtol_g = get_tolerance_min(["ao_grad", "mo_grad"], "strict")
     for g_cart, g_sphe in zip(grad_cart, grad_sphe, strict=True):
         assert not np.any(np.isnan(np.asarray(g_sphe))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(g_cart))), "NaN detected in second argument"
-        np.testing.assert_allclose(g_sphe, g_cart, atol=atol_gl, rtol=rtol_gl)
+        np.testing.assert_allclose(g_sphe, g_cart, atol=atol_g, rtol=rtol_g)
 
     lap_cart = compute_MOs_laplacian(mos_data=mos_cart, r_carts=r_carts)
     lap_sphe = compute_MOs_laplacian(mos_data=mos_sphe, r_carts=r_carts)
 
+    # lap path crosses ao_lap (fp64) -> mo_lap (fp64).
+    atol_l, rtol_l = get_tolerance_min(["ao_lap", "mo_lap"], "strict")
     assert not np.any(np.isnan(np.asarray(lap_sphe))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_cart))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol_gl, rtol=rtol_gl)
+    np.testing.assert_allclose(lap_sphe, lap_cart, atol=atol_l, rtol=rtol_l)
 
     jax.clear_caches()
 

--- a/tests/test_ao_basis_optimization.py
+++ b/tests/test_ao_basis_optimization.py
@@ -84,11 +84,16 @@ def _random_electron_coords(structure_data, coulomb_potential_data, geminal_data
 
 
 @pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvdz_cart.h5", "H2_ae_ccpvdz_sphe.h5"])
-def test_exponents_coefficients_are_jax_arrays(trexio_file):
-    """After Phase 1, exponents/coefficients should be jax.Array."""
+def test_exponents_coefficients_storage_is_numpy(trexio_file):
+    """Storage fields exponents/coefficients are np.ndarray[float64] (jnp view via _*_jnp)."""
     structure_data, aos_data, *_ = _load_trexio(trexio_file)
-    assert isinstance(aos_data.exponents, jax.Array), f"exponents type: {type(aos_data.exponents)}"
-    assert isinstance(aos_data.coefficients, jax.Array), f"coefficients type: {type(aos_data.coefficients)}"
+    assert isinstance(aos_data.exponents, np.ndarray), f"exponents type: {type(aos_data.exponents)}"
+    assert aos_data.exponents.dtype == np.float64, f"exponents dtype: {aos_data.exponents.dtype}"
+    assert isinstance(aos_data.coefficients, np.ndarray), f"coefficients type: {type(aos_data.coefficients)}"
+    assert aos_data.coefficients.dtype == np.float64, f"coefficients dtype: {aos_data.coefficients.dtype}"
+    # The jnp accessor returns jax.Array
+    assert isinstance(aos_data._exponents_jnp, jax.Array)
+    assert isinstance(aos_data._coefficients_jnp, jax.Array)
 
 
 # ============================================================
@@ -132,15 +137,15 @@ def test_j3_with_updated_ao_exponents():
     npt.assert_allclose(
         np.array(j3_new.ao_exponents),
         np.array(new_exp),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
     # Original should be unchanged
     npt.assert_allclose(
         np.array(j3.ao_exponents),
         np.array(aos_data.exponents),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
 
 
@@ -166,14 +171,14 @@ def test_geminal_ao_properties():
     npt.assert_allclose(
         np.array(exp_up),
         np.array(exp_up_ao),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
     npt.assert_allclose(
         np.array(exp_dn),
         np.array(exp_dn_ao),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
 
 
@@ -194,14 +199,14 @@ def test_geminal_with_updated_ao_exponents():
     npt.assert_allclose(
         np.array(geminal_new.ao_exponents_up),
         np.array(new_exp_up),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
     npt.assert_allclose(
         np.array(geminal_new.ao_exponents_dn),
         np.array(new_exp_dn),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
     # Lambda matrix should be unchanged
     npt.assert_array_equal(np.array(geminal_new.lambda_matrix), np.array(geminal_ao.lambda_matrix))
@@ -370,8 +375,8 @@ def test_get_variational_blocks_basis_flags():
     npt.assert_allclose(
         symmetrized,
         np.asarray(aos_data.exponents),
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
 
 
@@ -402,8 +407,8 @@ def test_apply_block_update_j3_basis():
     npt.assert_allclose(
         np.array(jastrow_new.jastrow_three_body_data.ao_exponents),
         new_exp,
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
 
 
@@ -430,14 +435,14 @@ def test_apply_block_update_geminal_basis():
     npt.assert_allclose(
         np.array(geminal_new.ao_exponents_up),
         new_exp_up,
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
     npt.assert_allclose(
         np.array(geminal_new.ao_exponents_dn),
         new_exp_dn,
-        atol=get_tolerance("orb_eval", "strict")[0],
-        rtol=get_tolerance("orb_eval", "strict")[1],
+        atol=get_tolerance("ao_eval", "strict")[0],
+        rtol=get_tolerance("ao_eval", "strict")[1],
     )
 
 
@@ -611,7 +616,7 @@ def test_shell_symmetrize_j3_basis():
     spm = ShellPrimMap.from_aos_data(aos_data)
     expected = spm.symmetrize(perturbed)
     npt.assert_allclose(
-        result, expected, atol=get_tolerance("orb_eval", "strict")[0], rtol=get_tolerance("orb_eval", "strict")[1]
+        result, expected, atol=get_tolerance("ao_eval", "strict")[0], rtol=get_tolerance("ao_eval", "strict")[1]
     )
 
 
@@ -656,7 +661,7 @@ def test_shell_symmetrize_geminal_basis():
     )
     expected = spm.symmetrize(perturbed)
     npt.assert_allclose(
-        result, expected, atol=get_tolerance("orb_eval", "strict")[0], rtol=get_tolerance("orb_eval", "strict")[1]
+        result, expected, atol=get_tolerance("ao_eval", "strict")[0], rtol=get_tolerance("ao_eval", "strict")[1]
     )
 
 

--- a/tests/test_ao_basis_optimization.py
+++ b/tests/test_ao_basis_optimization.py
@@ -21,6 +21,7 @@ from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_three_body_data,
     compute_Jastrow_three_body,
 )
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.molecular_orbital import MOs_data  # noqa: E402
 from jqmc.trexio_wrapper import read_trexio_file  # noqa: E402
 from jqmc.wavefunction import (  # noqa: E402
@@ -128,9 +129,19 @@ def test_j3_with_updated_ao_exponents():
 
     new_exp = j3.ao_exponents * 1.1
     j3_new = j3.with_updated_ao_exponents(new_exp)
-    npt.assert_allclose(np.array(j3_new.ao_exponents), np.array(new_exp), rtol=1e-14)
+    npt.assert_allclose(
+        np.array(j3_new.ao_exponents),
+        np.array(new_exp),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
     # Original should be unchanged
-    npt.assert_allclose(np.array(j3.ao_exponents), np.array(aos_data.exponents), rtol=1e-14)
+    npt.assert_allclose(
+        np.array(j3.ao_exponents),
+        np.array(aos_data.exponents),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
 
 
 # ============================================================
@@ -152,8 +163,18 @@ def test_geminal_ao_properties():
     geminal_ao = Geminal_data.convert_from_MOs_to_AOs(geminal_mo_data)
     exp_up_ao = geminal_ao.ao_exponents_up
     exp_dn_ao = geminal_ao.ao_exponents_dn
-    npt.assert_allclose(np.array(exp_up), np.array(exp_up_ao), rtol=1e-14)
-    npt.assert_allclose(np.array(exp_dn), np.array(exp_dn_ao), rtol=1e-14)
+    npt.assert_allclose(
+        np.array(exp_up),
+        np.array(exp_up_ao),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
+    npt.assert_allclose(
+        np.array(exp_dn),
+        np.array(exp_dn_ao),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
 
 
 # ============================================================
@@ -170,8 +191,18 @@ def test_geminal_with_updated_ao_exponents():
     new_exp_dn = geminal_ao.ao_exponents_dn * 1.1
     geminal_new = geminal_ao.with_updated_ao_exponents(new_exp_up, new_exp_dn)
 
-    npt.assert_allclose(np.array(geminal_new.ao_exponents_up), np.array(new_exp_up), rtol=1e-14)
-    npt.assert_allclose(np.array(geminal_new.ao_exponents_dn), np.array(new_exp_dn), rtol=1e-14)
+    npt.assert_allclose(
+        np.array(geminal_new.ao_exponents_up),
+        np.array(new_exp_up),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
+    npt.assert_allclose(
+        np.array(geminal_new.ao_exponents_dn),
+        np.array(new_exp_dn),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
     # Lambda matrix should be unchanged
     npt.assert_array_equal(np.array(geminal_new.lambda_matrix), np.array(geminal_ao.lambda_matrix))
 
@@ -182,6 +213,7 @@ def test_geminal_with_updated_ao_exponents():
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvdz_cart.h5", "H2_ae_ccpvdz_sphe.h5"])
 def test_j3_exponent_gradient_finite_diff(trexio_file):
     """Verify that jax.grad of J3 w.r.t. exponents matches finite differences."""
@@ -220,6 +252,7 @@ def test_j3_exponent_gradient_finite_diff(trexio_file):
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvdz_cart.h5", "H2_ae_ccpvdz_sphe.h5"])
 def test_j3_coefficient_gradient_finite_diff(trexio_file):
     """Verify that jax.grad of J3 w.r.t. coefficients matches finite differences."""
@@ -256,6 +289,7 @@ def test_j3_coefficient_gradient_finite_diff(trexio_file):
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_geminal_exponent_gradient_finite_diff():
     """Verify that jax.grad of Geminal det w.r.t. exponents matches finite differences."""
     structure_data, _, _, _, geminal_mo_data, coulomb_potential_data = _load_trexio("H2_ae_ccpvdz_cart.h5")
@@ -333,7 +367,12 @@ def test_get_variational_blocks_basis_flags():
     # symmetrize_metric should be set and be idempotent on the current values
     assert j3_exp_block.symmetrize_metric is not None
     symmetrized = j3_exp_block.symmetrize_metric(np.asarray(j3_exp_block.values))
-    npt.assert_allclose(symmetrized, np.asarray(aos_data.exponents), rtol=1e-14)
+    npt.assert_allclose(
+        symmetrized,
+        np.asarray(aos_data.exponents),
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
 
 
 # ============================================================
@@ -363,7 +402,8 @@ def test_apply_block_update_j3_basis():
     npt.assert_allclose(
         np.array(jastrow_new.jastrow_three_body_data.ao_exponents),
         new_exp,
-        rtol=1e-14,
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
     )
 
 
@@ -387,8 +427,18 @@ def test_apply_block_update_geminal_basis():
         size=int(new_exp.size),
     )
     geminal_new = geminal_ao.apply_block_update(block)
-    npt.assert_allclose(np.array(geminal_new.ao_exponents_up), new_exp_up, rtol=1e-14)
-    npt.assert_allclose(np.array(geminal_new.ao_exponents_dn), new_exp_dn, rtol=1e-14)
+    npt.assert_allclose(
+        np.array(geminal_new.ao_exponents_up),
+        new_exp_up,
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
+    npt.assert_allclose(
+        np.array(geminal_new.ao_exponents_dn),
+        new_exp_dn,
+        atol=get_tolerance("orb_eval", "strict")[0],
+        rtol=get_tolerance("orb_eval", "strict")[1],
+    )
 
 
 # ============================================================
@@ -560,7 +610,9 @@ def test_shell_symmetrize_j3_basis():
     # apply_block_update shell-averages the perturbed values
     spm = ShellPrimMap.from_aos_data(aos_data)
     expected = spm.symmetrize(perturbed)
-    npt.assert_allclose(result, expected, rtol=1e-14)
+    npt.assert_allclose(
+        result, expected, atol=get_tolerance("orb_eval", "strict")[0], rtol=get_tolerance("orb_eval", "strict")[1]
+    )
 
 
 def test_shell_symmetrize_geminal_basis():
@@ -603,7 +655,9 @@ def test_shell_symmetrize_geminal_basis():
         ShellPrimMap.from_aos_data(_get_aos_data(geminal_ao.orb_data_dn_spin)),
     )
     expected = spm.symmetrize(perturbed)
-    npt.assert_allclose(result, expected, rtol=1e-14)
+    npt.assert_allclose(
+        result, expected, atol=get_tolerance("orb_eval", "strict")[0], rtol=get_tolerance("orb_eval", "strict")[1]
+    )
 
 
 def test_shell_symmetrize_metric_averages_sn():

--- a/tests/test_checkpoint_mcmc.py
+++ b/tests/test_checkpoint_mcmc.py
@@ -307,10 +307,20 @@ class TestMCMCOptaxRoundtrip:
     """Optax optimizer state round-trip through MCMC save/load."""
 
     @pytest.fixture(autouse=True)
-    def _setup(self, trexio_file, jastrow_combo, tmp_path):
-        """Build hamiltonian_data once per test method."""
+    def _setup(self, trexio_file, jastrow_combo, tmp_path, monkeypatch):
+        """Build hamiltonian_data once per test method.
+
+        ``run_optimize`` writes ``hamiltonian_data_opt_step_*.h5`` checkpoint
+        files relative to the current working directory.  Without isolating
+        the CWD per test, parametrized runs (especially under pytest-xdist)
+        race on the same filename and h5py raises
+        ``BlockingIOError: Resource temporarily unavailable`` from the
+        underlying file lock.  Switch CWD to the per-test ``tmp_path`` so
+        each test owns its own checkpoint files.
+        """
         self.hd = _build_hamiltonian(trexio_file, jastrow_combo)
         self.tmp_path = tmp_path
+        monkeypatch.chdir(tmp_path)
 
     def test_optax_adam_state_roundtrip(self):
         """After 1 optax optimization step, optimizer_runtime survives save→load."""

--- a/tests/test_comparison_with_turborvb_AE.py
+++ b/tests/test_comparison_with_turborvb_AE.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 import jax
 import numpy as np
+import pytest
 
 # Add the project root directory to sys.path to allow executing this script directly
 # This is necessary because relative imports (e.g. 'from ..jqmc') are not allowed
@@ -56,6 +57,8 @@ from jqmc.wavefunction import Wavefunction_data, compute_kinetic_energy, evaluat
 # JAX float64
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_traceback_filtering", "off")
+
+pytestmark = pytest.mark.external_reference
 
 
 def test_comparison_with_TurboRVB_wo_Jastrow_AE():

--- a/tests/test_comparison_with_turborvb_ECP.py
+++ b/tests/test_comparison_with_turborvb_ECP.py
@@ -39,6 +39,7 @@ from pathlib import Path
 
 import jax
 import numpy as np
+import pytest
 from jax import numpy as jnp
 
 # Add the project root directory to sys.path to allow executing this script directly
@@ -64,6 +65,8 @@ from jqmc.wavefunction import Wavefunction_data, compute_kinetic_energy, evaluat
 # JAX float64
 jax.config.update("jax_enable_x64", True)
 jax.config.update("jax_traceback_filtering", "off")
+
+pytestmark = pytest.mark.external_reference
 
 Nv = 6
 NN = 1

--- a/tests/test_determinant.py
+++ b/tests/test_determinant.py
@@ -46,7 +46,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.atomic_orbital import AOs_sphe_data, compute_overlap_matrix  # noqa: E402
 from jqmc.determinant import (  # noqa: E402
     Geminal_data,
@@ -156,8 +156,8 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
     r_up_carts = np.array(r_up_carts).reshape(-1, 3)
     r_dn_carts = np.array(r_dn_carts).reshape(-1, 3)
 
-    atol_g, rtol_g = get_tolerance("geminal", "strict")
-    atol_d, rtol_d = get_tolerance("determinant", "strict")
+    atol_g, rtol_g = get_tolerance("det_eval", "strict")
+    atol_d, rtol_d = get_tolerance("det_eval", "strict")
 
     geminal_mo_debug = _compute_geminal_all_elements_debug(
         geminal_data=geminal_mo_data,
@@ -300,8 +300,8 @@ def _build_sphe_aos_l_le6(rng: np.random.Generator) -> AOs_sphe_data:
         num_ao=len(angular_momentums),
         num_ao_prim=len(exponents),
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -309,7 +309,9 @@ def _build_sphe_aos_l_le6(rng: np.random.Generator) -> AOs_sphe_data:
 
 def test_geminal_sphe_to_cart_AOs_data():
     """Round-trip AOs l<=6: spherical→Cartesian keeps geminal values/grads."""
-    atol_c, rtol_c = get_tolerance("geminal", "strict")
+    # Comparison crosses ao_eval/det_eval (values) and ao_grad_lap/det_grad_lap (grads);
+    # achievable agreement is bounded by the loosest zone on the path.
+    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad_lap", "det_grad_lap"), "strict")
     rng = np.random.default_rng(321)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -347,7 +349,9 @@ def test_geminal_sphe_to_cart_AOs_data():
 
 def test_geminal_cart_to_sphe_AOs_data():
     """Round-trip AOs l<=6: Cartesian→spherical keeps geminal values/grads."""
-    atol_c, rtol_c = get_tolerance("geminal", "strict")
+    # Comparison crosses ao_eval/det_eval (values) and ao_grad_lap/det_grad_lap (grads);
+    # achievable agreement is bounded by the loosest zone on the path.
+    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad_lap", "det_grad_lap"), "strict")
     rng = np.random.default_rng(654)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -387,7 +391,11 @@ def test_geminal_cart_to_sphe_AOs_data():
 
 def test_geminal_sphe_to_cart_MOs_data():
     """Round-trip MOs built on l<=6 AOs: spherical→Cartesian keeps geminal values/grads."""
-    atol_c, rtol_c = get_tolerance("geminal", "strict")
+    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad_lap/mo_grad_lap/det_grad_lap (grads);
+    # achievable agreement is bounded by the loosest zone on the path.
+    atol_c, rtol_c = get_tolerance_min(
+        ("ao_eval", "mo_eval", "det_eval", "ao_grad_lap", "mo_grad_lap", "det_grad_lap"), "strict"
+    )
     rng = np.random.default_rng(777)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -429,7 +437,11 @@ def test_geminal_sphe_to_cart_MOs_data():
 
 def test_geminal_cart_to_sphe_MOs_data():
     """Round-trip MOs l<=6: Cartesian→spherical keeps geminal values/grads."""
-    atol_c, rtol_c = get_tolerance("geminal", "strict")
+    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad_lap/mo_grad_lap/det_grad_lap (grads);
+    # achievable agreement is bounded by the loosest zone on the path.
+    atol_c, rtol_c = get_tolerance_min(
+        ("ao_eval", "mo_eval", "det_eval", "ao_grad_lap", "mo_grad_lap", "det_grad_lap"), "strict"
+    )
     rng = np.random.default_rng(888)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -485,8 +497,8 @@ def _build_small_sphe_aos_for_conversion() -> AOs_sphe_data:
         num_ao=4,
         num_ao_prim=4,
         orbital_indices=(0, 1, 2, 3),
-        exponents=(1.20, 1.00, 1.00, 1.00),
-        coefficients=(1.0, 1.0, 1.0, 1.0),
+        exponents=np.array([1.20, 1.00, 1.00, 1.00], dtype=np.float64),
+        coefficients=np.array([1.0, 1.0, 1.0, 1.0], dtype=np.float64),
         angular_momentums=(0, 1, 1, 1),
         magnetic_quantum_numbers=(0, -1, 0, 1),
     )
@@ -494,7 +506,7 @@ def _build_small_sphe_aos_for_conversion() -> AOs_sphe_data:
 
 def test_convert_from_AOs_to_MOs_full_projection_closed_shell():
     """AO->MO (all eigenvectors) followed by MO->AO recovers the AO lambda matrix."""
-    atol_c, rtol_c = get_tolerance("determinant", "strict")
+    atol_c, rtol_c = get_tolerance("det_eval", "strict")
     rng = np.random.default_rng(1234)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -528,7 +540,7 @@ def test_convert_from_AOs_to_MOs_full_projection_closed_shell():
 
 def test_convert_from_AOs_to_MOs_full_projection_open_shell():
     """AO->MO (all eigenvectors) round-trip recovers AO lambda matrix for open-shell case."""
-    atol_c, rtol_c = get_tolerance("determinant", "strict")
+    atol_c, rtol_c = get_tolerance("det_eval", "strict")
     rng = np.random.default_rng(1334)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -629,7 +641,7 @@ def test_convert_from_AOs_to_MOs_truncated_mode_open_shell():
 
 def test_apply_ao_projected_paired_update_and_reproject_fixed_num_dn():
     """AO-corrected paired update is applied then reprojected with fixed N=num_electron_dn."""
-    atol_c, rtol_c = get_tolerance("determinant", "strict")
+    atol_c, rtol_c = get_tolerance("det_eval", "strict")
     rng = np.random.default_rng(97531)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -806,7 +818,7 @@ def test_grads_and_laplacian_fast_update(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("det_grad_lap", "strict")
     assert not np.any(np.isnan(np.asarray(grad_up_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_up_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(grad_up_fast, grad_up_debug, atol=atol, rtol=rtol)
@@ -904,7 +916,7 @@ def test_comparing_AS_regularization(trexio_file: str):
 
     R_AS_jax = compute_AS_regularization_factor(geminal_data=geminal_mo_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
 
-    atol, rtol = get_tolerance("determinant", "strict")
+    atol, rtol = get_tolerance("det_eval", "strict")
     assert not np.any(np.isnan(np.asarray(R_AS_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(R_AS_jax))), "NaN detected in second argument"
     np.testing.assert_allclose(R_AS_debug, R_AS_jax, atol=atol, rtol=rtol)
@@ -1015,7 +1027,7 @@ def test_one_row_or_one_column_update(trexio_file: str):
     )
 
     # --- Numerical consistency asserts (no shape checks) ---
-    atol, rtol = get_tolerance("geminal", "strict")
+    atol, rtol = get_tolerance("det_eval", "strict")
     # up-one-row must equal the i-th row of the full geminal
     assert not np.any(np.isnan(np.asarray(np.asarray(geminal_mo_up_one_row).ravel()))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(geminal_mo[i_up, :])))), "NaN detected in second argument"
@@ -1152,7 +1164,7 @@ def test_numerial_and_auto_grads_and_laplacians_ln_Det(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("det_grad_lap", "loose")
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_numerical)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -1284,7 +1296,7 @@ def test_analytic_and_auto_grads_and_laplacians_ln_Det(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("det_grad_lap", "strict")
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -1405,7 +1417,7 @@ def test_ratio_determinant_rank1_update(pattern: str):
         new_r_dn_carts_arr=new_r_dn_carts_arr,
     )
 
-    atol, rtol = get_tolerance("determinant", "strict")
+    atol, rtol = get_tolerance("det_eval", "strict")
     atol_c, rtol_c = atol, rtol
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_rank1)))), "NaN detected in second argument"
@@ -1430,7 +1442,7 @@ def test_compute_ln_det_geminal_all_elements_fast_forward(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
-    atol, rtol = get_tolerance("determinant", "strict")
+    atol, rtol = get_tolerance("det_eval", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -1467,7 +1479,11 @@ def test_compute_ln_det_geminal_all_elements_fast_backward(trexio_file):
     grad_ref_fn = jax.grad(compute_ln_det_geminal_all_elements, argnums=0)
     grad_fast_fn = jax.grad(compute_ln_det_geminal_all_elements_fast, argnums=0)
 
-    atol, rtol = get_tolerance("determinant", "strict")
+    # Backward-AD comparison: ref uses SVD-pseudoinverse custom VJP, fast uses
+    # caller-supplied G_inv; both VJPs propagate through compute_geminal_all_elements
+    # which crosses ao_eval/mo_eval/det_eval. Tolerance is bounded by the
+    # loosest zone on the path.
+    atol, rtol = get_tolerance_min(("ao_eval", "mo_eval", "det_eval"), "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)

--- a/tests/test_determinant.py
+++ b/tests/test_determinant.py
@@ -46,16 +46,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    atol_auto_vs_numerical_deriv,
-    atol_consistency,
-    atol_debug_vs_production,
-    rtol_auto_vs_analytic_deriv,
-    rtol_auto_vs_numerical_deriv,
-    rtol_consistency,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.atomic_orbital import AOs_sphe_data, compute_overlap_matrix  # noqa: E402
 from jqmc.determinant import (  # noqa: E402
     Geminal_data,
@@ -165,6 +156,9 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
     r_up_carts = np.array(r_up_carts).reshape(-1, 3)
     r_dn_carts = np.array(r_dn_carts).reshape(-1, 3)
 
+    atol_g, rtol_g = get_tolerance("geminal", "strict")
+    atol_d, rtol_d = get_tolerance("determinant", "strict")
+
     geminal_mo_debug = _compute_geminal_all_elements_debug(
         geminal_data=geminal_mo_data,
         r_up_carts=r_up_carts,
@@ -179,7 +173,7 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(geminal_mo_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(geminal_mo_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(geminal_mo_debug, geminal_mo_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(geminal_mo_debug, geminal_mo_jax, atol=atol_g, rtol=rtol_g)
 
     geminal_mo = geminal_mo_jax
 
@@ -220,14 +214,14 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(geminal_ao_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(geminal_ao_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(geminal_ao_debug, geminal_ao_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(geminal_ao_debug, geminal_ao_jax, atol=atol_g, rtol=rtol_g)
 
     geminal_ao = geminal_ao_jax
 
     # check if geminals with AO and MO representations are consistent
     assert not np.any(np.isnan(np.asarray(geminal_ao))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(geminal_mo))), "NaN detected in second argument"
-    np.testing.assert_allclose(geminal_ao, geminal_mo, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(geminal_ao, geminal_mo, atol=atol_g, rtol=rtol_g)
 
     det_geminal_mo_debug = _compute_det_geminal_all_elements_debug(
         geminal_data=geminal_mo_data,
@@ -243,9 +237,7 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(det_geminal_mo_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(det_geminal_mo_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        det_geminal_mo_debug, det_geminal_mo_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(det_geminal_mo_debug, det_geminal_mo_jax, atol=atol_d, rtol=rtol_d)
 
     det_geminal_mo = det_geminal_mo_jax
 
@@ -263,14 +255,12 @@ def test_convert_from_MOs_to_AOs_closed_shell(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(det_geminal_ao_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(det_geminal_ao_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        det_geminal_ao_debug, det_geminal_ao_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(det_geminal_ao_debug, det_geminal_ao_jax, atol=atol_d, rtol=rtol_d)
     det_geminal_ao = det_geminal_ao_jax
 
     assert not np.any(np.isnan(np.asarray(det_geminal_ao))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(det_geminal_mo))), "NaN detected in second argument"
-    np.testing.assert_allclose(det_geminal_ao, det_geminal_mo, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(det_geminal_ao, det_geminal_mo, atol=atol_d, rtol=rtol_d)
 
     jax.clear_caches()
 
@@ -319,6 +309,7 @@ def _build_sphe_aos_l_le6(rng: np.random.Generator) -> AOs_sphe_data:
 
 def test_geminal_sphe_to_cart_AOs_data():
     """Round-trip AOs l<=6: spherical→Cartesian keeps geminal values/grads."""
+    atol_c, rtol_c = get_tolerance("geminal", "strict")
     rng = np.random.default_rng(321)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -342,20 +333,21 @@ def test_geminal_sphe_to_cart_AOs_data():
     G_cart = compute_geminal_all_elements(geminal_cart, r_up_carts, r_dn_carts)
     assert not np.any(np.isnan(np.asarray(np.asarray(G_sph)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(G_cart)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(G_sph), np.asarray(G_cart), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(G_sph), np.asarray(G_cart), atol=atol_c, rtol=rtol_c)
 
     grads_sph = compute_grads_and_laplacian_ln_Det(geminal_sph, r_up_carts, r_dn_carts)
     grads_cart = compute_grads_and_laplacian_ln_Det(geminal_cart, r_up_carts, r_dn_carts)
     for sph, cart in zip(grads_sph, grads_cart, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_c, rtol=rtol_c)
 
     jax.clear_caches()
 
 
 def test_geminal_cart_to_sphe_AOs_data():
     """Round-trip AOs l<=6: Cartesian→spherical keeps geminal values/grads."""
+    atol_c, rtol_c = get_tolerance("geminal", "strict")
     rng = np.random.default_rng(654)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -381,20 +373,21 @@ def test_geminal_cart_to_sphe_AOs_data():
     G_sph = compute_geminal_all_elements(geminal_cart_to_sph, r_up_carts, r_dn_carts)
     assert not np.any(np.isnan(np.asarray(np.asarray(G_cart)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(G_sph)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(G_cart), np.asarray(G_sph), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(G_cart), np.asarray(G_sph), atol=atol_c, rtol=rtol_c)
 
     grads_cart = compute_grads_and_laplacian_ln_Det(geminal_cart, r_up_carts, r_dn_carts)
     grads_sph = compute_grads_and_laplacian_ln_Det(geminal_cart_to_sph, r_up_carts, r_dn_carts)
     for cart, sph in zip(grads_cart, grads_sph, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_c, rtol=rtol_c)
 
     jax.clear_caches()
 
 
 def test_geminal_sphe_to_cart_MOs_data():
     """Round-trip MOs built on l<=6 AOs: spherical→Cartesian keeps geminal values/grads."""
+    atol_c, rtol_c = get_tolerance("geminal", "strict")
     rng = np.random.default_rng(777)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -422,20 +415,21 @@ def test_geminal_sphe_to_cart_MOs_data():
     G_cart = compute_geminal_all_elements(geminal_cart, r_up_carts, r_dn_carts)
     assert not np.any(np.isnan(np.asarray(np.asarray(G_sph)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(G_cart)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(G_sph), np.asarray(G_cart), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(G_sph), np.asarray(G_cart), atol=atol_c, rtol=rtol_c)
 
     grads_sph = compute_grads_and_laplacian_ln_Det(geminal_sph, r_up_carts, r_dn_carts)
     grads_cart = compute_grads_and_laplacian_ln_Det(geminal_cart, r_up_carts, r_dn_carts)
     for sph, cart in zip(grads_sph, grads_cart, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_c, rtol=rtol_c)
 
     jax.clear_caches()
 
 
 def test_geminal_cart_to_sphe_MOs_data():
     """Round-trip MOs l<=6: Cartesian→spherical keeps geminal values/grads."""
+    atol_c, rtol_c = get_tolerance("geminal", "strict")
     rng = np.random.default_rng(888)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -465,14 +459,14 @@ def test_geminal_cart_to_sphe_MOs_data():
     G_sph = compute_geminal_all_elements(geminal_cart_to_sph, r_up_carts, r_dn_carts)
     assert not np.any(np.isnan(np.asarray(np.asarray(G_cart)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(G_sph)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(G_cart), np.asarray(G_sph), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(G_cart), np.asarray(G_sph), atol=atol_c, rtol=rtol_c)
 
     grads_cart = compute_grads_and_laplacian_ln_Det(geminal_cart, r_up_carts, r_dn_carts)
     grads_sph = compute_grads_and_laplacian_ln_Det(geminal_cart_to_sph, r_up_carts, r_dn_carts)
     for cart, sph in zip(grads_cart, grads_sph, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_c, rtol=rtol_c)
 
     jax.clear_caches()
 
@@ -500,6 +494,7 @@ def _build_small_sphe_aos_for_conversion() -> AOs_sphe_data:
 
 def test_convert_from_AOs_to_MOs_full_projection_closed_shell():
     """AO->MO (all eigenvectors) followed by MO->AO recovers the AO lambda matrix."""
+    atol_c, rtol_c = get_tolerance("determinant", "strict")
     rng = np.random.default_rng(1234)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -526,13 +521,14 @@ def test_convert_from_AOs_to_MOs_full_projection_closed_shell():
     np.testing.assert_allclose(
         np.asarray(geminal_ao_back.lambda_matrix),
         np.asarray(geminal_ao.lambda_matrix),
-        atol=atol_consistency,
-        rtol=rtol_consistency,
+        atol=atol_c,
+        rtol=rtol_c,
     )
 
 
 def test_convert_from_AOs_to_MOs_full_projection_open_shell():
     """AO->MO (all eigenvectors) round-trip recovers AO lambda matrix for open-shell case."""
+    atol_c, rtol_c = get_tolerance("determinant", "strict")
     rng = np.random.default_rng(1334)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -561,8 +557,8 @@ def test_convert_from_AOs_to_MOs_full_projection_open_shell():
     np.testing.assert_allclose(
         np.asarray(geminal_ao_back.lambda_matrix),
         np.asarray(geminal_ao.lambda_matrix),
-        atol=atol_consistency,
-        rtol=rtol_consistency,
+        atol=atol_c,
+        rtol=rtol_c,
     )
 
 
@@ -633,6 +629,7 @@ def test_convert_from_AOs_to_MOs_truncated_mode_open_shell():
 
 def test_apply_ao_projected_paired_update_and_reproject_fixed_num_dn():
     """AO-corrected paired update is applied then reprojected with fixed N=num_electron_dn."""
+    atol_c, rtol_c = get_tolerance("determinant", "strict")
     rng = np.random.default_rng(97531)
     aos_data = _build_small_sphe_aos_for_conversion()
     aos_data.sanity_check()
@@ -700,8 +697,8 @@ def test_apply_ao_projected_paired_update_and_reproject_fixed_num_dn():
     np.testing.assert_allclose(
         np.asarray(actual.lambda_matrix),
         np.asarray(expected.lambda_matrix),
-        atol=atol_consistency,
-        rtol=rtol_consistency,
+        atol=atol_c,
+        rtol=rtol_c,
     )
 
 
@@ -809,18 +806,19 @@ def test_grads_and_laplacian_fast_update(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(grad_up_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_up_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(grad_up_fast, grad_up_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(grad_up_fast, grad_up_debug, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(grad_dn_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_dn_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(grad_dn_fast, grad_dn_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(grad_dn_fast, grad_dn_debug, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(lap_up_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_up_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_up_fast, lap_up_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(lap_up_fast, lap_up_debug, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(lap_dn_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(lap_dn_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(lap_dn_fast, lap_dn_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(lap_dn_fast, lap_dn_debug, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5", "H2_ae_ccpvdz_cart.h5", "N_ae_ccpvdz_cart.h5"])
@@ -906,9 +904,10 @@ def test_comparing_AS_regularization(trexio_file: str):
 
     R_AS_jax = compute_AS_regularization_factor(geminal_data=geminal_mo_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
 
+    atol, rtol = get_tolerance("determinant", "strict")
     assert not np.any(np.isnan(np.asarray(R_AS_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(R_AS_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(R_AS_debug, R_AS_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(R_AS_debug, R_AS_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1016,14 +1015,15 @@ def test_one_row_or_one_column_update(trexio_file: str):
     )
 
     # --- Numerical consistency asserts (no shape checks) ---
+    atol, rtol = get_tolerance("geminal", "strict")
     # up-one-row must equal the i-th row of the full geminal
     assert not np.any(np.isnan(np.asarray(np.asarray(geminal_mo_up_one_row).ravel()))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(geminal_mo[i_up, :])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(geminal_mo_up_one_row).ravel(),
         np.asarray(geminal_mo[i_up, :]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     # dn-one-column must equal the j-th *paired* column of the full geminal
@@ -1032,11 +1032,12 @@ def test_one_row_or_one_column_update(trexio_file: str):
     np.testing.assert_allclose(
         np.asarray(geminal_mo_dn_one_column).ravel(),
         np.asarray(geminal_mo[:, j_dn]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5", "H2_ae_ccpvdz_cart.h5", "N_ae_ccpvdz_cart.h5"])
 def test_numerial_and_auto_grads_and_laplacians_ln_Det(trexio_file: str):
     """Test the numerical and automatic gradients of the logarithm of the determinant of the geminal wave function."""
@@ -1151,37 +1152,38 @@ def test_numerial_and_auto_grads_and_laplacians_ln_Det(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_numerical)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(grad_ln_D_up_numerical),
         np.asarray(grad_ln_D_up_auto),
-        atol=atol_auto_vs_numerical_deriv,
-        rtol=rtol_auto_vs_numerical_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_dn_numerical)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(grad_ln_D_dn_numerical),
         np.asarray(grad_ln_D_dn_auto),
-        atol=atol_auto_vs_numerical_deriv,
-        rtol=rtol_auto_vs_numerical_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_up_numerical)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_ln_D_up_numerical),
         np.asarray(lap_ln_D_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_dn_numerical)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_ln_D_dn_numerical),
         np.asarray(lap_ln_D_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
     jax.clear_caches()
@@ -1282,37 +1284,38 @@ def test_analytic_and_auto_grads_and_laplacians_ln_Det(trexio_file: str):
         r_dn_carts=r_dn_carts,
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(grad_ln_D_up_analytic),
         np.asarray(grad_ln_D_up_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_dn_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_ln_D_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(grad_ln_D_dn_analytic),
         np.asarray(grad_ln_D_dn_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_up_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_ln_D_up_analytic),
         np.asarray(lap_ln_D_up_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_dn_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_ln_D_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_ln_D_dn_analytic),
         np.asarray(lap_ln_D_dn_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
 
     jax.clear_caches()
@@ -1402,18 +1405,16 @@ def test_ratio_determinant_rank1_update(pattern: str):
         new_r_dn_carts_arr=new_r_dn_carts_arr,
     )
 
+    atol, rtol = get_tolerance("determinant", "strict")
+    atol_c, rtol_c = atol, rtol
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_rank1)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(ratio_debug), np.asarray(ratio_rank1), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(np.asarray(ratio_debug), np.asarray(ratio_rank1), atol=atol, rtol=rtol)
 
     if pattern == "none_moved":
         assert not np.any(np.isnan(np.asarray(np.asarray(ratio_debug)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.ones_like(np.asarray(ratio_debug))))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(ratio_debug), np.ones_like(np.asarray(ratio_debug)), atol=atol_consistency, rtol=rtol_consistency
-        )
+        np.testing.assert_allclose(np.asarray(ratio_debug), np.ones_like(np.asarray(ratio_debug)), atol=atol_c, rtol=rtol_c)
 
     jax.clear_caches()
 
@@ -1429,6 +1430,7 @@ def test_compute_ln_det_geminal_all_elements_fast_forward(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
+    atol, rtol = get_tolerance("determinant", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -1443,8 +1445,8 @@ def test_compute_ln_det_geminal_all_elements_fast_forward(trexio_file):
         np.testing.assert_allclose(
             val_fast,
             val_ref,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg=f"Forward mismatch: fast={val_fast:.15f}, ref={val_ref:.15f}",
         )
 
@@ -1465,6 +1467,7 @@ def test_compute_ln_det_geminal_all_elements_fast_backward(trexio_file):
     grad_ref_fn = jax.grad(compute_ln_det_geminal_all_elements, argnums=0)
     grad_fast_fn = jax.grad(compute_ln_det_geminal_all_elements_fast, argnums=0)
 
+    atol, rtol = get_tolerance("determinant", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -1478,8 +1481,8 @@ def test_compute_ln_det_geminal_all_elements_fast_backward(trexio_file):
             lambda a, b: np.testing.assert_allclose(
                 np.asarray(a),
                 np.asarray(b),
-                rtol=rtol_debug_vs_production,
-                atol=atol_debug_vs_production,
+                rtol=rtol,
+                atol=atol,
                 err_msg="Backward mismatch in compute_ln_det_geminal_all_elements_fast",
             ),
             grad_ref,

--- a/tests/test_determinant.py
+++ b/tests/test_determinant.py
@@ -309,9 +309,9 @@ def _build_sphe_aos_l_le6(rng: np.random.Generator) -> AOs_sphe_data:
 
 def test_geminal_sphe_to_cart_AOs_data():
     """Round-trip AOs l<=6: spherical→Cartesian keeps geminal values/grads."""
-    # Comparison crosses ao_eval/det_eval (values) and ao_grad_lap/det_grad_lap (grads);
+    # Comparison crosses ao_eval/det_eval (values) and ao_grad/ao_lap/det_grad_lap (grads);
     # achievable agreement is bounded by the loosest zone on the path.
-    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad_lap", "det_grad_lap"), "strict")
+    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad", "ao_lap", "det_grad_lap"), "strict")
     rng = np.random.default_rng(321)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -349,9 +349,9 @@ def test_geminal_sphe_to_cart_AOs_data():
 
 def test_geminal_cart_to_sphe_AOs_data():
     """Round-trip AOs l<=6: Cartesian→spherical keeps geminal values/grads."""
-    # Comparison crosses ao_eval/det_eval (values) and ao_grad_lap/det_grad_lap (grads);
+    # Comparison crosses ao_eval/det_eval (values) and ao_grad/ao_lap/det_grad_lap (grads);
     # achievable agreement is bounded by the loosest zone on the path.
-    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad_lap", "det_grad_lap"), "strict")
+    atol_c, rtol_c = get_tolerance_min(("ao_eval", "det_eval", "ao_grad", "ao_lap", "det_grad_lap"), "strict")
     rng = np.random.default_rng(654)
 
     aos_sphe = _build_sphe_aos_l_le6(rng)
@@ -391,10 +391,11 @@ def test_geminal_cart_to_sphe_AOs_data():
 
 def test_geminal_sphe_to_cart_MOs_data():
     """Round-trip MOs built on l<=6 AOs: spherical→Cartesian keeps geminal values/grads."""
-    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad_lap/mo_grad_lap/det_grad_lap (grads);
+    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad/ao_lap/mo_grad/mo_lap/det_grad_lap (grads);
     # achievable agreement is bounded by the loosest zone on the path.
     atol_c, rtol_c = get_tolerance_min(
-        ("ao_eval", "mo_eval", "det_eval", "ao_grad_lap", "mo_grad_lap", "det_grad_lap"), "strict"
+        ("ao_eval", "mo_eval", "det_eval", "ao_grad", "ao_lap", "mo_grad", "mo_lap", "det_grad_lap"),
+        "strict",
     )
     rng = np.random.default_rng(777)
 
@@ -437,10 +438,11 @@ def test_geminal_sphe_to_cart_MOs_data():
 
 def test_geminal_cart_to_sphe_MOs_data():
     """Round-trip MOs l<=6: Cartesian→spherical keeps geminal values/grads."""
-    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad_lap/mo_grad_lap/det_grad_lap (grads);
+    # Comparison crosses ao_eval/mo_eval/det_eval (values) and ao_grad/ao_lap/mo_grad/mo_lap/det_grad_lap (grads);
     # achievable agreement is bounded by the loosest zone on the path.
     atol_c, rtol_c = get_tolerance_min(
-        ("ao_eval", "mo_eval", "det_eval", "ao_grad_lap", "mo_grad_lap", "det_grad_lap"), "strict"
+        ("ao_eval", "mo_eval", "det_eval", "ao_grad", "ao_lap", "mo_grad", "mo_lap", "det_grad_lap"),
+        "strict",
     )
     rng = np.random.default_rng(888)
 

--- a/tests/test_ecps.py
+++ b/tests/test_ecps.py
@@ -45,10 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_debug_vs_production,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.coulomb_potential import (  # noqa: E402
     _compute_bare_coulomb_potential_debug,
     _compute_bare_coulomb_potential_el_ion_element_wise_debug,
@@ -108,6 +105,7 @@ Nv_params = [pytest.param(Nv, id=f"Nv={Nv}") for Nv in (4, 6, 12, 18)]
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_bare_coulomb(trexio_file: str):
     """Test the bare coulomb potential computation."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         _,
         _,
@@ -159,12 +157,13 @@ def test_debug_and_jax_bare_coulomb(trexio_file: str):
     # print(f"vpot_bare_debug = {vpot_bare_debug}")
     assert not np.any(np.isnan(np.asarray(vpot_bare_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(vpot_bare_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(vpot_bare_jax, vpot_bare_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(vpot_bare_jax, vpot_bare_debug, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_ecp_local(trexio_file: str):
     """Test the local ECP potential computation."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         _,
         _,
@@ -214,9 +213,7 @@ def test_debug_and_jax_ecp_local(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(vpot_ecp_local_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(vpot_ecp_local_full_NN_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        vpot_ecp_local_full_NN_jax, vpot_ecp_local_full_NN_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(vpot_ecp_local_full_NN_jax, vpot_ecp_local_full_NN_debug, atol=atol, rtol=rtol)
 
 
 @pytest.mark.activate_if_skip_heavy
@@ -224,6 +221,7 @@ def test_debug_and_jax_ecp_local(trexio_file: str):
 @pytest.mark.parametrize("alpha, beta, gamma", angle_params)
 def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
     """Test the non-local ECP potential computation with the full neibohrs."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         structure_data,
         _,
@@ -314,9 +312,7 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
 
     assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_full_NN_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_full_NN_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        sum_V_nonlocal_full_NN_debug, sum_V_nonlocal_full_NN_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(sum_V_nonlocal_full_NN_debug, sum_V_nonlocal_full_NN_jax, atol=atol, rtol=rtol)
 
     mesh_non_local_r_up_carts_max_full_NN_jax = mesh_non_local_ecp_part_r_up_carts_full_NN_jax[
         np.argmax(V_nonlocal_full_NN_jax)
@@ -338,24 +334,24 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
     np.testing.assert_allclose(
         V_ecp_non_local_max_full_NN_jax,
         V_ecp_non_local_max_full_NN_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_full_NN_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_up_carts_max_full_NN_jax,
         mesh_non_local_r_up_carts_max_full_NN_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_full_NN_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_dn_carts_max_full_NN_jax,
         mesh_non_local_r_dn_carts_max_full_NN_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     # ecp non-local (NN, N=max)
@@ -395,16 +391,14 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
     np.testing.assert_allclose(
         sum_V_nonlocal_full_NN_debug,
         sum_V_nonlocal_NN_check_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     # jax, full-NN vs check-NN
     assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_NN_check_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        sum_V_nonlocal_full_NN_jax, sum_V_nonlocal_NN_check_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(sum_V_nonlocal_full_NN_jax, sum_V_nonlocal_NN_check_jax, atol=atol, rtol=rtol)
 
     mesh_non_local_r_up_carts_max_NN_check_jax = mesh_non_local_ecp_part_r_up_carts_NN_check_jax[
         np.argmax(V_nonlocal_NN_check_jax)
@@ -427,24 +421,24 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
     np.testing.assert_allclose(
         V_ecp_non_local_max_full_NN_debug,
         V_ecp_non_local_max_NN_check_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_full_NN_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_NN_check_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_up_carts_max_full_NN_debug,
         mesh_non_local_r_up_carts_max_NN_check_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_full_NN_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_NN_check_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_dn_carts_max_full_NN_debug,
         mesh_non_local_r_dn_carts_max_NN_check_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     # jax, full-NN vs check-NN
@@ -453,24 +447,24 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
     np.testing.assert_allclose(
         V_ecp_non_local_max_full_NN_jax,
         V_ecp_non_local_max_NN_check_jax,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_NN_check_jax))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_up_carts_max_full_NN_jax,
         mesh_non_local_r_up_carts_max_NN_check_jax,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_full_NN_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_NN_check_jax))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_non_local_r_dn_carts_max_full_NN_jax,
         mesh_non_local_r_dn_carts_max_NN_check_jax,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 
@@ -479,6 +473,7 @@ def test_debug_and_jax_ecp_non_local_full_NN(Nv, alpha, beta, gamma):
 @pytest.mark.parametrize("alpha, beta, gamma", angle_params)
 def test_debug_and_jax_ecp_non_local_partial_NN(Nv, alpha, beta, gamma):
     """Test the non-local ECP potential computation with partial neibohrs."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         structure_data,
         _,
@@ -572,9 +567,7 @@ def test_debug_and_jax_ecp_non_local_partial_NN(Nv, alpha, beta, gamma):
 
         assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_NN_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(sum_V_nonlocal_NN_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            sum_V_nonlocal_NN_debug, sum_V_nonlocal_NN_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-        )
+        np.testing.assert_allclose(sum_V_nonlocal_NN_debug, sum_V_nonlocal_NN_jax, atol=atol, rtol=rtol)
 
         mesh_non_local_r_up_carts_max_NN_jax = mesh_non_local_ecp_part_r_up_carts_NN_jax[np.argmax(V_nonlocal_NN_jax)]
         mesh_non_local_r_up_carts_max_NN_debug = mesh_non_local_ecp_part_r_up_carts_NN_debug[np.argmax(V_nonlocal_NN_debug)]
@@ -588,24 +581,24 @@ def test_debug_and_jax_ecp_non_local_partial_NN(Nv, alpha, beta, gamma):
         np.testing.assert_allclose(
             V_ecp_non_local_max_NN_jax,
             V_ecp_non_local_max_NN_debug,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
         )
         assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_NN_jax))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(mesh_non_local_r_up_carts_max_NN_debug))), "NaN detected in second argument"
         np.testing.assert_allclose(
             mesh_non_local_r_up_carts_max_NN_jax,
             mesh_non_local_r_up_carts_max_NN_debug,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
         )
         assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_NN_jax))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(mesh_non_local_r_dn_carts_max_NN_debug))), "NaN detected in second argument"
         np.testing.assert_allclose(
             mesh_non_local_r_dn_carts_max_NN_jax,
             mesh_non_local_r_dn_carts_max_NN_debug,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
         )
 
 
@@ -638,6 +631,7 @@ def _build_full_jastrow_data(structure_data, geminal_mo_data, coulomb_potential_
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_fast_update_ecp_non_local_partial_NN(trexio_file: str):
     """Fast-update nearest-neighbor ECP matches reference with all Jastrow terms enabled."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         structure_data,
         _aos_data,
@@ -703,29 +697,22 @@ def test_fast_update_ecp_non_local_partial_NN(trexio_file: str):
 
         assert not np.any(np.isnan(np.asarray(np.asarray(sum_V_fast)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(sum_V_ref)))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(sum_V_fast), np.asarray(sum_V_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-        )
+        np.testing.assert_allclose(np.asarray(sum_V_fast), np.asarray(sum_V_ref), atol=atol, rtol=rtol)
         assert not np.any(np.isnan(np.asarray(np.asarray(V_fast)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(V_ref)))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(V_fast), np.asarray(V_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-        )
+        np.testing.assert_allclose(np.asarray(V_fast), np.asarray(V_ref), atol=atol, rtol=rtol)
         assert not np.any(np.isnan(np.asarray(np.asarray(mesh_up_fast)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(mesh_up_ref)))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(mesh_up_fast), np.asarray(mesh_up_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-        )
+        np.testing.assert_allclose(np.asarray(mesh_up_fast), np.asarray(mesh_up_ref), atol=atol, rtol=rtol)
         assert not np.any(np.isnan(np.asarray(np.asarray(mesh_dn_fast)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(mesh_dn_ref)))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(mesh_dn_fast), np.asarray(mesh_dn_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-        )
+        np.testing.assert_allclose(np.asarray(mesh_dn_fast), np.asarray(mesh_dn_ref), atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_bare_el_ion_elements(trexio_file: str):
     """Test the bare couloumb potential computation."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         structure_data,
         _,
@@ -774,19 +761,16 @@ def test_debug_and_jax_bare_el_ion_elements(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(interactions_R_r_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(interactions_R_r_up_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        interactions_R_r_up_debug, interactions_R_r_up_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(interactions_R_r_up_debug, interactions_R_r_up_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(interactions_R_r_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(interactions_R_r_dn_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        interactions_R_r_dn_debug, interactions_R_r_dn_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(interactions_R_r_dn_debug, interactions_R_r_dn_jax, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_discretized_bare_el_ion_elements(trexio_file: str):
     """Test the bare couloumb potential computation."""
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         structure_data,
         _,
@@ -841,14 +825,10 @@ def test_debug_and_jax_discretized_bare_el_ion_elements(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(interactions_R_r_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(interactions_R_r_up_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        interactions_R_r_up_debug, interactions_R_r_up_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(interactions_R_r_up_debug, interactions_R_r_up_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(interactions_R_r_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(interactions_R_r_dn_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        interactions_R_r_dn_debug, interactions_R_r_dn_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(interactions_R_r_dn_debug, interactions_R_r_dn_jax, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("Nv", Nv_params)
@@ -859,6 +839,7 @@ def test_compute_ecp_coulomb_potential_fast(Nv, alpha, beta, gamma):
     With a freshly computed LU inverse both functions must agree to full double
     precision because the only difference is which code path owns the LU solve.
     """
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         _structure_data,
         _aos_data,
@@ -915,9 +896,7 @@ def test_compute_ecp_coulomb_potential_fast(Nv, alpha, beta, gamma):
 
     assert not np.any(np.isnan(np.asarray(V_ref))), "NaN detected in V_ref"
     assert not np.any(np.isnan(np.asarray(V_fast))), "NaN detected in V_fast"
-    np.testing.assert_allclose(
-        np.asarray(V_fast), np.asarray(V_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(np.asarray(V_fast), np.asarray(V_ref), atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("Nv", Nv_params)
@@ -929,6 +908,7 @@ def test_compute_coulomb_potential_fast(Nv, alpha, beta, gamma):
     Psi(r')/Psi(r) ratios must be identical between the two paths because the
     same A_old_inv (exact LU inverse) is used.
     """
+    atol, rtol = get_tolerance("coulomb", "strict")
     (
         _structure_data,
         _aos_data,
@@ -985,9 +965,7 @@ def test_compute_coulomb_potential_fast(Nv, alpha, beta, gamma):
 
     assert not np.any(np.isnan(np.asarray(V_ref))), "NaN detected in V_ref"
     assert not np.any(np.isnan(np.asarray(V_fast))), "NaN detected in V_fast"
-    np.testing.assert_allclose(
-        np.asarray(V_fast), np.asarray(V_ref), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(np.asarray(V_fast), np.asarray(V_ref), atol=atol, rtol=rtol)
 
 
 if __name__ == "__main__":

--- a/tests/test_hamiltonian.py
+++ b/tests/test_hamiltonian.py
@@ -45,14 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    atol_consistency,
-    atol_debug_vs_production,
-    rtol_auto_vs_analytic_deriv,
-    rtol_consistency,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.determinant import (
     Geminal_data,  # noqa: E402
     compute_geminal_all_elements,  # noqa: E402
@@ -222,6 +215,7 @@ def test_compute_local_energy_fast(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     for _ in range(10):
         r_up = jnp.array(first_nucleus + rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(first_nucleus + rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -237,8 +231,8 @@ def test_compute_local_energy_fast(trexio_file):
         np.testing.assert_allclose(
             e_fast,
             e_ref,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg=f"compute_local_energy_fast={e_fast:.10f} != compute_local_energy={e_ref:.10f}",
         )
 
@@ -247,10 +241,16 @@ def _compare_grad_leaves(
     grad_ref,
     grad_test,
     label,
-    atol=atol_auto_vs_analytic_deriv,
-    rtol=rtol_auto_vs_analytic_deriv,
+    atol=None,
+    rtol=None,
 ):
     """Flatten two pytrees and compare every leaf."""
+    if atol is None or rtol is None:
+        _atol, _rtol = get_tolerance_min(["geminal", "jastrow"], "strict")
+        if atol is None:
+            atol = _atol
+        if rtol is None:
+            rtol = _rtol
     leaves_ref = jax.tree_util.tree_leaves(grad_ref)
     leaves_tst = jax.tree_util.tree_leaves(grad_test)
     assert len(leaves_ref) == len(leaves_tst), f"{label}: number of leaves differ ({len(leaves_ref)} vs {len(leaves_tst)})"
@@ -297,26 +297,30 @@ def test_grad_compute_local_energy(trexio_file):
     r_dn = jnp.array(first_nucleus + rng.standard_normal((n_dn, 3)) * 0.5, dtype=jnp.float64)
 
     # Sanity: both forward values must agree.
+    atol, rtol = get_tolerance("kinetic", "strict")
     e_auto = float(_compute_local_energy_auto(hamiltonian_data, r_up, r_dn, RT))
     e_custom = float(compute_local_energy(hamiltonian_data, r_up, r_dn, RT))
     np.testing.assert_allclose(
         e_custom,
         e_auto,
-        atol=atol_consistency,
-        rtol=rtol_consistency,
+        atol=atol,
+        rtol=rtol,
         err_msg="forward e_L mismatch",
     )
 
     # Gradient comparison (w.r.t. full Hamiltonian pytree, argnums=0).
+    # Gradients flow through geminal and jastrow zones (float32 in mixed mode),
+    # so tolerance is bounded by the weakest zone on the path.
     grad_auto = jax.grad(_compute_local_energy_auto, argnums=0)(hamiltonian_data, r_up, r_dn, RT)
     grad_custom = jax.grad(compute_local_energy, argnums=0)(hamiltonian_data, r_up, r_dn, RT)
 
+    atol_grad, rtol_grad = get_tolerance_min(["geminal", "jastrow"], "strict")
     _compare_grad_leaves(
         grad_auto,
         grad_custom,
         label=f"grad(compute_local_energy) vs _auto [{trexio_file}, seed={seed}]",
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol_grad,
+        rtol=rtol_grad,
     )
 
 

--- a/tests/test_hamiltonian.py
+++ b/tests/test_hamiltonian.py
@@ -215,7 +215,7 @@ def test_compute_local_energy_fast(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     for _ in range(10):
         r_up = jnp.array(first_nucleus + rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(first_nucleus + rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -246,7 +246,7 @@ def _compare_grad_leaves(
 ):
     """Flatten two pytrees and compare every leaf."""
     if atol is None or rtol is None:
-        _atol, _rtol = get_tolerance_min(["geminal", "jastrow"], "strict")
+        _atol, _rtol = get_tolerance_min(["det_eval", "jastrow_eval"], "strict")
         if atol is None:
             atol = _atol
         if rtol is None:
@@ -297,7 +297,7 @@ def test_grad_compute_local_energy(trexio_file):
     r_dn = jnp.array(first_nucleus + rng.standard_normal((n_dn, 3)) * 0.5, dtype=jnp.float64)
 
     # Sanity: both forward values must agree.
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     e_auto = float(_compute_local_energy_auto(hamiltonian_data, r_up, r_dn, RT))
     e_custom = float(compute_local_energy(hamiltonian_data, r_up, r_dn, RT))
     np.testing.assert_allclose(
@@ -314,7 +314,7 @@ def test_grad_compute_local_energy(trexio_file):
     grad_auto = jax.grad(_compute_local_energy_auto, argnums=0)(hamiltonian_data, r_up, r_dn, RT)
     grad_custom = jax.grad(compute_local_energy, argnums=0)(hamiltonian_data, r_up, r_dn, RT)
 
-    atol_grad, rtol_grad = get_tolerance_min(["geminal", "jastrow"], "strict")
+    atol_grad, rtol_grad = get_tolerance_min(["det_eval", "jastrow_eval"], "strict")
     _compare_grad_leaves(
         grad_auto,
         grad_custom,

--- a/tests/test_jastrow.py
+++ b/tests/test_jastrow.py
@@ -80,7 +80,7 @@ from jqmc.wavefunction import VariationalParameterBlock  # noqa: E402
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_Jastrow_onebody_part(j1b_type):
     """Test the one-body Jastrow factor, comparing the debug and JAX implementations."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     num_r_up_cart_samples = 8
     num_r_dn_cart_samples = 4
     num_R_cart_samples = 6
@@ -129,7 +129,7 @@ def test_Jastrow_onebody_part(j1b_type):
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_numerical_and_auto_grads_Jastrow_onebody_part(j1b_type):
     """Test numerical and JAX grads of the one-body Jastrow factor."""
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "loose")
     num_r_up_cart_samples = 6
     num_r_dn_cart_samples = 3
     num_R_cart_samples = 5
@@ -193,7 +193,7 @@ def test_numerical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_analytical_and_auto_grads_Jastrow_onebody_part(j1b_type):
     """Analytic vs auto-diff gradients/laplacian for one-body Jastrow."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 4
     num_R_cart_samples = 4
@@ -247,7 +247,7 @@ def test_analytical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_Jastrow_twobody_part(j2b_type):
     """Test the two-body Jastrow factor, comparing the debug and JAX implementations."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -279,8 +279,8 @@ def test_Jastrow_twobody_part(j2b_type):
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
     """Test numerical and JAX grads of the two-body Jastrow factor, comparing the debug and JAX implementations."""
-    atol_s, rtol_s = get_tolerance("jastrow", "strict")
-    atol_l, rtol_l = get_tolerance("kinetic", "loose")
+    atol_s, rtol_s = get_tolerance("jastrow_eval", "strict")
+    atol_l, rtol_l = get_tolerance("jastrow_grad_lap", "loose")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -359,7 +359,7 @@ def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_analytic_and_auto_grads_Jastrow_twobody_part(j2b_type):
     """Analytic vs auto-diff gradients/laplacian for two-body Jastrow."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -422,7 +422,7 @@ def test_analytic_and_auto_grads_Jastrow_twobody_part(j2b_type):
 
 def test_Jastrow_threebody_part_with_AOs_data():
     """Test the three-body Jastrow factor, comparing the debug and JAX implementations, using AOs data."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 6
@@ -435,8 +435,8 @@ def test_Jastrow_threebody_part_with_AOs_data():
     magnetic_quantum_numbers = [0, 0, 0, 0, +1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -496,7 +496,7 @@ def test_Jastrow_threebody_part_with_AOs_data():
 
 def test_Jastrow_threebody_part_with_MOs_data():
     """Test the three-body Jastrow factor, comparing the debug and JAX implementations, using MOs data."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     num_el = 10
     num_mo = 5
     num_ao = 3
@@ -508,8 +508,8 @@ def test_Jastrow_threebody_part_with_MOs_data():
     magnetic_quantum_numbers = [0, 0, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -575,7 +575,7 @@ def test_Jastrow_threebody_part_with_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
     """Round-trip AOs l<=6: spherical→Cartesian keeps J3 values/grads."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     rng = np.random.default_rng(321)
 
     nucleus_index: list[int] = []
@@ -612,8 +612,8 @@ def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
         num_ao=len(angular_momentums),
         num_ao_prim=len(exponents),
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -645,7 +645,7 @@ def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
     """Round-trip AOs l<=6: Cartesian→spherical keeps J3 values/grads."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     rng = np.random.default_rng(654)
 
     nucleus_index: list[int] = []
@@ -682,8 +682,8 @@ def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
         num_ao=len(angular_momentums),
         num_ao_prim=len(exponents),
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -715,7 +715,7 @@ def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
     """Round-trip MOs built on l<=6 AOs: spherical→Cartesian keeps J3 values/grads."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     rng = np.random.default_rng(777)
 
     nucleus_index: list[int] = []
@@ -755,8 +755,8 @@ def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
         num_ao=num_ao,
         num_ao_prim=len(exponents),
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -792,7 +792,7 @@ def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_cart_to_sphe_MOs_data():
     """Round-trip MOs l<=6: Cartesian→spherical keeps J3 values/grads."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     rng = np.random.default_rng(888)
 
     nucleus_index: list[int] = []
@@ -832,8 +832,8 @@ def test_Jastrow_threebody_part_cart_to_sphe_MOs_data():
         num_ao=num_ao,
         num_ao_prim=len(exponents),
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -870,8 +870,8 @@ def test_Jastrow_threebody_part_cart_to_sphe_MOs_data():
 @pytest.mark.numerical_diff
 def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
     """Test numerical and JAX grads of the three-body Jastrow factor, comparing the debug and JAX implementations, using AOs data."""
-    atol_s, rtol_s = get_tolerance("jastrow", "strict")
-    atol_l, rtol_l = get_tolerance("kinetic", "loose")
+    atol_s, rtol_s = get_tolerance("jastrow_eval", "strict")
+    atol_l, rtol_l = get_tolerance("jastrow_grad_lap", "loose")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 6
@@ -884,8 +884,8 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
     magnetic_quantum_numbers = [0, 0, 0, 0, +1, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -985,8 +985,8 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 @pytest.mark.numerical_diff
 def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
     """Test numerical and JAX grads of the three-body Jastrow factor, comparing the debug and JAX implementations, using MOs data."""
-    atol_s, rtol_s = get_tolerance("jastrow", "strict")
-    atol_l, rtol_l = get_tolerance("kinetic", "loose")
+    atol_s, rtol_s = get_tolerance("jastrow_eval", "strict")
+    atol_l, rtol_l = get_tolerance("jastrow_grad_lap", "loose")
     num_el = 10
     num_mo = 5
     num_ao = 3
@@ -998,8 +998,8 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
     magnetic_quantum_numbers = [0, 0, -1]
 
     orbital_indices = tuple(orbital_indices)
-    exponents = tuple(exponents)
-    coefficients = tuple(coefficients)
+    exponents = np.array(exponents, dtype=np.float64)
+    coefficients = np.array(coefficients, dtype=np.float64)
     angular_momentums = tuple(angular_momentums)
     magnetic_quantum_numbers = tuple(magnetic_quantum_numbers)
 
@@ -1104,7 +1104,7 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
     """Analytic vs auto-diff gradients/laplacian for three-body Jastrow (AOs)."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "strict")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 5
@@ -1136,8 +1136,8 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
         num_ao=num_ao,
         num_ao_prim=num_ao_prim,
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -1176,7 +1176,7 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_analytic_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
     """Analytic vs auto-diff gradients/laplacian for three-body Jastrow (MOs)."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "strict")
     num_el = 8
     num_mo = 4
     num_ao = 3
@@ -1209,8 +1209,8 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
         num_ao=num_ao,
         num_ao_prim=num_ao_prim,
         orbital_indices=tuple(orbital_indices),
-        exponents=tuple(exponents),
-        coefficients=tuple(coefficients),
+        exponents=np.array(exponents, dtype=np.float64),
+        coefficients=np.array(coefficients, dtype=np.float64),
         angular_momentums=tuple(angular_momentums),
         magnetic_quantum_numbers=tuple(magnetic_quantum_numbers),
     )
@@ -1336,7 +1336,7 @@ def _build_jastrow_data_for_part_tests(j1b_type: str = "exp", j2b_type: str = "p
 @pytest.mark.parametrize("j1b_type,j2b_type,include_nn", _JASTROW_COMBOS)
 def test_numerical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
     """Numerical vs auto-diff gradients/laplacian for J1+J2+J3(+NN)."""
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "loose")
     jastrow_data, r_up_carts, r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 
     grad_up_num, grad_dn_num, lap_up_num, lap_dn_num = _compute_grads_and_laplacian_Jastrow_part_debug(
@@ -1382,7 +1382,7 @@ def test_numerical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 @pytest.mark.parametrize("j1b_type,j2b_type,include_nn", _JASTROW_COMBOS)
 def test_analytical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
     """Analytic vs auto-diff gradients/laplacian for J1+J2+J3(+NN)."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("jastrow_grad_lap", "strict")
     jastrow_data, r_up_carts, r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 
     grad_up_an, grad_dn_an, lap_up_an, lap_dn_an = compute_grads_and_laplacian_Jastrow_part(
@@ -1418,7 +1418,7 @@ def test_analytical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 @pytest.mark.parametrize("pattern", ["all_moved", "none_moved", "mixed"])
 def test_ratio_Jastrow_part_rank1_update(j1b_type, j2b_type, include_nn, pattern: str):
     """Compare ratio Jastrow part: debug vs rank-1 update implementation."""
-    atol, rtol = get_tolerance("jastrow", "strict")
+    atol, rtol = get_tolerance("jastrow_eval", "strict")
     np.random.seed(0)
     jastrow_data, old_r_up_carts, old_r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 

--- a/tests/test_jastrow.py
+++ b/tests/test_jastrow.py
@@ -43,16 +43,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    atol_auto_vs_numerical_deriv,
-    atol_consistency,
-    atol_debug_vs_production,
-    rtol_auto_vs_analytic_deriv,
-    rtol_auto_vs_numerical_deriv,
-    rtol_consistency,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.atomic_orbital import AOs_sphe_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -89,6 +80,7 @@ from jqmc.wavefunction import VariationalParameterBlock  # noqa: E402
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_Jastrow_onebody_part(j1b_type):
     """Test the one-body Jastrow factor, comparing the debug and JAX implementations."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     num_r_up_cart_samples = 8
     num_r_dn_cart_samples = 4
     num_R_cart_samples = 6
@@ -128,14 +120,16 @@ def test_Jastrow_onebody_part(j1b_type):
 
     assert not np.any(np.isnan(np.asarray(J1_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J1_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J1_debug, J1_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J1_debug, J1_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_numerical_and_auto_grads_Jastrow_onebody_part(j1b_type):
     """Test numerical and JAX grads of the one-body Jastrow factor."""
+    atol, rtol = get_tolerance("kinetic", "loose")
     num_r_up_cart_samples = 6
     num_r_dn_cart_samples = 3
     num_R_cart_samples = 5
@@ -172,29 +166,25 @@ def test_numerical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_num), np.asarray(grad_up_auto), atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_num), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_num), np.asarray(grad_dn_auto), atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_num), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_up_num),
         np.asarray(lap_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_dn_num),
         np.asarray(lap_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
     jax.clear_caches()
@@ -203,6 +193,7 @@ def test_numerical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 @pytest.mark.parametrize("j1b_type", ["exp", "pade"])
 def test_analytical_and_auto_grads_Jastrow_onebody_part(j1b_type):
     """Analytic vs auto-diff gradients/laplacian for one-body Jastrow."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 4
     num_R_cart_samples = 4
@@ -239,24 +230,16 @@ def test_analytical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -264,6 +247,7 @@ def test_analytical_and_auto_grads_Jastrow_onebody_part(j1b_type):
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_Jastrow_twobody_part(j2b_type):
     """Test the two-body Jastrow factor, comparing the debug and JAX implementations."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -285,15 +269,18 @@ def test_Jastrow_twobody_part(j2b_type):
 
     assert not np.any(np.isnan(np.asarray(J2_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J2_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J2_debug, J2_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J2_debug, J2_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
     """Test numerical and JAX grads of the two-body Jastrow factor, comparing the debug and JAX implementations."""
+    atol_s, rtol_s = get_tolerance("jastrow", "strict")
+    atol_l, rtol_l = get_tolerance("kinetic", "loose")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -315,7 +302,7 @@ def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
 
     assert not np.any(np.isnan(np.asarray(J2_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J2_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J2_debug, J2_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J2_debug, J2_jax, atol=atol_s, rtol=rtol_s)
 
     (
         grad_J2_up_debug,
@@ -344,29 +331,25 @@ def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
 
     assert not np.any(np.isnan(np.asarray(grad_J2_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_J2_up_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_J2_up_debug, grad_J2_up_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(grad_J2_up_debug, grad_J2_up_auto, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(grad_J2_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_J2_dn_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_J2_dn_debug, grad_J2_dn_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(grad_J2_dn_debug, grad_J2_dn_auto, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_up_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J2_up_debug),
         np.asarray(lap_J2_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_dn_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J2_dn_debug),
         np.asarray(lap_J2_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
 
     jax.clear_caches()
@@ -376,6 +359,7 @@ def test_numerical_and_auto_grads_Jastrow_twobody_part(j2b_type):
 @pytest.mark.parametrize("j2b_type", ["pade", "exp"])
 def test_analytic_and_auto_grads_Jastrow_twobody_part(j2b_type):
     """Analytic vs auto-diff gradients/laplacian for two-body Jastrow."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     num_r_up_cart_samples = 5
     num_r_dn_cart_samples = 2
 
@@ -405,32 +389,32 @@ def test_analytic_and_auto_grads_Jastrow_twobody_part(j2b_type):
     np.testing.assert_allclose(
         np.asarray(grad_J2_up_analytic),
         np.asarray(grad_J2_up_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_J2_dn_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_J2_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(grad_J2_dn_analytic),
         np.asarray(grad_J2_dn_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_up_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J2_up_analytic),
         np.asarray(lap_J2_up_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_dn_analytic)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J2_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J2_dn_analytic),
         np.asarray(lap_J2_dn_auto),
-        atol=atol_auto_vs_analytic_deriv,
-        rtol=rtol_auto_vs_analytic_deriv,
+        atol=atol,
+        rtol=rtol,
     )
 
     jax.clear_caches()
@@ -438,6 +422,7 @@ def test_analytic_and_auto_grads_Jastrow_twobody_part(j2b_type):
 
 def test_Jastrow_threebody_part_with_AOs_data():
     """Test the three-body Jastrow factor, comparing the debug and JAX implementations, using AOs data."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 6
@@ -504,13 +489,14 @@ def test_Jastrow_threebody_part_with_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(J3_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J3_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 def test_Jastrow_threebody_part_with_MOs_data():
     """Test the three-body Jastrow factor, comparing the debug and JAX implementations, using MOs data."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     num_el = 10
     num_mo = 5
     num_ao = 3
@@ -581,7 +567,7 @@ def test_Jastrow_threebody_part_with_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(J3_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J3_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -589,6 +575,7 @@ def test_Jastrow_threebody_part_with_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
     """Round-trip AOs l<=6: spherical→Cartesian keeps J3 values/grads."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     rng = np.random.default_rng(321)
 
     nucleus_index: list[int] = []
@@ -646,11 +633,11 @@ def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(J_sph)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(J_cart)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(J_sph), np.asarray(J_cart), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(J_sph), np.asarray(J_cart), atol=atol, rtol=rtol)
     for sph, cart in zip(grads_sph, grads_cart, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -658,6 +645,7 @@ def test_Jastrow_threebody_part_sphe_to_cart_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
     """Round-trip AOs l<=6: Cartesian→spherical keeps J3 values/grads."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     rng = np.random.default_rng(654)
 
     nucleus_index: list[int] = []
@@ -715,11 +703,11 @@ def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(J_cart)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(J_sph)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(J_cart), np.asarray(J_sph), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(J_cart), np.asarray(J_sph), atol=atol, rtol=rtol)
     for cart, sph in zip(grads_cart, grads_sph, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -727,6 +715,7 @@ def test_Jastrow_threebody_part_cart_to_sphe_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
     """Round-trip MOs built on l<=6 AOs: spherical→Cartesian keeps J3 values/grads."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     rng = np.random.default_rng(777)
 
     nucleus_index: list[int] = []
@@ -791,11 +780,11 @@ def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(J_sph)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(J_cart)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(J_sph), np.asarray(J_cart), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(J_sph), np.asarray(J_cart), atol=atol, rtol=rtol)
     for sph, cart in zip(grads_sph, grads_cart, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(sph), np.asarray(cart), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -803,6 +792,7 @@ def test_Jastrow_threebody_part_sphe_to_cart_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_Jastrow_threebody_part_cart_to_sphe_MOs_data():
     """Round-trip MOs l<=6: Cartesian→spherical keeps J3 values/grads."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     rng = np.random.default_rng(888)
 
     nucleus_index: list[int] = []
@@ -867,18 +857,21 @@ def test_Jastrow_threebody_part_cart_to_sphe_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(J_cart)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(J_sph)))), "NaN detected in second argument"
-    np.testing.assert_allclose(np.asarray(J_cart), np.asarray(J_sph), atol=atol_consistency, rtol=rtol_consistency)
+    np.testing.assert_allclose(np.asarray(J_cart), np.asarray(J_sph), atol=atol, rtol=rtol)
     for cart, sph in zip(grads_cart, grads_sph, strict=True):
         assert not np.any(np.isnan(np.asarray(np.asarray(cart)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.asarray(sph)))), "NaN detected in second argument"
-        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol_consistency, rtol=rtol_consistency)
+        np.testing.assert_allclose(np.asarray(cart), np.asarray(sph), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
     """Test numerical and JAX grads of the three-body Jastrow factor, comparing the debug and JAX implementations, using AOs data."""
+    atol_s, rtol_s = get_tolerance("jastrow", "strict")
+    atol_l, rtol_l = get_tolerance("kinetic", "loose")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 6
@@ -941,7 +934,7 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(J3_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J3_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_s, rtol=rtol_s)
 
     (
         grad_jastrow_J3_up_debug,
@@ -964,37 +957,36 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_up_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_jastrow_J3_up_debug, grad_jastrow_J3_up_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(grad_jastrow_J3_up_debug, grad_jastrow_J3_up_auto, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_dn_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_jastrow_J3_dn_debug, grad_jastrow_J3_dn_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(grad_jastrow_J3_dn_debug, grad_jastrow_J3_dn_auto, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_up_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J3_up_debug),
         np.asarray(lap_J3_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_dn_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J3_dn_debug),
         np.asarray(lap_J3_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
 
     jax.clear_caches()
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
     """Test numerical and JAX grads of the three-body Jastrow factor, comparing the debug and JAX implementations, using MOs data."""
+    atol_s, rtol_s = get_tolerance("jastrow", "strict")
+    atol_l, rtol_l = get_tolerance("kinetic", "loose")
     num_el = 10
     num_mo = 5
     num_ao = 3
@@ -1061,7 +1053,7 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(J3_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(J3_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(J3_debug, J3_jax, atol=atol_s, rtol=rtol_s)
 
     (
         grad_jastrow_J3_up_debug,
@@ -1084,30 +1076,26 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_up_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_jastrow_J3_up_debug, grad_jastrow_J3_up_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(grad_jastrow_J3_up_debug, grad_jastrow_J3_up_jax, atol=atol_l, rtol=rtol_l)
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(grad_jastrow_J3_dn_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        grad_jastrow_J3_dn_debug, grad_jastrow_J3_dn_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(grad_jastrow_J3_dn_debug, grad_jastrow_J3_dn_jax, atol=atol_l, rtol=rtol_l)
 
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_up_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_up_jax)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J3_up_debug),
         np.asarray(lap_J3_up_jax),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_dn_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_J3_dn_jax)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_J3_dn_debug),
         np.asarray(lap_J3_dn_jax),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol_l,
+        atol=atol_l,
     )
 
     jax.clear_caches()
@@ -1116,6 +1104,7 @@ def test_numerical_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
     """Analytic vs auto-diff gradients/laplacian for three-body Jastrow (AOs)."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     num_r_up_cart_samples = 4
     num_r_dn_cart_samples = 2
     num_R_cart_samples = 5
@@ -1170,24 +1159,16 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1195,6 +1176,7 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_AOs_data():
 @pytest.mark.activate_if_skip_heavy
 def test_analytic_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
     """Analytic vs auto-diff gradients/laplacian for three-body Jastrow (MOs)."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     num_el = 8
     num_mo = 4
     num_ao = 3
@@ -1252,24 +1234,16 @@ def test_analytic_and_auto_grads_Jastrow_threebody_part_with_MOs_data():
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1358,9 +1332,11 @@ def _build_jastrow_data_for_part_tests(j1b_type: str = "exp", j2b_type: str = "p
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("j1b_type,j2b_type,include_nn", _JASTROW_COMBOS)
 def test_numerical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
     """Numerical vs auto-diff gradients/laplacian for J1+J2+J3(+NN)."""
+    atol, rtol = get_tolerance("kinetic", "loose")
     jastrow_data, r_up_carts, r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 
     grad_up_num, grad_dn_num, lap_up_num, lap_dn_num = _compute_grads_and_laplacian_Jastrow_part_debug(
@@ -1377,30 +1353,26 @@ def test_numerical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_num), np.asarray(grad_up_auto), atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_num), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_num), np.asarray(grad_dn_auto), atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_num), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
 
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_up_num),
         np.asarray(lap_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_num)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(lap_dn_num),
         np.asarray(lap_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
     jax.clear_caches()
@@ -1410,6 +1382,7 @@ def test_numerical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 @pytest.mark.parametrize("j1b_type,j2b_type,include_nn", _JASTROW_COMBOS)
 def test_analytical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
     """Analytic vs auto-diff gradients/laplacian for J1+J2+J3(+NN)."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     jastrow_data, r_up_carts, r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 
     grad_up_an, grad_dn_an, lap_up_an, lap_dn_an = compute_grads_and_laplacian_Jastrow_part(
@@ -1426,24 +1399,16 @@ def test_analytical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_up_an), np.asarray(grad_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(grad_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(grad_dn_an), np.asarray(grad_dn_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_up_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_up_an), np.asarray(lap_up_auto), atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_an)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(lap_dn_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(np.asarray(lap_dn_an), np.asarray(lap_dn_auto), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1453,6 +1418,7 @@ def test_analytical_and_auto_grads_Jastrow_part(j1b_type, j2b_type, include_nn):
 @pytest.mark.parametrize("pattern", ["all_moved", "none_moved", "mixed"])
 def test_ratio_Jastrow_part_rank1_update(j1b_type, j2b_type, include_nn, pattern: str):
     """Compare ratio Jastrow part: debug vs rank-1 update implementation."""
+    atol, rtol = get_tolerance("jastrow", "strict")
     np.random.seed(0)
     jastrow_data, old_r_up_carts, old_r_dn_carts = _build_jastrow_data_for_part_tests(j1b_type, j2b_type, include_nn)
 
@@ -1491,16 +1457,12 @@ def test_ratio_Jastrow_part_rank1_update(j1b_type, j2b_type, include_nn, pattern
 
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(ratio_auto)))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        np.asarray(ratio_debug), np.asarray(ratio_auto), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(np.asarray(ratio_debug), np.asarray(ratio_auto), atol=atol, rtol=rtol)
 
     if pattern == "none_moved":
         assert not np.any(np.isnan(np.asarray(np.asarray(ratio_debug)))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(np.ones_like(np.asarray(ratio_debug))))), "NaN detected in second argument"
-        np.testing.assert_allclose(
-            np.asarray(ratio_debug), np.ones_like(np.asarray(ratio_debug)), atol=atol_consistency, rtol=rtol_consistency
-        )
+        np.testing.assert_allclose(np.asarray(ratio_debug), np.ones_like(np.asarray(ratio_debug)), atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_jqmc_gfmc_bra.py
+++ b/tests/test_jqmc_gfmc_bra.py
@@ -45,7 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -181,7 +181,12 @@ def test_jqmc_gfmc_n(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
-    atol, rtol = get_tolerance("gfmc", "strict")
+    # e_L / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/gfmc zones; the
+    # achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
+    atol, rtol = get_tolerance_min(
+        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+        "strict",
+    )
 
     if mpi_rank == 0:
         # w_L

--- a/tests/test_jqmc_gfmc_bra.py
+++ b/tests/test_jqmc_gfmc_bra.py
@@ -45,7 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production  # noqa: E402
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -181,27 +181,29 @@ def test_jqmc_gfmc_n(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
+    atol, rtol = get_tolerance("gfmc", "strict")
+
     if mpi_rank == 0:
         # w_L
         w_L_debug = gfmc_debug.w_L
         w_L_jax = gfmc_jax.w_L
         assert not np.any(np.isnan(np.asarray(w_L_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(w_L_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol, rtol=rtol)
 
         # e_L
         e_L_debug = gfmc_debug.e_L
         e_L_jax = gfmc_jax.e_L
         assert not np.any(np.isnan(np.asarray(e_L_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(e_L_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol, rtol=rtol)
 
         # e_L2
         e_L2_debug = gfmc_debug.e_L2
         e_L2_jax = gfmc_jax.e_L2
         assert not np.any(np.isnan(np.asarray(e_L2_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(e_L2_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol, rtol=rtol)
 
     # E
     E_debug, E_err_debug, Var_debug, Var_err_debug = gfmc_debug.get_E(
@@ -214,16 +216,16 @@ def test_jqmc_gfmc_n(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     assert not np.any(np.isnan(np.asarray(E_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_debug, E_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_debug, E_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(E_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol, rtol=rtol)
 
     # aF
     force_mean_debug, force_std_debug = gfmc_debug.get_aF(
@@ -236,10 +238,10 @@ def test_jqmc_gfmc_n(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     assert not np.any(np.isnan(np.asarray(force_mean_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_mean_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(force_std_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_std_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_jqmc_gfmc_bra.py
+++ b/tests/test_jqmc_gfmc_bra.py
@@ -181,10 +181,10 @@ def test_jqmc_gfmc_n(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
-    # e_L / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/gfmc zones; the
+    # e_L / w_L cross ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic zones; the
     # achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
     atol, rtol = get_tolerance_min(
-        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
         "strict",
     )
 

--- a/tests/test_jqmc_gfmc_tau.py
+++ b/tests/test_jqmc_gfmc_tau.py
@@ -45,7 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production  # noqa: E402
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -178,27 +178,29 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
+    atol, rtol = get_tolerance("gfmc", "strict")
+
     if mpi_rank == 0:
         # w_L
         w_L_debug = gfmc_debug.w_L
         w_L_jax = gfmc_jax.w_L
         assert not np.any(np.isnan(np.asarray(w_L_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(w_L_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol, rtol=rtol)
 
         # e_L
         e_L_debug = gfmc_debug.e_L
         e_L_jax = gfmc_jax.e_L
         assert not np.any(np.isnan(np.asarray(e_L_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(e_L_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol, rtol=rtol)
 
         # e_L2
         e_L2_debug = gfmc_debug.e_L2
         e_L2_jax = gfmc_jax.e_L2
         assert not np.any(np.isnan(np.asarray(e_L2_debug))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(e_L2_jax))), "NaN detected in second argument"
-        np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol, rtol=rtol)
 
     # average_projection_counter
     # Both GFMC_t and _GFMC_t_debug now store local averages per rank.
@@ -206,7 +208,7 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     apc_jax = gfmc_jax.average_projection_counter
     assert not np.any(np.isnan(np.asarray(apc_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(apc_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(apc_debug, apc_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(apc_debug, apc_jax, atol=atol, rtol=rtol)
 
     # E
     E_debug, E_err_debug, Var_debug, Var_err_debug = gfmc_debug.get_E(
@@ -219,16 +221,16 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     assert not np.any(np.isnan(np.asarray(E_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_debug, E_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_debug, E_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(E_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol, rtol=rtol)
 
     # aF
     force_mean_debug, force_std_debug = gfmc_debug.get_aF(
@@ -241,10 +243,10 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     assert not np.any(np.isnan(np.asarray(force_mean_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_mean_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(force_std_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_std_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_jqmc_gfmc_tau.py
+++ b/tests/test_jqmc_gfmc_tau.py
@@ -45,7 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -178,7 +178,12 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
-    atol, rtol = get_tolerance("gfmc", "strict")
+    # e_L / e_L2 / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/gfmc zones;
+    # the achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
+    atol, rtol = get_tolerance_min(
+        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+        "strict",
+    )
 
     if mpi_rank == 0:
         # w_L

--- a/tests/test_jqmc_gfmc_tau.py
+++ b/tests/test_jqmc_gfmc_tau.py
@@ -178,10 +178,10 @@ def test_jqmc_gfmc_t(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jast
     )
     gfmc_jax.run(num_mcmc_steps=num_mcmc_steps)
 
-    # e_L / e_L2 / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/gfmc zones;
+    # e_L / e_L2 / w_L cross ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic zones;
     # the achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
     atol, rtol = get_tolerance_min(
-        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "gfmc"),
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
         "strict",
     )
 

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -80,10 +80,10 @@ param_grid = [
 @pytest.mark.parametrize("trexio_file,with_1b_jastrow,with_2b_jastrow,with_3b_jastrow,with_nn_jastrow", param_grid)
 def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastrow, with_nn_jastrow):
     """Test comparison with MCMC debug and MCMC production implementations."""
-    # e_L / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/mcmc zones; the
+    # e_L / w_L cross ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic zones; the
     # achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
     atol, rtol = get_tolerance_min(
-        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "mcmc"),
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
         "strict",
     )
     (
@@ -1034,9 +1034,9 @@ def test_opt_with_projected_MOs(trexio_file, monkeypatch):
     ln_psi_mo = float(evaluate_ln_wavefunction(final_wf, r_up, r_dn))
     ln_psi_ao = float(evaluate_ln_wavefunction(wf_ao, r_up, r_dn))
 
-    # ln|Psi| crosses orb_eval/jastrow/geminal/determinant; bound by weakest zone.
+    # ln|Psi| crosses ao_eval/jastrow_eval/det_eval; bound by weakest zone.
     atol, rtol = get_tolerance_min(
-        ("orb_eval", "jastrow", "geminal", "determinant", "mcmc"),
+        ("ao_eval", "jastrow_eval", "det_eval"),
         "strict",
     )
     assert not np.any(np.isnan(np.asarray(ln_psi_mo))), "NaN detected in first argument"
@@ -1220,9 +1220,9 @@ def test_vmc_symmetry_preservation(j3_type, lambda_type, monkeypatch):
     lam_after = np.asarray(mcmc.hamiltonian_data.wavefunction_data.geminal_data.lambda_matrix)
 
     # ── Assertions ───────────────────────────────────────────────────────────
-    # j3 / lambda_matrix live in jastrow / geminal zones; symmetry is a structural
+    # j3 / lambda_matrix live in jastrow_eval / det_eval zones; symmetry is a structural
     # property of the matrix itself, so use those zones' tolerances.
-    atol, rtol = get_tolerance_min(("jastrow", "geminal"), "strict")
+    atol, rtol = get_tolerance_min(("jastrow_eval", "det_eval"), "strict")
     if j3_type == "sym":
         np.testing.assert_allclose(
             j3_after[:, :-1],
@@ -1611,7 +1611,7 @@ def test_get_aH_and_solve_lm_debug_vs_production():
 
     # H_0/f/S/K/B cross the full e_L path + optimization assembly; bound by weakest zone.
     atol, rtol = get_tolerance_min(
-        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "mcmc", "optimization"),
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "local_energy"),
         "strict",
     )
 

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -47,7 +47,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance, get_tolerance_min  # noqa: E402
 from jqmc.determinant import Geminal_data  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
@@ -80,7 +80,12 @@ param_grid = [
 @pytest.mark.parametrize("trexio_file,with_1b_jastrow,with_2b_jastrow,with_3b_jastrow,with_nn_jastrow", param_grid)
 def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastrow, with_nn_jastrow):
     """Test comparison with MCMC debug and MCMC production implementations."""
-    atol, rtol = get_tolerance("mcmc", "strict")
+    # e_L / w_L cross orb_eval/jastrow/geminal/coulomb/kinetic/mcmc zones; the
+    # achievable debug-vs-jax agreement is bounded by the weakest (fp32 in mixed).
+    atol, rtol = get_tolerance_min(
+        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "mcmc"),
+        "strict",
+    )
     (
         structure_data,
         _,
@@ -1029,7 +1034,11 @@ def test_opt_with_projected_MOs(trexio_file, monkeypatch):
     ln_psi_mo = float(evaluate_ln_wavefunction(final_wf, r_up, r_dn))
     ln_psi_ao = float(evaluate_ln_wavefunction(wf_ao, r_up, r_dn))
 
-    atol, rtol = get_tolerance("mcmc", "strict")
+    # ln|Psi| crosses orb_eval/jastrow/geminal/determinant; bound by weakest zone.
+    atol, rtol = get_tolerance_min(
+        ("orb_eval", "jastrow", "geminal", "determinant", "mcmc"),
+        "strict",
+    )
     assert not np.any(np.isnan(np.asarray(ln_psi_mo))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(ln_psi_ao))), "NaN detected in second argument"
     np.testing.assert_allclose(ln_psi_mo, ln_psi_ao, atol=atol, rtol=rtol)
@@ -1211,7 +1220,9 @@ def test_vmc_symmetry_preservation(j3_type, lambda_type, monkeypatch):
     lam_after = np.asarray(mcmc.hamiltonian_data.wavefunction_data.geminal_data.lambda_matrix)
 
     # ── Assertions ───────────────────────────────────────────────────────────
-    atol, rtol = get_tolerance("mcmc", "strict")
+    # j3 / lambda_matrix live in jastrow / geminal zones; symmetry is a structural
+    # property of the matrix itself, so use those zones' tolerances.
+    atol, rtol = get_tolerance_min(("jastrow", "geminal"), "strict")
     if j3_type == "sym":
         np.testing.assert_allclose(
             j3_after[:, :-1],
@@ -1598,7 +1609,11 @@ def test_get_aH_and_solve_lm_debug_vs_production():
     # Get variational blocks
     blocks = hamiltonian_data.wavefunction_data.get_variational_blocks()
 
-    atol, rtol = get_tolerance("mcmc", "strict")
+    # H_0/f/S/K/B cross the full e_L path + optimization assembly; bound by weakest zone.
+    atol, rtol = get_tolerance_min(
+        ("orb_eval", "jastrow", "geminal", "determinant", "coulomb", "kinetic", "mcmc", "optimization"),
+        "strict",
+    )
 
     # --- Test 1: get_aH in LM mode (return_matrices=True) ---
     H_0_d, f_d, S_d, K_d, B_d = mcmc_debug.get_aH(

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -47,7 +47,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production  # noqa: E402
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.determinant import Geminal_data  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
@@ -80,6 +80,7 @@ param_grid = [
 @pytest.mark.parametrize("trexio_file,with_1b_jastrow,with_2b_jastrow,with_3b_jastrow,with_nn_jastrow", param_grid)
 def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastrow, with_nn_jastrow):
     """Test comparison with MCMC debug and MCMC production implementations."""
+    atol, rtol = get_tolerance("mcmc", "strict")
     (
         structure_data,
         _,
@@ -173,21 +174,21 @@ def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastro
     w_L_jax = mcmc_jax.w_L
     assert not np.any(np.isnan(np.asarray(w_L_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(w_L_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(w_L_debug, w_L_jax, atol=atol, rtol=rtol)
 
     # e_L
     e_L_debug = mcmc_debug.e_L
     e_L_jax = mcmc_jax.e_L
     assert not np.any(np.isnan(np.asarray(e_L_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(e_L_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(e_L_debug, e_L_jax, atol=atol, rtol=rtol)
 
     # e_L2
     e_L2_debug = mcmc_debug.e_L2
     e_L2_jax = mcmc_jax.e_L2
     assert not np.any(np.isnan(np.asarray(e_L2_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(e_L2_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(e_L2_debug, e_L2_jax, atol=atol, rtol=rtol)
 
     # E
     E_debug, E_err_debug, Var_debug, Var_err_debug = mcmc_debug.get_E(
@@ -208,16 +209,16 @@ def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastro
     assert not np.any(np.isnan(Var_err_jax)), f"Var_err_jax contains NaN: {Var_err_jax}"
     assert not np.any(np.isnan(np.asarray(E_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_debug, E_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_debug, E_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(E_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(E_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(E_err_debug, E_err_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_debug, Var_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(Var_err_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(Var_err_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(Var_err_debug, Var_err_jax, atol=atol, rtol=rtol)
 
     # aF
     force_mean_debug, force_std_debug = mcmc_debug.get_aF(
@@ -234,10 +235,10 @@ def test_jqmc_mcmc(trexio_file, with_1b_jastrow, with_2b_jastrow, with_3b_jastro
     assert not np.any(np.isnan(force_std_jax)), f"force_std_jax contains NaN: {force_std_jax}"
     assert not np.any(np.isnan(np.asarray(force_mean_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_mean_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_mean_debug, force_mean_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(force_std_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(force_std_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(force_std_debug, force_std_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1028,9 +1029,10 @@ def test_opt_with_projected_MOs(trexio_file, monkeypatch):
     ln_psi_mo = float(evaluate_ln_wavefunction(final_wf, r_up, r_dn))
     ln_psi_ao = float(evaluate_ln_wavefunction(wf_ao, r_up, r_dn))
 
+    atol, rtol = get_tolerance("mcmc", "strict")
     assert not np.any(np.isnan(np.asarray(ln_psi_mo))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(ln_psi_ao))), "NaN detected in second argument"
-    np.testing.assert_allclose(ln_psi_mo, ln_psi_ao, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(ln_psi_mo, ln_psi_ao, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 
@@ -1209,12 +1211,13 @@ def test_vmc_symmetry_preservation(j3_type, lambda_type, monkeypatch):
     lam_after = np.asarray(mcmc.hamiltonian_data.wavefunction_data.geminal_data.lambda_matrix)
 
     # ── Assertions ───────────────────────────────────────────────────────────
+    atol, rtol = get_tolerance("mcmc", "strict")
     if j3_type == "sym":
         np.testing.assert_allclose(
             j3_after[:, :-1],
             j3_after[:, :-1].T,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg="j3 sub-block symmetry broken after VMC update",
         )
     else:
@@ -1225,8 +1228,8 @@ def test_vmc_symmetry_preservation(j3_type, lambda_type, monkeypatch):
         np.testing.assert_allclose(
             lam_after,
             lam_after.T,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg="square lambda symmetry broken after VMC update",
         )
     elif lambda_type == "rect_paired_sym":
@@ -1234,8 +1237,8 @@ def test_vmc_symmetry_preservation(j3_type, lambda_type, monkeypatch):
         np.testing.assert_allclose(
             lam_after[:, :n_paired],
             lam_after[:, :n_paired].T,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg="rectangular lambda paired sub-block symmetry broken after VMC update",
         )
     else:
@@ -1595,6 +1598,8 @@ def test_get_aH_and_solve_lm_debug_vs_production():
     # Get variational blocks
     blocks = hamiltonian_data.wavefunction_data.get_variational_blocks()
 
+    atol, rtol = get_tolerance("mcmc", "strict")
+
     # --- Test 1: get_aH in LM mode (return_matrices=True) ---
     H_0_d, f_d, S_d, K_d, B_d = mcmc_debug.get_aH(
         blocks=blocks,
@@ -1607,11 +1612,11 @@ def test_get_aH_and_solve_lm_debug_vs_production():
         return_matrices=True,
     )
 
-    np.testing.assert_allclose(H_0_d, H_0_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(f_d, f_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(S_d, S_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(K_d, K_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(B_d, B_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(H_0_d, H_0_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(f_d, f_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(S_d, S_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(K_d, K_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(B_d, B_p, atol=atol, rtol=rtol)
 
     # --- Test 2: get_aH in aSR mode (return_matrices=False) ---
     # Use a simple direction vector g for the aSR scalar projection test
@@ -1631,19 +1636,19 @@ def test_get_aH_and_solve_lm_debug_vs_production():
         return_matrices=False,
     )
 
-    np.testing.assert_allclose(H_0_d2, H_0_p2, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(H_1_d, H_1_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(H_2_d, H_2_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(S_2_d, S_2_p, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(H_0_d2, H_0_p2, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(H_1_d, H_1_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(H_2_d, H_2_p, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(S_2_d, S_2_p, atol=atol, rtol=rtol)
 
     # --- Test 3: aSR scalars should be consistent with LM matrices ---
     # H_1 = -1/2 g^T f,  S_2 = g^T S g,  H_2 = g^T (K+B) g
     H_1_from_mat = -0.5 * np.dot(g, f_d)
     S_2_from_mat = g @ S_d @ g
     H_2_from_mat = g @ (K_d + B_d) @ g
-    np.testing.assert_allclose(H_1_d, H_1_from_mat, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(S_2_d, S_2_from_mat, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(H_2_d, H_2_from_mat, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(H_1_d, H_1_from_mat, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(S_2_d, S_2_from_mat, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(H_2_d, H_2_from_mat, atol=atol, rtol=rtol)
 
     # --- Test 4: solve_linear_method with identical inputs ---
     # Use the production matrices for both to verify the two implementations
@@ -1651,8 +1656,8 @@ def test_get_aH_and_solve_lm_debug_vs_production():
     epsilon_lm = 1e-6
     c_debug, E_debug = _MCMC_debug.solve_linear_method(H_0_p, f_p, S_p, K_p, B_p, epsilon_lm)
     c_prod, E_prod = MCMC.solve_linear_method(H_0_p, f_p, S_p, K_p, B_p, epsilon_lm)
-    np.testing.assert_allclose(c_debug, c_prod, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
-    np.testing.assert_allclose(E_debug, E_prod, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(c_debug, c_prod, atol=atol, rtol=rtol)
+    np.testing.assert_allclose(E_debug, E_prod, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_jqmc_tool.py
+++ b/tests/test_jqmc_tool.py
@@ -61,10 +61,7 @@ from jqmc.jqmc_tool import (  # noqa: E402
     vmc_analyze_output,
     vmc_generate_input,
 )
-from jqmc._setting import (  # noqa: E402
-    atol_consistency,
-    rtol_consistency,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.trexio_wrapper import read_trexio_file  # noqa: E402
 
 trexio_files = [
@@ -607,8 +604,9 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
-        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
+        atol, rtol = get_tolerance("io", "strict")
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
     def test_mcmc_multi_rank_random(self, tmp_path):
         """Multiple MPI ranks with random data should match np.sum reference."""
@@ -638,8 +636,9 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
-        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
+        atol, rtol = get_tolerance("io", "strict")
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
     def test_mcmc_warmup_discards_steps(self, tmp_path):
         """Warmup discard + random data post-warmup must match reference."""
@@ -669,8 +668,9 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
-        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
+        atol, rtol = get_tolerance("io", "strict")
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
     def test_lrdmc_random_energy_jackknife(self, tmp_path):
         """LRDMC jqmc-tool must match the np.sum-based reference jackknife for random data."""
@@ -699,8 +699,9 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
-        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
+        atol, rtol = get_tolerance("io", "strict")
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
     def test_lrdmc_multi_rank_random(self, tmp_path):
         """Multiple LRDMC ranks with random data must match np.sum reference."""
@@ -730,8 +731,9 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        np.testing.assert_allclose(E_cli, E_ref, atol=atol_consistency, rtol=rtol_consistency)
-        np.testing.assert_allclose(std_cli, std_ref, atol=atol_consistency, rtol=rtol_consistency)
+        atol, rtol = get_tolerance("io", "strict")
+        np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
+        np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
     def test_lrdmc_extrapolate_energy(self, tmp_path):
         """extrapolate-energy with two LRDMC checkpoints should report a->0 result."""

--- a/tests/test_jqmc_tool.py
+++ b/tests/test_jqmc_tool.py
@@ -604,7 +604,7 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        atol, rtol = get_tolerance("io", "strict")
+        atol, rtol = get_tolerance("local_energy", "strict")
         np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
         np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
@@ -636,7 +636,7 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        atol, rtol = get_tolerance("io", "strict")
+        atol, rtol = get_tolerance("local_energy", "strict")
         np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
         np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
@@ -668,7 +668,7 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        atol, rtol = get_tolerance("io", "strict")
+        atol, rtol = get_tolerance("local_energy", "strict")
         np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
         np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
@@ -699,7 +699,7 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        atol, rtol = get_tolerance("io", "strict")
+        atol, rtol = get_tolerance("local_energy", "strict")
         np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
         np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 
@@ -731,7 +731,7 @@ class TestComputeEnergy:
         m = re.search(r"E\s*=\s*([+-]?[\d.eE+-]+)\s*\+-\s*([\d.eE+-]+)", result.output)
         assert m is not None
         E_cli, std_cli = float(m.group(1)), float(m.group(2))
-        atol, rtol = get_tolerance("io", "strict")
+        atol, rtol = get_tolerance("local_energy", "strict")
         np.testing.assert_allclose(E_cli, E_ref, atol=atol, rtol=rtol)
         np.testing.assert_allclose(std_cli, std_ref, atol=atol, rtol=rtol)
 

--- a/tests/test_lrdmc_force.py
+++ b/tests/test_lrdmc_force.py
@@ -44,7 +44,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production  # noqa: E402
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -204,21 +204,22 @@ def test_lrdmc_force_with_SWCT_n(trexio_file: str, jastrow_parameters: dict, loc
     )
 
     # See [J. Chem. Phys. 156, 034101 (2022)]
+    atol, rtol = get_tolerance("gfmc", "strict")
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_mean[0]),
         -1.0 * np.array(force_mean[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.array(force_std[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.array(force_std[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_std[0]),
         np.array(force_std[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 
@@ -315,21 +316,22 @@ def test_lrdmc_force_with_SWCT_t(trexio_file: str, jastrow_parameters: dict, loc
     )
 
     # See [J. Chem. Phys. 156, 034101 (2022)]
+    atol, rtol = get_tolerance("gfmc", "strict")
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_mean[0]),
         -1.0 * np.array(force_mean[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.array(force_std[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.array(force_std[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_std[0]),
         np.array(force_std[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 

--- a/tests/test_lrdmc_force.py
+++ b/tests/test_lrdmc_force.py
@@ -44,7 +44,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance_min  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -203,8 +203,12 @@ def test_lrdmc_force_with_SWCT_n(trexio_file: str, jastrow_parameters: dict, loc
         num_mcmc_bin_blocks=num_mcmc_bin_blocks,
     )
 
+    # Force crosses ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic; bound by weakest zone (fp32 in mixed).
     # See [J. Chem. Phys. 156, 034101 (2022)]
-    atol, rtol = get_tolerance("gfmc", "strict")
+    atol, rtol = get_tolerance_min(
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
+        "strict",
+    )
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -315,8 +319,12 @@ def test_lrdmc_force_with_SWCT_t(trexio_file: str, jastrow_parameters: dict, loc
         num_mcmc_bin_blocks=num_mcmc_bin_blocks,
     )
 
+    # Force crosses ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic; bound by weakest zone (fp32 in mixed).
     # See [J. Chem. Phys. 156, 034101 (2022)]
-    atol, rtol = get_tolerance("gfmc", "strict")
+    atol, rtol = get_tolerance_min(
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
+        "strict",
+    )
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(

--- a/tests/test_mcmc_force.py
+++ b/tests/test_mcmc_force.py
@@ -44,7 +44,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production  # noqa: E402
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -199,21 +199,22 @@ def test_mcmc_force_with_SWCT(trexio_file: str, jastrow_parameters: dict):
     )
 
     # See [J. Chem. Phys. 156, 034101 (2022)]
+    atol, rtol = get_tolerance("mcmc", "strict")
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_mean[0]),
         -1.0 * np.array(force_mean[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(np.array(force_std[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.array(force_std[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.array(force_std[0]),
         np.array(force_std[1]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 

--- a/tests/test_mcmc_force.py
+++ b/tests/test_mcmc_force.py
@@ -44,7 +44,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import get_tolerance  # noqa: E402
+from jqmc._precision import get_tolerance_min  # noqa: E402
 from jqmc.hamiltonians import Hamiltonian_data  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -198,8 +198,12 @@ def test_mcmc_force_with_SWCT(trexio_file: str, jastrow_parameters: dict):
         num_mcmc_bin_blocks=num_mcmc_bin_blocks,
     )
 
+    # Force crosses ao_eval/jastrow_eval/det_eval/coulomb/wf_kinetic; bound by weakest zone (fp32 in mixed).
     # See [J. Chem. Phys. 156, 034101 (2022)]
-    atol, rtol = get_tolerance("mcmc", "strict")
+    atol, rtol = get_tolerance_min(
+        ("ao_eval", "jastrow_eval", "det_eval", "coulomb", "wf_kinetic"),
+        "strict",
+    )
     assert not np.any(np.isnan(np.asarray(np.array(force_mean[0])))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(-1.0 * np.array(force_mean[1])))), "NaN detected in second argument"
     np.testing.assert_allclose(

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -94,11 +94,11 @@ def _skip_if_not_mixed(request):
 @pytest.fixture(autouse=True)
 def _configure_mixed():
     """Ensure mixed mode is active and JIT caches are cleared."""
-    configure({"mode": "mixed"})
+    configure("mixed")
     jax.clear_caches()
     yield
     # Restore full mode after each test to avoid polluting other tests
-    configure({"mode": "full"})
+    configure("full")
     jax.clear_caches()
 
 

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -31,7 +31,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._precision import configure, get_dtype  # noqa: E402
+from jqmc._precision import configure, get_dtype_jnp  # noqa: E402
 from jqmc.atomic_orbital import (  # noqa: E402
     compute_AOs,
     compute_AOs_grad,
@@ -54,12 +54,12 @@ from jqmc.hamiltonians import Hamiltonian_data, compute_local_energy  # noqa: E4
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
     Jastrow_one_body_data,
-    Jastrow_two_body_data,
     Jastrow_three_body_data,
+    Jastrow_two_body_data,
     compute_Jastrow_one_body,
     compute_Jastrow_part,
-    compute_Jastrow_two_body,
     compute_Jastrow_three_body,
+    compute_Jastrow_two_body,
 )
 from jqmc.molecular_orbital import (  # noqa: E402
     compute_MOs,
@@ -178,25 +178,25 @@ class TestAODtype:
     """Verify AO evaluation outputs are float32 in mixed mode."""
 
     def test_compute_AOs_output_dtype(self, h2_data):
-        """compute_AOs must return float32 (orb_eval zone)."""
+        """compute_AOs must return float32 (ao_eval zone)."""
         AOs = compute_AOs(h2_data["aos_data"], h2_data["r_up"])
-        expected = get_dtype("orb_eval")
+        expected = get_dtype_jnp("ao_eval")
         assert AOs.dtype == expected, (
             f"compute_AOs output dtype is {AOs.dtype}, expected {expected}. "
-            "Likely cause: fp64 data (R_carts, exponents, coefficients) not cast to orb_eval dtype inside kernel."
+            "Likely cause: fp64 data (R_carts, exponents, coefficients) not cast to ao_eval dtype inside kernel."
         )
 
     def test_compute_AOs_grad_output_dtype(self, h2_data):
-        """compute_AOs_grad must return float in kinetic zone dtype."""
+        """compute_AOs_grad must return ao_grad_lap zone dtype."""
         grad_x, grad_y, grad_z = compute_AOs_grad(h2_data["aos_data"], h2_data["r_up"])
-        expected = get_dtype("kinetic")
+        expected = get_dtype_jnp("ao_grad_lap")
         for name, arr in [("grad_x", grad_x), ("grad_y", grad_y), ("grad_z", grad_z)]:
             assert arr.dtype == expected, f"compute_AOs_grad {name} dtype is {arr.dtype}, expected {expected}."
 
     def test_compute_AOs_laplacian_output_dtype(self, h2_data):
-        """compute_AOs_laplacian must return kinetic zone dtype."""
+        """compute_AOs_laplacian must return ao_grad_lap zone dtype."""
         lap = compute_AOs_laplacian(h2_data["aos_data"], h2_data["r_up"])
-        expected = get_dtype("kinetic")
+        expected = get_dtype_jnp("ao_grad_lap")
         assert lap.dtype == expected, f"compute_AOs_laplacian dtype is {lap.dtype}, expected {expected}."
 
 
@@ -216,12 +216,12 @@ class TestMODtype:
     """
 
     def test_compute_MOs_output_dtype(self, h2_data):
-        """compute_MOs must return determinant-zone dtype (fp64 in mixed)."""
+        """compute_MOs must return mo_eval-zone dtype (fp64 in mixed)."""
         MOs = compute_MOs(h2_data["mos_data_up"], h2_data["r_up"])
-        expected = get_dtype("determinant")
+        expected = get_dtype_jnp("mo_eval")
         assert MOs.dtype == expected, (
             f"compute_MOs output dtype is {MOs.dtype}, expected {expected}. "
-            "compute_MOs should upcast its small matmul to the determinant zone "
+            "compute_MOs should upcast its small matmul to the mo_eval zone "
             "to avoid fp32 amplification downstream."
         )
 
@@ -241,7 +241,7 @@ class TestJastrowDtype:
         """
         j2_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="pade")
         J2 = compute_Jastrow_two_body(j2_data, h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("jastrow")
+        expected = get_dtype_jnp("jastrow_eval")
         assert jnp.asarray(J2).dtype == expected, (
             f"compute_Jastrow_two_body dtype is {jnp.asarray(J2).dtype}, expected {expected}. "
             "Likely cause: jastrow_2b_param not cast to jastrow dtype."
@@ -256,7 +256,7 @@ class TestJastrowDtype:
             orb_data=h2_data["aos_data"], random_init=True, random_scale=1e-3
         )
         J3 = compute_Jastrow_three_body(j3_data, h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("jastrow")
+        expected = get_dtype_jnp("jastrow_eval")
         assert jnp.asarray(J3).dtype == expected, (
             f"compute_Jastrow_three_body dtype is {jnp.asarray(J3).dtype}, expected {expected}. "
             "Likely cause: j_matrix not cast to jastrow dtype."
@@ -274,7 +274,7 @@ class TestJastrowDtype:
             jastrow_three_body_data=j3_data,
         )
         J = compute_Jastrow_part(jastrow_data, h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("jastrow")
+        expected = get_dtype_jnp("jastrow_eval")
         assert jnp.asarray(J).dtype == expected, f"compute_Jastrow_part dtype is {jnp.asarray(J).dtype}, expected {expected}."
 
 
@@ -292,7 +292,7 @@ class TestGeminalDtype:
         Catches: lambda_matrix or AO data not cast to geminal dtype.
         """
         G = compute_geminal_all_elements(h2_data["geminal_data"], h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("geminal")
+        expected = get_dtype_jnp("det_eval")
         assert G.dtype == expected, f"compute_geminal_all_elements dtype is {G.dtype}, expected {expected}."
 
 
@@ -310,7 +310,7 @@ class TestDeterminantDtype:
         Even though geminal matrix is float32, the log-det must be computed in float64.
         """
         ln_det = compute_ln_det_geminal_all_elements(h2_data["geminal_data"], h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("determinant")
+        expected = get_dtype_jnp("det_eval")
         assert jnp.asarray(ln_det).dtype == expected, (
             f"compute_ln_det dtype is {jnp.asarray(ln_det).dtype}, expected {expected}."
         )
@@ -327,7 +327,7 @@ class TestCoulombDtype:
     def test_bare_coulomb_el_el_output_dtype(self, h2_data):
         """Electron-electron Coulomb must return float32 (coulomb zone)."""
         V = compute_bare_coulomb_potential_el_el(h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("coulomb")
+        expected = get_dtype_jnp("coulomb")
         assert jnp.asarray(V).dtype == expected, (
             f"compute_bare_coulomb_potential_el_el dtype is {jnp.asarray(V).dtype}, expected {expected}."
         )
@@ -340,7 +340,7 @@ class TestCoulombDtype:
         V_up, V_dn = compute_bare_coulomb_potential_el_ion_element_wise(
             h2_data["coulomb_data"], h2_data["r_up"], h2_data["r_dn"]
         )
-        expected = get_dtype("coulomb")
+        expected = get_dtype_jnp("coulomb")
         assert V_up.dtype == expected, (
             f"el_ion V_up dtype is {V_up.dtype}, expected {expected}. "
             "Likely cause: R_charges or R_carts not cast to coulomb dtype."
@@ -349,7 +349,7 @@ class TestCoulombDtype:
     def test_bare_coulomb_total_output_dtype(self, h2_data):
         """Total bare Coulomb must return float32 (coulomb zone)."""
         V = compute_bare_coulomb_potential(h2_data["coulomb_data"], h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("coulomb")
+        expected = get_dtype_jnp("coulomb")
         assert jnp.asarray(V).dtype == expected, (
             f"compute_bare_coulomb_potential dtype is {jnp.asarray(V).dtype}, expected {expected}."
         )
@@ -364,10 +364,10 @@ class TestKineticDtype:
     """Verify kinetic energy stays float64 in mixed mode."""
 
     def test_kinetic_energy_output_dtype(self, h2_data):
-        """compute_kinetic_energy must return float64 (kinetic zone)."""
+        """compute_kinetic_energy must return float64 (wf_kinetic zone)."""
         wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
         T = compute_kinetic_energy(wf_data, h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("kinetic")
+        expected = get_dtype_jnp("wf_kinetic")
         assert jnp.asarray(T).dtype == expected, f"compute_kinetic_energy dtype is {jnp.asarray(T).dtype}, expected {expected}."
 
 
@@ -393,7 +393,7 @@ class TestWavefunctionDtype:
         )
         wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"], jastrow_data=jastrow_data)
         ln_psi = evaluate_ln_wavefunction(wf_data, h2_data["r_up"], h2_data["r_dn"])
-        expected = get_dtype("determinant")
+        expected = get_dtype_jnp("wf_eval")
         assert jnp.asarray(ln_psi).dtype == expected, (
             f"evaluate_ln_wavefunction dtype is {jnp.asarray(ln_psi).dtype}, expected {expected}."
         )
@@ -409,16 +409,16 @@ class TestAOSpheDtype:
 
     def test_compute_AOs_sphe_output_dtype(self, h2_sphe_data):
         AOs = compute_AOs(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
-        _assert_dtype(AOs, get_dtype("orb_eval"), "compute_AOs (sphe)")
+        _assert_dtype(AOs, get_dtype_jnp("ao_eval"), "compute_AOs (sphe)")
 
     def test_compute_AOs_sphe_grad_output_dtype(self, h2_sphe_data):
         gx, gy, gz = compute_AOs_grad(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
         for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
-            _assert_dtype(arr, get_dtype("kinetic"), f"compute_AOs_grad sphe {name}")
+            _assert_dtype(arr, get_dtype_jnp("ao_grad_lap"), f"compute_AOs_grad sphe {name}")
 
     def test_compute_AOs_sphe_laplacian_output_dtype(self, h2_sphe_data):
         lap = compute_AOs_laplacian(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
-        _assert_dtype(lap, get_dtype("kinetic"), "compute_AOs_laplacian (sphe)")
+        _assert_dtype(lap, get_dtype_jnp("ao_grad_lap"), "compute_AOs_laplacian (sphe)")
 
 
 class TestMOExtendedDtype:
@@ -426,13 +426,13 @@ class TestMOExtendedDtype:
 
     def test_compute_MOs_grad_output_dtype(self, h2_data):
         gx, gy, gz = compute_MOs_grad(h2_data["mos_data_up"], h2_data["r_up"])
-        expected = get_dtype("kinetic")
+        expected = get_dtype_jnp("mo_grad_lap")
         for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
             _assert_dtype(arr, expected, f"compute_MOs_grad {name}")
 
     def test_compute_MOs_laplacian_output_dtype(self, h2_data):
         lap = compute_MOs_laplacian(h2_data["mos_data_up"], h2_data["r_up"])
-        _assert_dtype(lap, get_dtype("kinetic"), "compute_MOs_laplacian")
+        _assert_dtype(lap, get_dtype_jnp("mo_grad_lap"), "compute_MOs_laplacian")
 
 
 class TestJastrowOneBodyDtype:
@@ -447,7 +447,7 @@ class TestJastrowOneBodyDtype:
             jastrow_1b_type="pade",
         )
         J1 = compute_Jastrow_one_body(j1_data, h2_data["r_up"], h2_data["r_dn"])
-        _assert_dtype(J1, get_dtype("jastrow"), "compute_Jastrow_one_body")
+        _assert_dtype(J1, get_dtype_jnp("jastrow_eval"), "compute_Jastrow_one_body")
 
 
 class TestGeminalFastUpdateDtype:
@@ -461,12 +461,12 @@ class TestGeminalFastUpdateDtype:
     def test_geminal_up_one_row_output_dtype(self, water_data):
         # Use [0:1] to get shape (1, 3) — compute_orb_api requires (N, 3), not (3,)
         row = compute_geminal_up_one_row_elements(water_data["geminal_data"], water_data["r_up"][0:1], water_data["r_dn"])
-        _assert_dtype(row, get_dtype("geminal"), "compute_geminal_up_one_row_elements")
+        _assert_dtype(row, get_dtype_jnp("det_ratio"), "compute_geminal_up_one_row_elements")
 
     def test_geminal_dn_one_column_output_dtype(self, water_data):
         # Use [0:1] to get shape (1, 3) — compute_orb_api requires (N, 3), not (3,)
         col = compute_geminal_dn_one_column_elements(water_data["geminal_data"], water_data["r_up"], water_data["r_dn"][0:1])
-        _assert_dtype(col, get_dtype("geminal"), "compute_geminal_dn_one_column_elements")
+        _assert_dtype(col, get_dtype_jnp("det_ratio"), "compute_geminal_dn_one_column_elements")
 
 
 class TestECPDtype:
@@ -477,7 +477,7 @@ class TestECPDtype:
 
     def test_compute_ecp_local_parts_output_dtype(self, h2_ecp_data):
         V_loc = compute_ecp_local_parts_all_pairs(h2_ecp_data["coulomb_data"], h2_ecp_data["r_up"], h2_ecp_data["r_dn"])
-        _assert_dtype(V_loc, get_dtype("coulomb"), "compute_ecp_local_parts_all_pairs")
+        _assert_dtype(V_loc, get_dtype_jnp("coulomb"), "compute_ecp_local_parts_all_pairs")
 
     def test_compute_ecp_non_local_eval_shape_dtype(self, h2_ecp_data):
         """Heavy ECP non-local kernel: verify dtype via jax.eval_shape (no execution)."""
@@ -498,7 +498,7 @@ class TestECPDtype:
         )
         _assert_eval_shape_dtype(
             compute_ecp_non_local_part_all_pairs_jax_weights_grid_points,
-            get_dtype("coulomb"),
+            get_dtype_jnp("coulomb"),
             "compute_ecp_non_local_part_all_pairs_jax_weights_grid_points",
             h2_ecp_data["coulomb_data"],
             wf_data,
@@ -521,7 +521,7 @@ class TestLocalEnergyDtype:
         )
         RT = jnp.eye(3, dtype=jnp.float64)
         e_L = compute_local_energy(ham, h2_data["r_up"], h2_data["r_dn"], RT)
-        _assert_dtype(e_L, get_dtype("kinetic"), "compute_local_energy")
+        _assert_dtype(e_L, get_dtype_jnp("local_energy"), "compute_local_energy")
 
 
 class TestKineticEvalShape:
@@ -535,7 +535,7 @@ class TestKineticEvalShape:
         wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
         _assert_eval_shape_dtype(
             compute_kinetic_energy,
-            get_dtype("kinetic"),
+            get_dtype_jnp("wf_kinetic"),
             "compute_kinetic_energy (eval_shape)",
             wf_data,
             h2_data["r_up"],
@@ -546,7 +546,7 @@ class TestKineticEvalShape:
         wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
         _assert_eval_shape_dtype(
             evaluate_ln_wavefunction,
-            get_dtype("determinant"),
+            get_dtype_jnp("wf_eval"),
             "evaluate_ln_wavefunction (eval_shape)",
             wf_data,
             h2_data["r_up"],

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -206,18 +206,23 @@ class TestAODtype:
 
 
 class TestMODtype:
-    """Verify MO evaluation outputs are float32 in mixed mode."""
+    """Verify MO evaluation outputs use the determinant-zone dtype.
+
+    Note: AO evaluation itself runs in ``orb_eval`` precision (e.g. fp32 in mixed
+    mode), but the (small) MO matmul is upcast to the ``determinant`` zone dtype
+    (fp64 by default).  This avoids amplifying fp32 round-off through the
+    32x32 determinant / kinetic / energy paths while keeping the heavy AO
+    kernels in fp32 (see bug/fp32 diagnostics).
+    """
 
     def test_compute_MOs_output_dtype(self, h2_data):
-        """compute_MOs must return float32 (orb_eval zone).
-
-        Catches: mo_coefficients (fp64) × AOs (fp32) promotion.
-        """
+        """compute_MOs must return determinant-zone dtype (fp64 in mixed)."""
         MOs = compute_MOs(h2_data["mos_data_up"], h2_data["r_up"])
-        expected = get_dtype("orb_eval")
+        expected = get_dtype("determinant")
         assert MOs.dtype == expected, (
             f"compute_MOs output dtype is {MOs.dtype}, expected {expected}. "
-            "Likely cause: mo_coefficients not cast to orb_eval dtype."
+            "compute_MOs should upcast its small matmul to the determinant zone "
+            "to avoid fp32 amplification downstream."
         )
 
 

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -1,0 +1,549 @@
+"""Mixed precision dtype propagation tests.
+
+These tests verify that when ``--precision-mode=mixed`` is active, each
+Precision Zone produces outputs in the expected dtype. They catch JAX
+dtype-promotion bugs where fp64 data (io/optimization zone) leaks into
+fp32 compute kernels and silently promotes the entire computation to fp64.
+
+Every test:
+  1. Configures ``mode="mixed"`` explicitly (independent of the CLI flag).
+  2. Calls the target function with realistic inputs.
+  3. Asserts the output dtype matches the zone's configured dtype.
+
+In ``mode="full"`` (the default), all zones are fp64 and these tests are
+trivially satisfied, so they are skipped to save time.
+
+Run with::
+
+    pytest tests/test_mixed_precision.py -v --precision-mode=mixed
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+project_root = str(Path(__file__).parent.parent)
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
+from jqmc._precision import configure, get_dtype  # noqa: E402
+from jqmc.atomic_orbital import (  # noqa: E402
+    compute_AOs,
+    compute_AOs_grad,
+    compute_AOs_laplacian,
+)
+from jqmc.coulomb_potential import (  # noqa: E402
+    compute_bare_coulomb_potential,
+    compute_bare_coulomb_potential_el_el,
+    compute_bare_coulomb_potential_el_ion_element_wise,
+    compute_ecp_local_parts_all_pairs,
+    compute_ecp_non_local_part_all_pairs_jax_weights_grid_points,
+)
+from jqmc.determinant import (  # noqa: E402
+    compute_geminal_all_elements,
+    compute_geminal_dn_one_column_elements,
+    compute_geminal_up_one_row_elements,
+    compute_ln_det_geminal_all_elements,
+)
+from jqmc.hamiltonians import Hamiltonian_data, compute_local_energy  # noqa: E402
+from jqmc.jastrow_factor import (  # noqa: E402
+    Jastrow_data,
+    Jastrow_one_body_data,
+    Jastrow_two_body_data,
+    Jastrow_three_body_data,
+    compute_Jastrow_one_body,
+    compute_Jastrow_part,
+    compute_Jastrow_two_body,
+    compute_Jastrow_three_body,
+)
+from jqmc.molecular_orbital import (  # noqa: E402
+    compute_MOs,
+    compute_MOs_grad,
+    compute_MOs_laplacian,
+)
+from jqmc.trexio_wrapper import read_trexio_file  # noqa: E402
+from jqmc.wavefunction import (  # noqa: E402
+    Wavefunction_data,
+    compute_kinetic_energy,
+    evaluate_ln_wavefunction,
+)
+
+# JAX float64
+jax.config.update("jax_enable_x64", True)
+jax.config.update("jax_traceback_filtering", "off")
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TREXIO_DIR = os.path.join(os.path.dirname(__file__), "trexio_example_files")
+
+
+@pytest.fixture(autouse=True)
+def _skip_if_not_mixed(request):
+    """Skip these tests unless --precision-mode=mixed is active."""
+    if request.config.getoption("--precision-mode") != "mixed":
+        pytest.skip("Only runs with --precision-mode=mixed")
+
+
+@pytest.fixture(autouse=True)
+def _configure_mixed():
+    """Ensure mixed mode is active and JIT caches are cleared."""
+    configure({"mode": "mixed"})
+    jax.clear_caches()
+    yield
+    # Restore full mode after each test to avoid polluting other tests
+    configure({"mode": "full"})
+    jax.clear_caches()
+
+
+def _load_trexio(filename: str) -> dict:
+    """Helper that loads a TREXIO file and synthesizes random electron coordinates."""
+    trexio_file = os.path.join(TREXIO_DIR, filename)
+    structure_data, aos_data, mos_data_up, mos_data_dn, geminal_data, coulomb_data = read_trexio_file(
+        trexio_file=trexio_file, store_tuple=True
+    )
+    rng = np.random.default_rng(42)
+    n_up = geminal_data.num_electron_up
+    n_dn = geminal_data.num_electron_dn
+    r_up = jnp.array(rng.standard_normal((n_up, 3)) * 0.5, dtype=jnp.float64)
+    r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 0.5, dtype=jnp.float64)
+    return {
+        "structure_data": structure_data,
+        "aos_data": aos_data,
+        "mos_data_up": mos_data_up,
+        "mos_data_dn": mos_data_dn,
+        "geminal_data": geminal_data,
+        "coulomb_data": coulomb_data,
+        "r_up": r_up,
+        "r_dn": r_dn,
+    }
+
+
+@pytest.fixture
+def h2_data():
+    """Load H2 all-electron Cartesian basis test data."""
+    return _load_trexio("H2_ae_ccpvdz_cart.h5")
+
+
+@pytest.fixture
+def h2_sphe_data():
+    """Load H2 all-electron spherical basis test data (covers AO_sphe path)."""
+    return _load_trexio("H2_ae_ccpvdz_sphe.h5")
+
+
+@pytest.fixture
+def h2_ecp_data():
+    """Load H2 ECP test data (covers ECP local/non-local paths)."""
+    return _load_trexio("H2_ecp_ccpvtz.h5")
+
+
+def _assert_dtype(arr, expected, label):
+    """Helper: assert array (or scalar) dtype matches expected."""
+    actual = jnp.asarray(arr).dtype
+    assert actual == expected, (
+        f"{label} dtype is {actual}, expected {expected}. "
+        "Check kernel-entry casts of (1) input r_carts, (2) all pytree float fields, "
+        "(3) jnp.array/zeros/ones literals."
+    )
+
+
+def _assert_eval_shape_dtype(fn, expected, label, *args, **kwargs):
+    """Helper: use jax.eval_shape (no actual execution) to assert output dtype.
+
+    Useful for heavy kernels (ECP non-local) where executing in mixed mode
+    is slow. Returns a ShapeDtypeStruct (or pytree thereof) and we walk the
+    leaves to assert every float leaf has the expected dtype.
+    """
+    out = jax.eval_shape(fn, *args, **kwargs)
+    leaves = jax.tree_util.tree_leaves(out)
+    bad = [(i, leaf.dtype) for i, leaf in enumerate(leaves) if leaf.dtype.kind == "f" and leaf.dtype != expected]
+    assert not bad, (
+        f"{label} has float leaves with unexpected dtype: {bad}. Expected {expected}. "
+        "Heavy kernels checked via jax.eval_shape (no execution)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# A. AO zone (orb_eval → float32 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestAODtype:
+    """Verify AO evaluation outputs are float32 in mixed mode."""
+
+    def test_compute_AOs_output_dtype(self, h2_data):
+        """compute_AOs must return float32 (orb_eval zone)."""
+        AOs = compute_AOs(h2_data["aos_data"], h2_data["r_up"])
+        expected = get_dtype("orb_eval")
+        assert AOs.dtype == expected, (
+            f"compute_AOs output dtype is {AOs.dtype}, expected {expected}. "
+            "Likely cause: fp64 data (R_carts, exponents, coefficients) not cast to orb_eval dtype inside kernel."
+        )
+
+    def test_compute_AOs_grad_output_dtype(self, h2_data):
+        """compute_AOs_grad must return float in kinetic zone dtype."""
+        grad_x, grad_y, grad_z = compute_AOs_grad(h2_data["aos_data"], h2_data["r_up"])
+        expected = get_dtype("kinetic")
+        for name, arr in [("grad_x", grad_x), ("grad_y", grad_y), ("grad_z", grad_z)]:
+            assert arr.dtype == expected, f"compute_AOs_grad {name} dtype is {arr.dtype}, expected {expected}."
+
+    def test_compute_AOs_laplacian_output_dtype(self, h2_data):
+        """compute_AOs_laplacian must return kinetic zone dtype."""
+        lap = compute_AOs_laplacian(h2_data["aos_data"], h2_data["r_up"])
+        expected = get_dtype("kinetic")
+        assert lap.dtype == expected, f"compute_AOs_laplacian dtype is {lap.dtype}, expected {expected}."
+
+
+# ---------------------------------------------------------------------------
+# B. MO zone (orb_eval → float32 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestMODtype:
+    """Verify MO evaluation outputs are float32 in mixed mode."""
+
+    def test_compute_MOs_output_dtype(self, h2_data):
+        """compute_MOs must return float32 (orb_eval zone).
+
+        Catches: mo_coefficients (fp64) × AOs (fp32) promotion.
+        """
+        MOs = compute_MOs(h2_data["mos_data_up"], h2_data["r_up"])
+        expected = get_dtype("orb_eval")
+        assert MOs.dtype == expected, (
+            f"compute_MOs output dtype is {MOs.dtype}, expected {expected}. "
+            "Likely cause: mo_coefficients not cast to orb_eval dtype."
+        )
+
+
+# ---------------------------------------------------------------------------
+# C. Jastrow zone (jastrow → float32 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestJastrowDtype:
+    """Verify Jastrow outputs are float32 in mixed mode."""
+
+    def test_jastrow_two_body_output_dtype(self, h2_data):
+        """compute_Jastrow_two_body must return float32 (jastrow zone).
+
+        Catches: jastrow_2b_param (fp64) not cast to jastrow dtype.
+        """
+        j2_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="pade")
+        J2 = compute_Jastrow_two_body(j2_data, h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("jastrow")
+        assert jnp.asarray(J2).dtype == expected, (
+            f"compute_Jastrow_two_body dtype is {jnp.asarray(J2).dtype}, expected {expected}. "
+            "Likely cause: jastrow_2b_param not cast to jastrow dtype."
+        )
+
+    def test_jastrow_three_body_output_dtype(self, h2_data):
+        """compute_Jastrow_three_body must return float32 (jastrow zone).
+
+        Catches: j_matrix (fp64) not cast to jastrow dtype.
+        """
+        j3_data = Jastrow_three_body_data.init_jastrow_three_body_data(
+            orb_data=h2_data["aos_data"], random_init=True, random_scale=1e-3
+        )
+        J3 = compute_Jastrow_three_body(j3_data, h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("jastrow")
+        assert jnp.asarray(J3).dtype == expected, (
+            f"compute_Jastrow_three_body dtype is {jnp.asarray(J3).dtype}, expected {expected}. "
+            "Likely cause: j_matrix not cast to jastrow dtype."
+        )
+
+    def test_jastrow_part_output_dtype(self, h2_data):
+        """compute_Jastrow_part (J1+J2+J3) must return float32 (jastrow zone)."""
+        j2_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="exp")
+        j3_data = Jastrow_three_body_data.init_jastrow_three_body_data(
+            orb_data=h2_data["aos_data"], random_init=True, random_scale=1e-3
+        )
+        jastrow_data = Jastrow_data(
+            jastrow_one_body_data=None,
+            jastrow_two_body_data=j2_data,
+            jastrow_three_body_data=j3_data,
+        )
+        J = compute_Jastrow_part(jastrow_data, h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("jastrow")
+        assert jnp.asarray(J).dtype == expected, f"compute_Jastrow_part dtype is {jnp.asarray(J).dtype}, expected {expected}."
+
+
+# ---------------------------------------------------------------------------
+# D. Geminal zone (geminal → float32 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestGeminalDtype:
+    """Verify geminal matrix is float32 in mixed mode."""
+
+    def test_geminal_matrix_output_dtype(self, h2_data):
+        """compute_geminal_all_elements must return float32 (geminal zone).
+
+        Catches: lambda_matrix or AO data not cast to geminal dtype.
+        """
+        G = compute_geminal_all_elements(h2_data["geminal_data"], h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("geminal")
+        assert G.dtype == expected, f"compute_geminal_all_elements dtype is {G.dtype}, expected {expected}."
+
+
+# ---------------------------------------------------------------------------
+# E. Determinant zone (determinant → float64 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestDeterminantDtype:
+    """Verify determinant outputs stay float64 in mixed mode."""
+
+    def test_ln_det_output_dtype(self, h2_data):
+        """compute_ln_det_geminal_all_elements must return float64 (determinant zone).
+
+        Even though geminal matrix is float32, the log-det must be computed in float64.
+        """
+        ln_det = compute_ln_det_geminal_all_elements(h2_data["geminal_data"], h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("determinant")
+        assert jnp.asarray(ln_det).dtype == expected, (
+            f"compute_ln_det dtype is {jnp.asarray(ln_det).dtype}, expected {expected}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# F. Coulomb zone (coulomb → float32 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestCoulombDtype:
+    """Verify Coulomb outputs are float32 in mixed mode."""
+
+    def test_bare_coulomb_el_el_output_dtype(self, h2_data):
+        """Electron-electron Coulomb must return float32 (coulomb zone)."""
+        V = compute_bare_coulomb_potential_el_el(h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("coulomb")
+        assert jnp.asarray(V).dtype == expected, (
+            f"compute_bare_coulomb_potential_el_el dtype is {jnp.asarray(V).dtype}, expected {expected}."
+        )
+
+    def test_bare_coulomb_el_ion_output_dtype(self, h2_data):
+        """Electron-ion Coulomb must return float32 (coulomb zone).
+
+        Catches: R_charges (fp64) or structure positions (fp64) not cast.
+        """
+        V_up, V_dn = compute_bare_coulomb_potential_el_ion_element_wise(
+            h2_data["coulomb_data"], h2_data["r_up"], h2_data["r_dn"]
+        )
+        expected = get_dtype("coulomb")
+        assert V_up.dtype == expected, (
+            f"el_ion V_up dtype is {V_up.dtype}, expected {expected}. "
+            "Likely cause: R_charges or R_carts not cast to coulomb dtype."
+        )
+
+    def test_bare_coulomb_total_output_dtype(self, h2_data):
+        """Total bare Coulomb must return float32 (coulomb zone)."""
+        V = compute_bare_coulomb_potential(h2_data["coulomb_data"], h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("coulomb")
+        assert jnp.asarray(V).dtype == expected, (
+            f"compute_bare_coulomb_potential dtype is {jnp.asarray(V).dtype}, expected {expected}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# G. Kinetic zone (kinetic → float64 in mixed)
+# ---------------------------------------------------------------------------
+
+
+class TestKineticDtype:
+    """Verify kinetic energy stays float64 in mixed mode."""
+
+    def test_kinetic_energy_output_dtype(self, h2_data):
+        """compute_kinetic_energy must return float64 (kinetic zone)."""
+        wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
+        T = compute_kinetic_energy(wf_data, h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("kinetic")
+        assert jnp.asarray(T).dtype == expected, f"compute_kinetic_energy dtype is {jnp.asarray(T).dtype}, expected {expected}."
+
+
+# ---------------------------------------------------------------------------
+# H. Wavefunction zone boundary
+# ---------------------------------------------------------------------------
+
+
+class TestWavefunctionDtype:
+    """Verify wavefunction evaluation zone boundaries."""
+
+    def test_ln_wavefunction_output_dtype(self, h2_data):
+        """evaluate_ln_wavefunction must return float64 (determinant zone).
+
+        The output combines Jastrow (float32) and log-det (float64),
+        cast to determinant zone dtype.
+        """
+        j2_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="exp")
+        jastrow_data = Jastrow_data(
+            jastrow_one_body_data=None,
+            jastrow_two_body_data=j2_data,
+            jastrow_three_body_data=None,
+        )
+        wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"], jastrow_data=jastrow_data)
+        ln_psi = evaluate_ln_wavefunction(wf_data, h2_data["r_up"], h2_data["r_dn"])
+        expected = get_dtype("determinant")
+        assert jnp.asarray(ln_psi).dtype == expected, (
+            f"evaluate_ln_wavefunction dtype is {jnp.asarray(ln_psi).dtype}, expected {expected}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Extended coverage (a): additional boundary kernels
+# ---------------------------------------------------------------------------
+
+
+class TestAOSpheDtype:
+    """Verify AO spherical basis path also returns float32 (orb_eval)."""
+
+    def test_compute_AOs_sphe_output_dtype(self, h2_sphe_data):
+        AOs = compute_AOs(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
+        _assert_dtype(AOs, get_dtype("orb_eval"), "compute_AOs (sphe)")
+
+    def test_compute_AOs_sphe_grad_output_dtype(self, h2_sphe_data):
+        gx, gy, gz = compute_AOs_grad(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
+        for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
+            _assert_dtype(arr, get_dtype("kinetic"), f"compute_AOs_grad sphe {name}")
+
+    def test_compute_AOs_sphe_laplacian_output_dtype(self, h2_sphe_data):
+        lap = compute_AOs_laplacian(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
+        _assert_dtype(lap, get_dtype("kinetic"), "compute_AOs_laplacian (sphe)")
+
+
+class TestMOExtendedDtype:
+    """MO derivative kernels (kinetic zone)."""
+
+    def test_compute_MOs_grad_output_dtype(self, h2_data):
+        gx, gy, gz = compute_MOs_grad(h2_data["mos_data_up"], h2_data["r_up"])
+        expected = get_dtype("kinetic")
+        for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
+            _assert_dtype(arr, expected, f"compute_MOs_grad {name}")
+
+    def test_compute_MOs_laplacian_output_dtype(self, h2_data):
+        lap = compute_MOs_laplacian(h2_data["mos_data_up"], h2_data["r_up"])
+        _assert_dtype(lap, get_dtype("kinetic"), "compute_MOs_laplacian")
+
+
+class TestJastrowOneBodyDtype:
+    """Verify J1 forward standalone output (jastrow zone)."""
+
+    def test_compute_Jastrow_one_body_output_dtype(self, h2_data):
+        core_electrons = tuple([0.0] * len(h2_data["structure_data"].positions))
+        j1_data = Jastrow_one_body_data.init_jastrow_one_body_data(
+            jastrow_1b_param=1.0,
+            structure_data=h2_data["structure_data"],
+            core_electrons=core_electrons,
+            jastrow_1b_type="pade",
+        )
+        J1 = compute_Jastrow_one_body(j1_data, h2_data["r_up"], h2_data["r_dn"])
+        _assert_dtype(J1, get_dtype("jastrow"), "compute_Jastrow_one_body")
+
+
+class TestGeminalFastUpdateDtype:
+    """Verify Geminal row/column kernels used in MCMC fast updates (geminal zone)."""
+
+    @pytest.fixture
+    def water_data(self):
+        """Water ECP data with multiple electrons (needed for row/column tests)."""
+        return _load_trexio("water_ccecp_ccpvqz.h5")
+
+    def test_geminal_up_one_row_output_dtype(self, water_data):
+        # Use [0:1] to get shape (1, 3) — compute_orb_api requires (N, 3), not (3,)
+        row = compute_geminal_up_one_row_elements(water_data["geminal_data"], water_data["r_up"][0:1], water_data["r_dn"])
+        _assert_dtype(row, get_dtype("geminal"), "compute_geminal_up_one_row_elements")
+
+    def test_geminal_dn_one_column_output_dtype(self, water_data):
+        # Use [0:1] to get shape (1, 3) — compute_orb_api requires (N, 3), not (3,)
+        col = compute_geminal_dn_one_column_elements(water_data["geminal_data"], water_data["r_up"], water_data["r_dn"][0:1])
+        _assert_dtype(col, get_dtype("geminal"), "compute_geminal_dn_one_column_elements")
+
+
+class TestECPDtype:
+    """Verify ECP local + non-local paths (coulomb zone).
+
+    Local: executed directly. Non-local: heavy, checked via jax.eval_shape (no run).
+    """
+
+    def test_compute_ecp_local_parts_output_dtype(self, h2_ecp_data):
+        V_loc = compute_ecp_local_parts_all_pairs(h2_ecp_data["coulomb_data"], h2_ecp_data["r_up"], h2_ecp_data["r_dn"])
+        _assert_dtype(V_loc, get_dtype("coulomb"), "compute_ecp_local_parts_all_pairs")
+
+    def test_compute_ecp_non_local_eval_shape_dtype(self, h2_ecp_data):
+        """Heavy ECP non-local kernel: verify dtype via jax.eval_shape (no execution)."""
+        wf_data = Wavefunction_data(geminal_data=h2_ecp_data["geminal_data"])
+        # Minimal Lebedev-like quadrature placeholder (6-point). Values are not
+        # used by eval_shape; only shapes/dtypes matter for static dtype tracing.
+        weights = jnp.ones((6,), dtype=jnp.float64) / 6.0
+        grid_points = jnp.array(
+            [
+                [1.0, 0.0, 0.0],
+                [-1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, -1.0, 0.0],
+                [0.0, 0.0, 1.0],
+                [0.0, 0.0, -1.0],
+            ],
+            dtype=jnp.float64,
+        )
+        _assert_eval_shape_dtype(
+            compute_ecp_non_local_part_all_pairs_jax_weights_grid_points,
+            get_dtype("coulomb"),
+            "compute_ecp_non_local_part_all_pairs_jax_weights_grid_points",
+            h2_ecp_data["coulomb_data"],
+            wf_data,
+            h2_ecp_data["r_up"],
+            h2_ecp_data["r_dn"],
+            weights,
+            grid_points,
+        )
+
+
+class TestLocalEnergyDtype:
+    """Final boundary: compute_local_energy aggregates kinetic + coulomb (kinetic zone)."""
+
+    def test_compute_local_energy_output_dtype(self, h2_data):
+        wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
+        ham = Hamiltonian_data(
+            structure_data=h2_data["structure_data"],
+            wavefunction_data=wf_data,
+            coulomb_potential_data=h2_data["coulomb_data"],
+        )
+        RT = jnp.eye(3, dtype=jnp.float64)
+        e_L = compute_local_energy(ham, h2_data["r_up"], h2_data["r_dn"], RT)
+        _assert_dtype(e_L, get_dtype("kinetic"), "compute_local_energy")
+
+
+class TestKineticEvalShape:
+    """jax.eval_shape coverage for kinetic energy fast/discretized variants.
+
+    These exercise different code paths (Sherman-Morrison fast update,
+    discretized DMC) without actually executing the heavy autodiff laplacian.
+    """
+
+    def test_kinetic_energy_eval_shape_dtype(self, h2_data):
+        wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
+        _assert_eval_shape_dtype(
+            compute_kinetic_energy,
+            get_dtype("kinetic"),
+            "compute_kinetic_energy (eval_shape)",
+            wf_data,
+            h2_data["r_up"],
+            h2_data["r_dn"],
+        )
+
+    def test_evaluate_ln_wavefunction_eval_shape_dtype(self, h2_data):
+        wf_data = Wavefunction_data(geminal_data=h2_data["geminal_data"])
+        _assert_eval_shape_dtype(
+            evaluate_ln_wavefunction,
+            get_dtype("determinant"),
+            "evaluate_ln_wavefunction (eval_shape)",
+            wf_data,
+            h2_data["r_up"],
+            h2_data["r_dn"],
+        )

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -48,6 +48,7 @@ from jqmc.determinant import (  # noqa: E402
     compute_geminal_all_elements,
     compute_geminal_dn_one_column_elements,
     compute_geminal_up_one_row_elements,
+    compute_grads_and_laplacian_ln_Det,
     compute_ln_det_geminal_all_elements,
 )
 from jqmc.hamiltonians import Hamiltonian_data, compute_local_energy  # noqa: E402
@@ -187,16 +188,16 @@ class TestAODtype:
         )
 
     def test_compute_AOs_grad_output_dtype(self, h2_data):
-        """compute_AOs_grad must return ao_grad_lap zone dtype."""
+        """compute_AOs_grad must return ao_grad zone dtype."""
         grad_x, grad_y, grad_z = compute_AOs_grad(h2_data["aos_data"], h2_data["r_up"])
-        expected = get_dtype_jnp("ao_grad_lap")
+        expected = get_dtype_jnp("ao_grad")
         for name, arr in [("grad_x", grad_x), ("grad_y", grad_y), ("grad_z", grad_z)]:
             assert arr.dtype == expected, f"compute_AOs_grad {name} dtype is {arr.dtype}, expected {expected}."
 
     def test_compute_AOs_laplacian_output_dtype(self, h2_data):
-        """compute_AOs_laplacian must return ao_grad_lap zone dtype."""
+        """compute_AOs_laplacian must return ao_lap zone dtype."""
         lap = compute_AOs_laplacian(h2_data["aos_data"], h2_data["r_up"])
-        expected = get_dtype_jnp("ao_grad_lap")
+        expected = get_dtype_jnp("ao_lap")
         assert lap.dtype == expected, f"compute_AOs_laplacian dtype is {lap.dtype}, expected {expected}."
 
 
@@ -315,6 +316,17 @@ class TestDeterminantDtype:
             f"compute_ln_det dtype is {jnp.asarray(ln_det).dtype}, expected {expected}."
         )
 
+    def test_compute_grads_and_laplacian_ln_Det_output_dtype(self, h2_data):
+        """compute_grads_and_laplacian_ln_Det outputs must use det_grad_lap zone dtype."""
+        grad_up, grad_dn, lap_up, lap_dn = compute_grads_and_laplacian_ln_Det(
+            h2_data["geminal_data"], h2_data["r_up"], h2_data["r_dn"]
+        )
+        expected = get_dtype_jnp("det_grad_lap")
+        _assert_dtype(grad_up, expected, "compute_grads_and_laplacian_ln_Det grad_up")
+        _assert_dtype(grad_dn, expected, "compute_grads_and_laplacian_ln_Det grad_dn")
+        _assert_dtype(lap_up, expected, "compute_grads_and_laplacian_ln_Det lap_up")
+        _assert_dtype(lap_dn, expected, "compute_grads_and_laplacian_ln_Det lap_dn")
+
 
 # ---------------------------------------------------------------------------
 # F. Coulomb zone (coulomb → float32 in mixed)
@@ -414,11 +426,11 @@ class TestAOSpheDtype:
     def test_compute_AOs_sphe_grad_output_dtype(self, h2_sphe_data):
         gx, gy, gz = compute_AOs_grad(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
         for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
-            _assert_dtype(arr, get_dtype_jnp("ao_grad_lap"), f"compute_AOs_grad sphe {name}")
+            _assert_dtype(arr, get_dtype_jnp("ao_grad"), f"compute_AOs_grad sphe {name}")
 
     def test_compute_AOs_sphe_laplacian_output_dtype(self, h2_sphe_data):
         lap = compute_AOs_laplacian(h2_sphe_data["aos_data"], h2_sphe_data["r_up"])
-        _assert_dtype(lap, get_dtype_jnp("ao_grad_lap"), "compute_AOs_laplacian (sphe)")
+        _assert_dtype(lap, get_dtype_jnp("ao_lap"), "compute_AOs_laplacian (sphe)")
 
 
 class TestMOExtendedDtype:
@@ -426,13 +438,13 @@ class TestMOExtendedDtype:
 
     def test_compute_MOs_grad_output_dtype(self, h2_data):
         gx, gy, gz = compute_MOs_grad(h2_data["mos_data_up"], h2_data["r_up"])
-        expected = get_dtype_jnp("mo_grad_lap")
+        expected = get_dtype_jnp("mo_grad")
         for name, arr in [("grad_x", gx), ("grad_y", gy), ("grad_z", gz)]:
             _assert_dtype(arr, expected, f"compute_MOs_grad {name}")
 
     def test_compute_MOs_laplacian_output_dtype(self, h2_data):
         lap = compute_MOs_laplacian(h2_data["mos_data_up"], h2_data["r_up"])
-        _assert_dtype(lap, get_dtype_jnp("mo_grad_lap"), "compute_MOs_laplacian")
+        _assert_dtype(lap, get_dtype_jnp("mo_lap"), "compute_MOs_laplacian")
 
 
 class TestJastrowOneBodyDtype:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -54,7 +54,7 @@ def _make_non_pbc_structure():
 
 def test_reciprocal_lattice_dot_2pi():
     """Test that the dot product of the cell and reciprocal cell gives 2pi delta_ij."""
-    atol, rtol = get_tolerance("io", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     structure = _make_pbc_structure()
     recip = structure.recip_cell
     cell = structure.cell
@@ -69,7 +69,7 @@ def test_reciprocal_lattice_dot_2pi():
 
 def test_np_jnp_consistency_non_pbc():
     """Test consistency between NumPy and JAX implementations for non-PBC structures."""
-    atol, rtol = get_tolerance("io", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     structure = _make_non_pbc_structure()
     r_cart = np.array([0.2, 0.0, 0.0])
 
@@ -100,7 +100,7 @@ def test_np_jnp_consistency_non_pbc():
 
 def test_pbc_minimum_image_and_nearest():
     """Test PBC minimum image convention and nearest nucleus finding."""
-    atol, rtol = get_tolerance("io", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     structure = _make_pbc_structure()
     r_cart = np.array([9.1, 0.0, 0.0])
 
@@ -145,7 +145,7 @@ def test_pbc_minimum_image_and_nearest():
 @pytest.mark.parametrize("use_pbc", [False, True])
 def test_find_nearest_index_matches_min_dist_jnp(use_pbc):
     """Test that the nearest index found matches the minimum distance calculation."""
-    atol, rtol = get_tolerance("io", "strict")
+    atol, rtol = get_tolerance("local_energy", "strict")
     structure = _make_pbc_structure() if use_pbc else _make_non_pbc_structure()
     r_cart = np.array([9.1, 0.0, 0.0]) if use_pbc else np.array([1.8, 0.1, 0.0])
 

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from jqmc._setting import atol_debug_vs_production, rtol_debug_vs_production
+from jqmc._precision import get_tolerance
 from jqmc.structure import (
     Structure_data,
     _find_nearest_index_jnp,
@@ -54,6 +54,7 @@ def _make_non_pbc_structure():
 
 def test_reciprocal_lattice_dot_2pi():
     """Test that the dot product of the cell and reciprocal cell gives 2pi delta_ij."""
+    atol, rtol = get_tolerance("io", "strict")
     structure = _make_pbc_structure()
     recip = structure.recip_cell
     cell = structure.cell
@@ -63,11 +64,12 @@ def test_reciprocal_lattice_dot_2pi():
             expected = 2.0 * np.pi if i == j else 0.0
             assert not np.any(np.isnan(np.asarray(dot))), "NaN detected in first argument"
             assert not np.any(np.isnan(np.asarray(expected))), "NaN detected in second argument"
-            np.testing.assert_allclose(dot, expected, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+            np.testing.assert_allclose(dot, expected, atol=atol, rtol=rtol)
 
 
 def test_np_jnp_consistency_non_pbc():
     """Test consistency between NumPy and JAX implementations for non-PBC structures."""
+    atol, rtol = get_tolerance("io", "strict")
     structure = _make_non_pbc_structure()
     r_cart = np.array([0.2, 0.0, 0.0])
 
@@ -76,8 +78,8 @@ def test_np_jnp_consistency_non_pbc():
     np.testing.assert_allclose(
         structure._positions_cart_np,
         np.asarray(structure._positions_cart_jnp),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     idx_np = _find_nearest_index_np(structure, r_cart)
@@ -93,11 +95,12 @@ def test_np_jnp_consistency_non_pbc():
         rel_jnp = np.asarray(_get_min_dist_rel_R_cart_jnp(structure, r_cart, i_atom))
         assert not np.any(np.isnan(np.asarray(rel_np))), "NaN detected in first argument"
         assert not np.any(np.isnan(np.asarray(rel_jnp))), "NaN detected in second argument"
-        np.testing.assert_allclose(rel_np, rel_jnp, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+        np.testing.assert_allclose(rel_np, rel_jnp, atol=atol, rtol=rtol)
 
 
 def test_pbc_minimum_image_and_nearest():
     """Test PBC minimum image convention and nearest nucleus finding."""
+    atol, rtol = get_tolerance("io", "strict")
     structure = _make_pbc_structure()
     r_cart = np.array([9.1, 0.0, 0.0])
 
@@ -117,31 +120,32 @@ def test_pbc_minimum_image_and_nearest():
     np.testing.assert_allclose(
         rel_atom0,
         np.array([0.9, 0.0, 0.0]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(rel_atom1))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.array([-0.1, 0.0, 0.0])))), "NaN detected in second argument"
     np.testing.assert_allclose(
         rel_atom1,
         np.array([-0.1, 0.0, 0.0]),
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
     rel_atom0_jnp = np.asarray(_get_min_dist_rel_R_cart_jnp(structure, r_cart, 0))
     rel_atom1_jnp = np.asarray(_get_min_dist_rel_R_cart_jnp(structure, r_cart, 1))
     assert not np.any(np.isnan(np.asarray(rel_atom0_jnp))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(rel_atom0))), "NaN detected in second argument"
-    np.testing.assert_allclose(rel_atom0_jnp, rel_atom0, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(rel_atom0_jnp, rel_atom0, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(rel_atom1_jnp))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(rel_atom1))), "NaN detected in second argument"
-    np.testing.assert_allclose(rel_atom1_jnp, rel_atom1, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(rel_atom1_jnp, rel_atom1, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("use_pbc", [False, True])
 def test_find_nearest_index_matches_min_dist_jnp(use_pbc):
     """Test that the nearest index found matches the minimum distance calculation."""
+    atol, rtol = get_tolerance("io", "strict")
     structure = _make_pbc_structure() if use_pbc else _make_non_pbc_structure()
     r_cart = np.array([9.1, 0.0, 0.0]) if use_pbc else np.array([1.8, 0.1, 0.0])
 
@@ -160,4 +164,4 @@ def test_find_nearest_index_matches_min_dist_jnp(use_pbc):
 
     assert not np.any(np.isnan(np.asarray(dist_idx))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.min(dist_all)))), "NaN detected in second argument"
-    np.testing.assert_allclose(dist_idx, np.min(dist_all), atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(dist_idx, np.min(dist_all), atol=atol, rtol=rtol)

--- a/tests/test_swct.py
+++ b/tests/test_swct.py
@@ -61,7 +61,7 @@ jax.config.update("jax_traceback_filtering", "off")
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_SWCT_omega(trexio_file: str):
     """Test SWCT omega, compare debug and jax."""
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("swct", "strict")
     (
         structure_data,
         _,

--- a/tests/test_swct.py
+++ b/tests/test_swct.py
@@ -44,10 +44,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_debug_vs_production,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.swct import (  # noqa: E402
     _evaluate_swct_domega_debug,
     _evaluate_swct_omega_debug,
@@ -64,6 +61,7 @@ jax.config.update("jax_traceback_filtering", "off")
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5"])
 def test_debug_and_jax_SWCT_omega(trexio_file: str):
     """Test SWCT omega, compare debug and jax."""
+    atol, rtol = get_tolerance("kinetic", "strict")
     (
         structure_data,
         _,
@@ -88,10 +86,10 @@ def test_debug_and_jax_SWCT_omega(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(omega_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(omega_up_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(omega_up_debug, omega_up_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(omega_up_debug, omega_up_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(omega_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(omega_dn_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(omega_dn_debug, omega_dn_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(omega_dn_debug, omega_dn_jax, atol=atol, rtol=rtol)
 
     domega_up_debug = _evaluate_swct_domega_debug(structure_data=structure_data, r_carts=r_up_carts)
     domega_dn_debug = _evaluate_swct_domega_debug(structure_data=structure_data, r_carts=r_dn_carts)
@@ -100,10 +98,10 @@ def test_debug_and_jax_SWCT_omega(trexio_file: str):
 
     assert not np.any(np.isnan(np.asarray(domega_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(domega_up_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(domega_up_debug, domega_up_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(domega_up_debug, domega_up_jax, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(domega_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(domega_dn_jax))), "NaN detected in second argument"
-    np.testing.assert_allclose(domega_dn_debug, domega_dn_jax, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(domega_dn_debug, domega_dn_jax, atol=atol, rtol=rtol)
 
     jax.clear_caches()
 

--- a/tests/test_wave_function.py
+++ b/tests/test_wave_function.py
@@ -121,7 +121,7 @@ def test_kinetic_energy_analytic_and_numerical(trexio_file: str):
 
     K_debug = _compute_kinetic_energy_debug(wavefunction_data=wavefunction_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
     K_jax = compute_kinetic_energy(wavefunction_data=wavefunction_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("wf_kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(np.asarray(K_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(K_jax)))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -172,7 +172,7 @@ def test_kinetic_energy_analytic_and_auto(trexio_file: str):
         r_dn_carts=jnp.asarray(r_dn_carts),
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(K_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(K_analytic, K_auto, atol=atol, rtol=rtol)
@@ -221,7 +221,7 @@ def test_debug_and_auto_kinetic_energy_all_elements(trexio_file: str):
         wavefunction_data=wavefunction_data, r_up_carts=r_up_carts_jnp, r_dn_carts=r_dn_carts_jnp
     )
 
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("wf_kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(K_elements_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_up_auto))), "NaN detected in second argument"
     np.testing.assert_allclose(K_elements_up_debug, K_elements_up_auto, atol=atol, rtol=rtol)
@@ -291,7 +291,7 @@ def test_auto_and_analytic_kinetic_energy_all_elements(trexio_file: str):
         wavefunction_data=wavefunction_data, r_up_carts=r_up_carts_jnp, r_dn_carts=r_dn_carts_jnp
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(K_elements_up_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_up_analytic))), "NaN detected in second argument"
     np.testing.assert_allclose(K_elements_up_auto, K_elements_up_analytic, atol=atol, rtol=rtol)
@@ -359,7 +359,7 @@ def test_fast_update_kinetic_energy_all_elements(trexio_file: str):
         geminal_inverse=A_inv,
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(ke_up_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(ke_up_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(ke_up_fast, ke_up_debug, atol=atol, rtol=rtol)
@@ -441,7 +441,7 @@ def test_debug_and_jax_discretized_kinetic_energy(trexio_file: str):
         RT=RT,
     )
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
@@ -542,7 +542,7 @@ def test_nodal_distance_analytic_vs_debug(trexio_file: str):
     )
 
     # They should be identical up to numerical noise
-    atol, rtol = get_tolerance("kinetic", "loose")
+    atol, rtol = get_tolerance("wf_kinetic", "loose")
     np.testing.assert_allclose(
         np.asarray(nd_analytic),
         np.asarray(nd_debug),
@@ -595,7 +595,7 @@ def test_evaluate_ln_wavefunction_fast_forward(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -632,7 +632,7 @@ def test_evaluate_ln_wavefunction_fast_backward(trexio_file):
     grad_ref_fn = jax.grad(evaluate_ln_wavefunction, argnums=0)
     grad_fast_fn = jax.grad(evaluate_ln_wavefunction_fast, argnums=0)
 
-    atol, rtol = get_tolerance("kinetic", "strict")
+    atol, rtol = get_tolerance("wf_kinetic", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)

--- a/tests/test_wave_function.py
+++ b/tests/test_wave_function.py
@@ -45,14 +45,7 @@ project_root = str(Path(__file__).parent.parent)
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
-from jqmc._setting import (  # noqa: E402
-    atol_auto_vs_analytic_deriv,
-    atol_auto_vs_numerical_deriv,
-    atol_debug_vs_production,
-    rtol_auto_vs_analytic_deriv,
-    rtol_auto_vs_numerical_deriv,
-    rtol_debug_vs_production,
-)
+from jqmc._precision import get_tolerance  # noqa: E402
 from jqmc.determinant import compute_geminal_all_elements  # noqa: E402
 from jqmc.jastrow_factor import (  # noqa: E402
     Jastrow_data,
@@ -87,6 +80,7 @@ jax.config.update("jax_traceback_filtering", "off")
 
 
 @pytest.mark.activate_if_skip_heavy
+@pytest.mark.numerical_diff
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5", "H2_ae_ccpvdz_cart.h5", "N_ae_ccpvdz_cart.h5"])
 def test_kinetic_energy_analytic_and_numerical(trexio_file: str):
     """Test the kinetic energy computation."""
@@ -127,13 +121,14 @@ def test_kinetic_energy_analytic_and_numerical(trexio_file: str):
 
     K_debug = _compute_kinetic_energy_debug(wavefunction_data=wavefunction_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
     K_jax = compute_kinetic_energy(wavefunction_data=wavefunction_data, r_up_carts=r_up_carts, r_dn_carts=r_dn_carts)
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(np.asarray(K_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(K_jax)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(K_debug),
         np.asarray(K_jax),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
 
@@ -177,9 +172,10 @@ def test_kinetic_energy_analytic_and_auto(trexio_file: str):
         r_dn_carts=jnp.asarray(r_dn_carts),
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(K_analytic))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(K_analytic, K_auto, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv)
+    np.testing.assert_allclose(K_analytic, K_auto, atol=atol, rtol=rtol)
 
 
 @pytest.mark.activate_if_skip_heavy
@@ -225,24 +221,21 @@ def test_debug_and_auto_kinetic_energy_all_elements(trexio_file: str):
         wavefunction_data=wavefunction_data, r_up_carts=r_up_carts_jnp, r_dn_carts=r_dn_carts_jnp
     )
 
+    atol, rtol = get_tolerance("kinetic", "loose")
     assert not np.any(np.isnan(np.asarray(K_elements_up_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_up_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        K_elements_up_debug, K_elements_up_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(K_elements_up_debug, K_elements_up_auto, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(K_elements_dn_debug))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_dn_auto))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        K_elements_dn_debug, K_elements_dn_auto, atol=atol_auto_vs_numerical_deriv, rtol=rtol_auto_vs_numerical_deriv
-    )
+    np.testing.assert_allclose(K_elements_dn_debug, K_elements_dn_auto, atol=atol, rtol=rtol)
 
     assert not np.any(np.isnan(np.asarray(np.asarray(K_elements_up_debug)))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(np.asarray(K_elements_up_auto)))), "NaN detected in second argument"
     np.testing.assert_allclose(
         np.asarray(K_elements_up_debug),
         np.asarray(K_elements_up_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
     assert not np.any(np.isnan(np.asarray(np.asarray(K_elements_dn_debug)))), "NaN detected in first argument"
@@ -250,8 +243,8 @@ def test_debug_and_auto_kinetic_energy_all_elements(trexio_file: str):
     np.testing.assert_allclose(
         np.asarray(K_elements_dn_debug),
         np.asarray(K_elements_dn_auto),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
 
@@ -298,16 +291,13 @@ def test_auto_and_analytic_kinetic_energy_all_elements(trexio_file: str):
         wavefunction_data=wavefunction_data, r_up_carts=r_up_carts_jnp, r_dn_carts=r_dn_carts_jnp
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(K_elements_up_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_up_analytic))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        K_elements_up_auto, K_elements_up_analytic, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(K_elements_up_auto, K_elements_up_analytic, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(K_elements_dn_auto))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(K_elements_dn_analytic))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        K_elements_dn_auto, K_elements_dn_analytic, atol=atol_auto_vs_analytic_deriv, rtol=rtol_auto_vs_analytic_deriv
-    )
+    np.testing.assert_allclose(K_elements_dn_auto, K_elements_dn_analytic, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5", "H2_ae_ccpvdz_cart.h5", "N_ae_ccpvdz_cart.h5"])
@@ -369,12 +359,13 @@ def test_fast_update_kinetic_energy_all_elements(trexio_file: str):
         geminal_inverse=A_inv,
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(ke_up_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(ke_up_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(ke_up_fast, ke_up_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(ke_up_fast, ke_up_debug, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(ke_dn_fast))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(ke_dn_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(ke_dn_fast, ke_dn_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production)
+    np.testing.assert_allclose(ke_dn_fast, ke_dn_debug, atol=atol, rtol=rtol)
 
 
 @pytest.mark.parametrize("trexio_file", ["water_ccecp_ccpvqz.h5", "H2_ae_ccpvdz_cart.h5", "N_ae_ccpvdz_cart.h5"])
@@ -450,50 +441,49 @@ def test_debug_and_jax_discretized_kinetic_energy(trexio_file: str):
         RT=RT,
     )
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_kinetic_part_r_up_carts_jax,
         mesh_kinetic_part_r_up_carts_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_dn_carts_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_dn_carts_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_kinetic_part_r_dn_carts_jax,
         mesh_kinetic_part_r_dn_carts_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_jax_fast_update))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_up_carts_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_kinetic_part_r_up_carts_jax_fast_update,
         mesh_kinetic_part_r_up_carts_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_dn_carts_jax_fast_update))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(mesh_kinetic_part_r_dn_carts_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         mesh_kinetic_part_r_dn_carts_jax_fast_update,
         mesh_kinetic_part_r_dn_carts_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
     assert not np.any(np.isnan(np.asarray(elements_kinetic_part_jax))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(elements_kinetic_part_debug))), "NaN detected in second argument"
-    np.testing.assert_allclose(
-        elements_kinetic_part_jax, elements_kinetic_part_debug, atol=atol_debug_vs_production, rtol=rtol_debug_vs_production
-    )
+    np.testing.assert_allclose(elements_kinetic_part_jax, elements_kinetic_part_debug, atol=atol, rtol=rtol)
     assert not np.any(np.isnan(np.asarray(elements_kinetic_part_jax_fast_update))), "NaN detected in first argument"
     assert not np.any(np.isnan(np.asarray(elements_kinetic_part_debug))), "NaN detected in second argument"
     np.testing.assert_allclose(
         elements_kinetic_part_jax_fast_update,
         elements_kinetic_part_debug,
-        atol=atol_debug_vs_production,
-        rtol=rtol_debug_vs_production,
+        atol=atol,
+        rtol=rtol,
     )
 
 
@@ -552,11 +542,12 @@ def test_nodal_distance_analytic_vs_debug(trexio_file: str):
     )
 
     # They should be identical up to numerical noise
+    atol, rtol = get_tolerance("kinetic", "loose")
     np.testing.assert_allclose(
         np.asarray(nd_analytic),
         np.asarray(nd_debug),
-        rtol=rtol_auto_vs_numerical_deriv,
-        atol=atol_auto_vs_numerical_deriv,
+        rtol=rtol,
+        atol=atol,
     )
 
     # Sanity: nodal distance should be positive
@@ -604,6 +595,7 @@ def test_evaluate_ln_wavefunction_fast_forward(trexio_file):
     n_up = geminal_data.num_electron_up
     n_dn = geminal_data.num_electron_dn
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -618,8 +610,8 @@ def test_evaluate_ln_wavefunction_fast_forward(trexio_file):
         np.testing.assert_allclose(
             val_fast,
             val_ref,
-            atol=atol_debug_vs_production,
-            rtol=rtol_debug_vs_production,
+            atol=atol,
+            rtol=rtol,
             err_msg=f"Forward mismatch: fast={val_fast:.15f}, ref={val_ref:.15f}",
         )
 
@@ -640,6 +632,7 @@ def test_evaluate_ln_wavefunction_fast_backward(trexio_file):
     grad_ref_fn = jax.grad(evaluate_ln_wavefunction, argnums=0)
     grad_fast_fn = jax.grad(evaluate_ln_wavefunction_fast, argnums=0)
 
+    atol, rtol = get_tolerance("kinetic", "strict")
     for _ in range(10):
         r_up = jnp.array(rng.standard_normal((n_up, 3)) * 1.2, dtype=jnp.float64)
         r_dn = jnp.array(rng.standard_normal((n_dn, 3)) * 1.2, dtype=jnp.float64)
@@ -653,8 +646,8 @@ def test_evaluate_ln_wavefunction_fast_backward(trexio_file):
             lambda a, b: np.testing.assert_allclose(
                 np.asarray(a),
                 np.asarray(b),
-                atol=atol_debug_vs_production,
-                rtol=rtol_debug_vs_production,
+                atol=atol,
+                rtol=rtol,
                 err_msg="Backward mismatch in evaluate_ln_wavefunction_fast",
             ),
             grad_ref,


### PR DESCRIPTION
Big refactoring: Add mixed-precision (fp32/fp64) support with selectable per-zone dtype

- Adds a **mixed-precision mode** to jQMC. With `[precision] mode = "mixed"` in the TOML input, numerically tolerant parts of the computation (AO, Jastrow, Coulomb, ...) run in fp32 while sensitive parts stay in fp64. This targets ~30–40% memory reduction and ~1.5–2x GPU throughput on large molecules with negligible energy bias. The default remains `mode = "full"` (all fp64, fully backward-compatible).
- The computation is partitioned into 18 Precision Zones, each owned by exactly one module. Zones are named for their purpose rather than their dtype; the zone-to-dtype mapping is determined by the active mode in `jqmc/_precision.py`.
- The design is codified as **three principles** (at the top of `_precision.py` and in `doc/notes/mixed_precision.md`):
  - **P1** — one zone is owned by exactly one module.
  - **P2** — a module may own multiple zones, named by purpose rather than dtype.
  - **P3** — cast responsibility lies with the function that performs the arithmetic, never with passthrough wrappers.
    - **3a (frozen args):** function arguments must not be rebound (`arg = jnp.asarray(arg, ...)` at function entry is forbidden).
    - **3b (local cast at arithmetic):** cast at the use site. For `r - R`, reconstruct the difference in the caller-supplied precision (fp64) and then downcast to the zone dtype. Never hardcode `jnp.float64` / `jnp.float32` literals; always use `get_dtype_jnp(zone)` / `get_dtype_np(zone)`.
- Numerical-stability decisions baked into `mixed` mode:
  - The geminal stays fp64 because fp32 amplifies error in `log|det|`.
  - `ao_lap` stays fp64 because the analytic Laplacian contains catastrophic-cancellation terms.
  - `r - R` differences are reconstructed in fp64, then downcast.
- Workflow API: `VMC_Workflow(..., precision_mode="mixed")` (also added to `mcmc_workflow` and `lrdmc_workflow`).
- Documentation: `doc/notes/mixed_precision.md` was rewritten to cover the zone table, the three principles, and the storage-vs-arithmetic exemption rules.
- Tests: new `tests/test_mixed_precision.py` (566 lines). Existing tests were updated to scale tolerances with the active zone dtype via `get_tolerance(zone, level)` and `get_tolerance_min(zones, level)`.
- CI: `jqmc-run-short-pytest.yml`, `jqmc-run-rc-pytest.yml`, and `jqmc-run-full-pytest.yml` were updated to cover both modes.