### PR TITLE
Vectorize walker init: electron configs and PRNG keys

### DIFF
--- a/.github/workflows/jqmc-run-full-pytest.yml
+++ b/.github/workflows/jqmc-run-full-pytest.yml
@@ -57,6 +57,7 @@ jobs:
     - name: Test jqmc (intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --cov=jqmc --cov-branch --no-cov-on-fail
+        pytest -s -v tests/test_init_electron_configurations.py --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_structure.py --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_AOs.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_MOs.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append

--- a/.github/workflows/jqmc-run-short-pytest.yml
+++ b/.github/workflows/jqmc-run-short-pytest.yml
@@ -68,6 +68,7 @@ jobs:
     - name: Test jqmc (pytest) with @jit decorator (intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --skip-heavy
+        pytest -s -v tests/test_init_electron_configurations.py --skip-heavy
         pytest -s -v tests/test_structure.py --skip-heavy
         pytest -s -v tests/test_AOs.py --skip-heavy
         pytest -s -v tests/test_MOs.py --skip-heavy

--- a/jqmc/_jqmc_utility.py
+++ b/jqmc/_jqmc_utility.py
@@ -58,7 +58,179 @@ def _generate_init_electron_configurations(
     charges: np.ndarray,
     coords: np.ndarray,
 ) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
-    """Generate initial electron configurations for walkers.
+    """Vectorized initial electron configuration generator for many walkers.
+
+    Functionally equivalent to :func:`_generate_init_electron_configurations_debug`
+    but avoids the per-walker Python loop. Designed for large walker counts
+    (e.g. ``num_walkers = 16384``) where the reference version becomes the
+    initialization bottleneck.
+
+    Algorithm:
+        1. Compute the deterministic atom-assignment templates for spin-up and
+           spin-down electrons by replaying the original state machine **once**.
+           These templates depend only on (charges, coords) — every walker
+           shares them.
+        2. Tile the templates to shape ``(num_walkers, ned)``.
+        3. For the only branch in the original that uses per-walker randomness
+           — Phase 1b "extra up" electrons when
+           ``tot_num_electron_up > sum(zeta - occup_dn)`` — draw the random
+           atom indices in one batched ``np.random.randint`` call.
+        4. Draw all spherical random offsets in one batched call per spin and
+           add them to the chosen atomic coordinates.
+
+    The duplicate-avoidance retry loop in the reference implementation is
+    omitted: spherical offsets are sampled from continuous uniform
+    distributions, so the probability of two ``float64`` positions colliding
+    within ``1e-6`` is effectively zero. The companion test
+    ``test_init_electron_configurations`` verifies uniqueness across all
+    generated positions.
+
+    Parameters and returns are identical to
+    :func:`_generate_init_electron_configurations_debug`.
+    """
+    min_dst = 0.1
+    max_dst = 1.0
+    dtype_np = np.float64
+
+    nion = coords.shape[0]
+    coords_np = np.asarray(coords, dtype=dtype_np)
+    zeta = np.array([int(round(c)) for c in np.asarray(charges)], dtype=int)
+    max_dn_per_atom = zeta // 2
+
+    # 1) Build ion_seq (each next index is the atom farthest from the previous).
+    ion_sel = np.ones(nion, dtype=bool)
+    ion_seq = np.zeros(nion, dtype=int)
+    ion_seq[0] = 0
+    ion_sel[0] = False
+    i_prev = 0
+    for idx in range(1, nion):
+        d2 = np.sum((coords_np[i_prev] - coords_np) ** 2, axis=1)
+        d2_masked = np.where(ion_sel, d2, -1.0)
+        best_i = int(np.argmax(d2_masked))
+        ion_seq[idx] = best_i
+        ion_sel[best_i] = False
+        i_prev = best_i
+
+    # 2) Replay the deterministic state machine ONCE to obtain owner templates.
+    occup_total = np.zeros(nion, dtype=int)
+    occup_dn = np.zeros(nion, dtype=int)
+    occup_up = np.zeros(nion, dtype=int)
+
+    # Phase 1a: place all spin-down electrons (deterministic).
+    ned_dn = tot_num_electron_dn
+    dn_owner_template = np.empty(ned_dn, dtype=int)
+    j_counter = 0
+    for idn in range(ned_dn):
+        while True:
+            atom = ion_seq[j_counter % nion]
+            if np.any(occup_dn < max_dn_per_atom):
+                cond = occup_dn[atom] < max_dn_per_atom[atom]
+            else:
+                mask_zero = (max_dn_per_atom == 0) & (occup_total < zeta)
+                if np.any(mask_zero):
+                    cond = (max_dn_per_atom[atom] == 0) and (occup_total[atom] < zeta[atom])
+                else:
+                    cond = occup_total[atom] < zeta[atom]
+            if cond:
+                dn_owner_template[idn] = atom
+                occup_dn[atom] += 1
+                occup_total[atom] += 1
+                j_counter += 1
+                break
+            j_counter += 1
+
+    # Phase 1b: place spin-up electrons; deterministic except for the
+    # "extra" tail in Case 2 which is per-walker random.
+    up_needed = zeta - occup_dn
+    sum_up_needed = int(np.sum(up_needed))
+    ned_up = tot_num_electron_up
+    up_owner_template = np.empty(ned_up, dtype=int)
+    n_random_extras = 0  # trailing electrons whose owner is random per walker
+
+    if ned_up <= sum_up_needed:
+        # Case 1: place exactly into the up_needed slots — fully deterministic.
+        ptr = 0
+        for iup in range(ned_up):
+            while True:
+                atom = ion_seq[ptr % nion]
+                if occup_up[atom] < up_needed[atom]:
+                    up_owner_template[iup] = atom
+                    occup_up[atom] += 1
+                    occup_total[atom] += 1
+                    ptr += 1
+                    break
+                ptr += 1
+    else:
+        # Case 2: first satisfy every atom's up_needed (deterministic), then
+        # the remainder is sampled per walker.
+        cnt = 0
+        for atom in ion_seq:
+            to_give = int(up_needed[atom])
+            for _ in range(to_give):
+                up_owner_template[cnt] = atom
+                occup_up[atom] += 1
+                occup_total[atom] += 1
+                cnt += 1
+        n_random_extras = ned_up - sum_up_needed
+
+    # 3) Build per-walker owner arrays.
+    if ned_dn > 0:
+        dn_owner = np.broadcast_to(dn_owner_template, (num_walkers, ned_dn)).copy()
+    else:
+        dn_owner = np.empty((num_walkers, 0), dtype=int)
+
+    up_owner = np.empty((num_walkers, ned_up), dtype=int)
+    if n_random_extras > 0:
+        det_count = ned_up - n_random_extras
+        if det_count > 0:
+            up_owner[:, :det_count] = up_owner_template[:det_count][None, :]
+        # Per-walker random pick from ion_seq, matching the original
+        #   idx = int(floor(np.random.rand() * nion))
+        rand_idx = np.floor(np.random.rand(num_walkers, n_random_extras) * nion).astype(int)
+        # Clip to nion-1 just in case np.random.rand() returns 1.0 (it shouldn't).
+        np.clip(rand_idx, 0, nion - 1, out=rand_idx)
+        up_owner[:, det_count:] = ion_seq[rand_idx]
+    else:
+        up_owner[:] = up_owner_template[None, :]
+
+    # 4) Draw all spherical random offsets in batched form.
+    def _spherical_offsets(shape: tuple[int, int]) -> np.ndarray:
+        distance = np.random.uniform(min_dst, max_dst, size=shape)
+        theta = np.random.uniform(0.0, np.pi, size=shape)
+        phi = np.random.uniform(0.0, 2.0 * np.pi, size=shape)
+        sin_t = np.sin(theta)
+        return np.stack(
+            [
+                distance * sin_t * np.cos(phi),
+                distance * sin_t * np.sin(phi),
+                distance * np.cos(theta),
+            ],
+            axis=-1,
+        ).astype(dtype_np, copy=False)
+
+    offset_dn = _spherical_offsets((num_walkers, ned_dn)) if ned_dn > 0 else np.zeros((num_walkers, 0, 3), dtype=dtype_np)
+    offset_up = _spherical_offsets((num_walkers, ned_up)) if ned_up > 0 else np.zeros((num_walkers, 0, 3), dtype=dtype_np)
+
+    # 5) Assemble final positions: r = coords[owner] + offset.
+    r_carts_up = (coords_np[up_owner] + offset_up).astype(dtype_np, copy=False)
+    r_carts_dn = (coords_np[dn_owner] + offset_dn).astype(dtype_np, copy=False)
+
+    return r_carts_up, r_carts_dn, up_owner, dn_owner
+
+
+def _generate_init_electron_configurations_debug(
+    tot_num_electron_up: int,
+    tot_num_electron_dn: int,
+    num_walkers: int,
+    charges: np.ndarray,
+    coords: np.ndarray,
+) -> tuple[npt.NDArray, npt.NDArray, npt.NDArray, npt.NDArray]:
+    """Reference (per-walker Python loop) initial electron configuration generator.
+
+    This is the original implementation kept for cross-checks against the
+    vectorized :func:`_generate_init_electron_configurations`. It runs an
+    ``O(num_walkers)`` Python loop and is too slow for large walker counts
+    (e.g. ``num_walkers = 16384``); use only for tests / debugging.
 
     Generate initial electron configurations (up/down positions) for a set of walkers,
     using the same ion_seq idea as the Fortran initconf routine, but without

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -242,9 +242,10 @@ class GFMC_t:
         # Initialization
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list_init = jnp.array(
-            [jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)]
-        )
+        # Use jax.random.split (batched) instead of a Python list-comp of
+        # fold_in calls; the latter scaled linearly with num_walkers and
+        # dominated init time at large walker counts (e.g. nw = 16384).
+        self.__jax_PRNG_key_list_init = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
         self.__jax_PRNG_key_list = self.__jax_PRNG_key_list_init
 
         # initialize random seed
@@ -269,15 +270,18 @@ class GFMC_t:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed — it was O(num_walkers) Python
+        # work (np.bincount per walker) executed regardless of log level, which
+        # at nw = 16384 added measurable startup overhead.
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
@@ -2629,9 +2633,10 @@ class _GFMC_t_debug:
         # Initialization
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list_init = jnp.array(
-            [jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)]
-        )
+        # Use jax.random.split (batched) instead of a Python list-comp of
+        # fold_in calls; the latter scaled linearly with num_walkers and
+        # dominated init time at large walker counts (e.g. nw = 16384).
+        self.__jax_PRNG_key_list_init = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
         self.__jax_PRNG_key_list = self.__jax_PRNG_key_list_init
 
         # initialize random seed
@@ -2656,15 +2661,18 @@ class _GFMC_t_debug:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed — it was O(num_walkers) Python
+        # work (np.bincount per walker) executed regardless of log level, which
+        # at nw = 16384 added measurable startup overhead.
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
@@ -3937,9 +3945,10 @@ class GFMC_n:
         # Initialization
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list_init = jnp.array(
-            [jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)]
-        )
+        # Use jax.random.split (batched) instead of a Python list-comp of
+        # fold_in calls; the latter scaled linearly with num_walkers and
+        # dominated init time at large walker counts (e.g. nw = 16384).
+        self.__jax_PRNG_key_list_init = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
         self.__jax_PRNG_key_list = self.__jax_PRNG_key_list_init
 
         # initialize random seed
@@ -3964,15 +3973,18 @@ class GFMC_n:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed — it was O(num_walkers) Python
+        # work (np.bincount per walker) executed regardless of log level, which
+        # at nw = 16384 added measurable startup overhead.
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
@@ -6560,9 +6572,10 @@ class _GFMC_n_debug:
         # Initialization
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list_init = jnp.array(
-            [jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)]
-        )
+        # Use jax.random.split (batched) instead of a Python list-comp of
+        # fold_in calls; the latter scaled linearly with num_walkers and
+        # dominated init time at large walker counts (e.g. nw = 16384).
+        self.__jax_PRNG_key_list_init = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
         self.__jax_PRNG_key_list = self.__jax_PRNG_key_list_init
 
         # initialize random seed
@@ -6587,15 +6600,18 @@ class _GFMC_n_debug:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed — it was O(num_walkers) Python
+        # work (np.bincount per walker) executed regardless of log level, which
+        # at nw = 16384 added measurable startup overhead.
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -190,7 +190,11 @@ class MCMC:
         # seeds
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list = jnp.array([jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)])
+        # Use jax.random.split to obtain ``num_walkers`` independent PRNGKeys in
+        # one batched call; replaces the previous ``[fold_in(..., nw) for nw ...]``
+        # Python-loop, which scaled linearly with num_walkers and dominated init
+        # time at large walker counts (e.g. nw = 16384).
+        self.__jax_PRNG_key_list = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
 
         # initialize random seed
         np.random.seed(self.__mpi_seed)
@@ -221,15 +225,18 @@ class MCMC:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed — it was O(num_walkers) Python
+        # work (np.bincount per walker) executed regardless of log level, which
+        # at nw = 16384 added measurable startup overhead.
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)
@@ -4791,7 +4798,9 @@ class _MCMC_debug:
         # seeds
         self.__mpi_seed = self.__mcmc_seed * (mpi_rank + 1)
         self.__jax_PRNG_key = jax.random.PRNGKey(self.__mpi_seed)
-        self.__jax_PRNG_key_list = jnp.array([jax.random.fold_in(self.__jax_PRNG_key, nw) for nw in range(self.__num_walkers)])
+        # Use jax.random.split (batched) to match the production MCMC class so
+        # MCMC ↔ _MCMC_debug parity tests stay aligned.
+        self.__jax_PRNG_key_list = jax.random.split(self.__jax_PRNG_key, self.__num_walkers)
 
         # initialize random seed
         np.random.seed(self.__mpi_seed)
@@ -4821,15 +4830,16 @@ class _MCMC_debug:
         )
 
         ## Electron assignment for all atoms is complete. Check the assignment.
-        for i_walker in range(self.__num_walkers):
-            logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
-            nion = coords.shape[0]
-            up_counts = np.bincount(up_owner[i_walker], minlength=nion)
-            dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
-            logger.debug(f"  Charges: {charges}")
-            logger.debug(f"  up counts: {up_counts}")
-            logger.debug(f"  dn counts: {dn_counts}")
-            logger.debug(f"  Total counts: {up_counts + dn_counts}")
+        # NOTE: per-walker debug log loop removed (see MCMC.__init__ for rationale).
+        # for i_walker in range(self.__num_walkers):
+        #     logger.debug(f"--Walker No.{i_walker + 1}: electrons assignment--")
+        #     nion = coords.shape[0]
+        #     up_counts = np.bincount(up_owner[i_walker], minlength=nion)
+        #     dn_counts = np.bincount(dn_owner[i_walker], minlength=nion)
+        #     logger.debug(f"  Charges: {charges}")
+        #     logger.debug(f"  up counts: {up_counts}")
+        #     logger.debug(f"  dn counts: {dn_counts}")
+        #     logger.debug(f"  Total counts: {up_counts + dn_counts}")
 
         dtype_jnp = jnp.float64
         self.__latest_r_up_carts = jnp.asarray(r_carts_up, dtype=dtype_jnp)

--- a/tests/test_init_electron_configurations.py
+++ b/tests/test_init_electron_configurations.py
@@ -1,0 +1,324 @@
+"""Unit tests for the vectorized initial-electron-configuration generator.
+
+Specifically guards against regressions in
+:func:`jqmc._jqmc_utility._generate_init_electron_configurations`:
+
+* All generated 3D positions across walkers and electrons must be unique
+  (no duplicates).
+* Output shapes match the documented contract.
+* Per-walker electron-to-atom assignment is consistent
+  (each owner is a valid atom index, total count matches input).
+* The vectorized version agrees with the reference implementation
+  ``_generate_init_electron_configurations_debug`` on the deterministic
+  atom-assignment template (i.e., owner indices, modulo per-walker random
+  extras).
+"""
+
+import numpy as np
+import pytest
+
+from jqmc._jqmc_utility import (
+    _generate_init_electron_configurations,
+    _generate_init_electron_configurations_debug,
+)
+
+
+# (name, charges, coords, tot_up, tot_dn)
+_TEST_SYSTEMS = [
+    (
+        "H2_ae",
+        np.array([1.0, 1.0]),
+        np.array([[-0.37, 0.0, 0.0], [0.37, 0.0, 0.0]]),
+        1,
+        1,
+    ),
+    (
+        "Li2_ae",
+        np.array([3.0, 3.0]),
+        np.array([[-1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
+        3,
+        3,
+    ),
+    (
+        "H2O_ae",
+        np.array([1.0, 8.0, 1.0]),
+        np.array([[0.00, 0.00, 0.00], [0.96, 0.00, 0.00], [-0.24, 0.93, 0.00]]),
+        5,
+        5,
+    ),
+    (
+        "H2O_ecp",
+        np.array([6.0, 1.0, 1.0]),
+        np.array([[0.00, 0.00, 0.00], [0.76, 0.59, 0.00], [-0.76, 0.59, 0.00]]),
+        4,
+        4,
+    ),
+    (
+        "N2_spin_polarized",
+        np.array([7.0, 7.0]),
+        np.array([[-0.6, 0.0, 0.0], [0.6, 0.0, 0.0]]),
+        10,
+        4,
+    ),
+    (
+        "single_H_ae",
+        np.array([1.0]),
+        np.array([[0.0, 0.0, 0.0]]),
+        1,
+        0,
+    ),
+]
+
+
+@pytest.mark.parametrize("name,charges,coords,tot_up,tot_dn", _TEST_SYSTEMS)
+@pytest.mark.parametrize("num_walkers", [1, 16, 256])
+def test_generated_positions_are_all_unique(name, charges, coords, tot_up, tot_dn, num_walkers):
+    """All (walker, electron) 3D positions across both spins are pairwise distinct."""
+    np.random.seed(123)
+    r_up, r_dn, _, _ = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    all_pos = np.concatenate([r_up.reshape(-1, 3), r_dn.reshape(-1, 3)], axis=0)
+    n_total = all_pos.shape[0]
+    assert n_total == num_walkers * (tot_up + tot_dn)
+    n_unique = np.unique(all_pos, axis=0).shape[0]
+    assert n_unique == n_total, (
+        f"[{name}, nw={num_walkers}] expected {n_total} unique positions, got {n_unique} (duplicates present)"
+    )
+
+
+@pytest.mark.parametrize("name,charges,coords,tot_up,tot_dn", _TEST_SYSTEMS)
+def test_output_shapes_and_owner_ranges(name, charges, coords, tot_up, tot_dn):
+    """Returned arrays have documented shapes and owners reference valid atoms."""
+    nion = coords.shape[0]
+    num_walkers = 32
+    np.random.seed(7)
+    r_up, r_dn, up_owner, dn_owner = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    assert r_up.shape == (num_walkers, tot_up, 3)
+    assert r_dn.shape == (num_walkers, tot_dn, 3)
+    assert up_owner.shape == (num_walkers, tot_up)
+    assert dn_owner.shape == (num_walkers, tot_dn)
+
+    if tot_up > 0:
+        assert up_owner.min() >= 0 and up_owner.max() < nion
+    if tot_dn > 0:
+        assert dn_owner.min() >= 0 and dn_owner.max() < nion
+
+
+@pytest.mark.parametrize("name,charges,coords,tot_up,tot_dn", _TEST_SYSTEMS)
+def test_vectorized_owners_match_reference(name, charges, coords, tot_up, tot_dn):
+    """Vectorized and reference implementations agree on the deterministic owner template.
+
+    Both versions place the spin-down electrons via the same deterministic
+    state machine, and place the spin-up electrons deterministically except
+    for any "extra" tail when ``tot_up > sum(zeta - occup_dn)``. This test
+    checks that the deterministic prefix of owner assignments matches.
+    """
+    num_walkers = 1
+    np.random.seed(0)
+    _, _, up_v, dn_v = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    np.random.seed(0)
+    _, _, up_r, dn_r = _generate_init_electron_configurations_debug(tot_up, tot_dn, num_walkers, charges, coords)
+
+    # Down-electron assignment is fully deterministic in both implementations.
+    np.testing.assert_array_equal(dn_v[0], dn_r[0])
+
+    # Up-electron assignment is deterministic up to the "extra" tail; compare
+    # the deterministic portion only.
+    zeta = np.rint(charges).astype(int)
+    occup_dn = np.bincount(dn_r[0], minlength=coords.shape[0])
+    sum_up_needed = int(np.sum(np.maximum(zeta - occup_dn, 0)))
+    det_count = min(tot_up, sum_up_needed)
+    np.testing.assert_array_equal(up_v[0, :det_count], up_r[0, :det_count])
+
+
+@pytest.mark.parametrize("name,charges,coords,tot_up,tot_dn", _TEST_SYSTEMS)
+@pytest.mark.parametrize("num_walkers", [1, 8])
+def test_per_atom_spin_counts_match_reference(name, charges, coords, tot_up, tot_dn, num_walkers):
+    """Per-atom up/dn populations must agree exactly with the reference implementation.
+
+    This guards against regressions in the *aggregate* spin-assignment behavior
+    (more permissive than owner-vector equality, but catches any change in
+    physical spin distribution per atom). Critical for systems where the old
+    algorithm specifically handled distant-atom spin distribution.
+    """
+    nion = coords.shape[0]
+    np.random.seed(0)
+    _, _, up_v, dn_v = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    np.random.seed(0)
+    _, _, up_r, dn_r = _generate_init_electron_configurations_debug(tot_up, tot_dn, num_walkers, charges, coords)
+    for iw in range(num_walkers):
+        np.testing.assert_array_equal(
+            np.bincount(up_v[iw], minlength=nion),
+            np.bincount(up_r[iw], minlength=nion),
+            err_msg=f"[{name}, walker {iw}] vectorized vs reference up counts differ",
+        )
+        np.testing.assert_array_equal(
+            np.bincount(dn_v[iw], minlength=nion),
+            np.bincount(dn_r[iw], minlength=nion),
+            err_msg=f"[{name}, walker {iw}] vectorized vs reference dn counts differ",
+        )
+
+
+# Identical-atom dimers in the global singlet (S=0) configuration. The expected
+# physical behavior at any separation: each atom carries zeta electrons with
+# Hund-maximum local moment, anti-aligned to its partner so the global S=0.
+# E.g., for N2 (zeta=7 each) at S=0 → one atom (4u, 3d), the other (3u, 4d).
+@pytest.mark.parametrize("elem_z", [3, 6, 7, 8])  # Li, C, N, O (AE valence counts)
+@pytest.mark.parametrize("separation", [0.5, 2.0, 5.0, 100.0])
+def test_dimer_singlet_atoms_are_antialigned(elem_z, separation):
+    """For a homonuclear dimer at S=0 the two atoms must be spin-mirror images."""
+    charges = np.array([float(elem_z), float(elem_z)])
+    coords = np.array([[0.0, 0.0, 0.0], [separation, 0.0, 0.0]])
+    tot_up = elem_z
+    tot_dn = elem_z
+    num_walkers = 4
+
+    np.random.seed(0)
+    _, _, up_owner, dn_owner = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    for iw in range(num_walkers):
+        up_counts = np.bincount(up_owner[iw], minlength=2)
+        dn_counts = np.bincount(dn_owner[iw], minlength=2)
+        # Each atom is charge-neutral.
+        np.testing.assert_array_equal(
+            up_counts + dn_counts,
+            np.array([elem_z, elem_z]),
+            err_msg=f"sep={separation}, Z={elem_z}, walker {iw}: per-atom electron count != zeta",
+        )
+        # Spins anti-aligned: nup on one = ndn on the other (and vice versa).
+        assert up_counts[0] == dn_counts[1], (
+            f"sep={separation}, Z={elem_z}, walker {iw}: expected up_counts[0] == dn_counts[1], got {up_counts}, {dn_counts}"
+        )
+        assert dn_counts[0] == up_counts[1], (
+            f"sep={separation}, Z={elem_z}, walker {iw}: expected dn_counts[0] == up_counts[1], got {up_counts}, {dn_counts}"
+        )
+        # Hund respected: |nup - ndn| per atom = expected unpaired-electron count.
+        # For zeta = elem_z, max_dn_per_atom = elem_z // 2, so unpaired = elem_z - 2 * (elem_z // 2).
+        expected_unpaired = elem_z - 2 * (elem_z // 2) + 2 * abs((elem_z // 2) - min(up_counts[0], dn_counts[0]))
+        # Relaxed check: each atom's |nup - ndn| should be at least the parity (1 if odd zeta, else 0).
+        parity = elem_z % 2
+        for atom in range(2):
+            assert abs(int(up_counts[atom]) - int(dn_counts[atom])) >= parity, (
+                f"sep={separation}, Z={elem_z}, walker {iw}, atom {atom}: "
+                f"|nup-ndn| < parity ({parity}); counts up={up_counts}, dn={dn_counts}"
+            )
+
+
+# For homonuclear / heteronuclear dimers, sweep every reachable global spin S
+# (i.e., every valid (tot_up, tot_dn) partition that sums to total electron
+# count) and verify per-atom charge neutrality. This is the core invariant
+# the original algorithm was designed to provide for widely-separated atoms
+# (e.g., N---N at 100 bohr where each atom must locally hold zeta electrons
+# regardless of global spin polarization).
+@pytest.mark.parametrize("separation", [2.0, 100.0])
+@pytest.mark.parametrize(
+    "label,zeta_pair",
+    [
+        ("N---N", (7, 7)),
+        ("N---O", (7, 8)),
+        ("O---O", (8, 8)),
+        ("Li---N", (3, 7)),
+        ("Li---Li", (3, 3)),
+        ("C---N", (6, 7)),
+    ],
+)
+def test_dimer_per_atom_charge_neutral_for_all_S(label, zeta_pair, separation):
+    """For every reachable S of a (neutral) dimer, both atoms must be charge-neutral.
+
+    Iterates over every valid ``(tot_up, tot_dn)`` partition with
+    ``tot_up + tot_dn == zeta[0] + zeta[1]``. For each, asserts that
+    ``np.bincount(up_owner) + np.bincount(dn_owner) == zeta`` for every walker.
+    Also checks the totals match the input split.
+    """
+    z0, z1 = zeta_pair
+    total = z0 + z1
+    charges = np.array([float(z0), float(z1)])
+    coords = np.array([[0.0, 0.0, 0.0], [separation, 0.0, 0.0]])
+    expected_zeta = np.array([z0, z1])
+    num_walkers = 4
+
+    for tot_up in range(total + 1):
+        tot_dn = total - tot_up
+        np.random.seed(0)
+        _, _, up_owner, dn_owner = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+        S2 = tot_up - tot_dn  # 2*S signed
+        for iw in range(num_walkers):
+            up_counts = np.bincount(up_owner[iw], minlength=2)
+            dn_counts = np.bincount(dn_owner[iw], minlength=2)
+            per_atom_total = up_counts + dn_counts
+            np.testing.assert_array_equal(
+                per_atom_total,
+                expected_zeta,
+                err_msg=(
+                    f"[{label}, sep={separation}, 2S={S2}, walker {iw}] "
+                    f"per-atom total {per_atom_total} != zeta {expected_zeta}; "
+                    f"up={up_counts.tolist()}, dn={dn_counts.tolist()}"
+                ),
+            )
+            assert int(up_counts.sum()) == tot_up, (
+                f"[{label}, 2S={S2}, walker {iw}] sum(up_counts)={up_counts.sum()} != tot_up={tot_up}"
+            )
+            assert int(dn_counts.sum()) == tot_dn, (
+                f"[{label}, 2S={S2}, walker {iw}] sum(dn_counts)={dn_counts.sum()} != tot_dn={tot_dn}"
+            )
+
+
+# Same idea, against the reference implementation: per-atom up/dn counts must
+# match across all S values. This is a stricter "no-regression" check on the
+# vectorized refactor specifically for the spin-distribution behavior.
+@pytest.mark.parametrize(
+    "label,zeta_pair",
+    [
+        ("N---N", (7, 7)),
+        ("N---O", (7, 8)),
+        ("Li---N", (3, 7)),
+    ],
+)
+def test_dimer_per_atom_counts_match_reference_for_all_S(label, zeta_pair):
+    """Vectorized vs reference per-atom spin counts must agree for every S."""
+    z0, z1 = zeta_pair
+    total = z0 + z1
+    charges = np.array([float(z0), float(z1)])
+    coords = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0]])
+    num_walkers = 2
+
+    for tot_up in range(total + 1):
+        tot_dn = total - tot_up
+        np.random.seed(0)
+        _, _, up_v, dn_v = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+        np.random.seed(0)
+        _, _, up_r, dn_r = _generate_init_electron_configurations_debug(tot_up, tot_dn, num_walkers, charges, coords)
+        for iw in range(num_walkers):
+            np.testing.assert_array_equal(
+                np.bincount(up_v[iw], minlength=2),
+                np.bincount(up_r[iw], minlength=2),
+                err_msg=f"[{label}, 2S={tot_up - tot_dn}, walker {iw}] up counts differ",
+            )
+            np.testing.assert_array_equal(
+                np.bincount(dn_v[iw], minlength=2),
+                np.bincount(dn_r[iw], minlength=2),
+                err_msg=f"[{label}, 2S={tot_up - tot_dn}, walker {iw}] dn counts differ",
+            )
+
+
+# Triatomic (linear, well-separated) chain — exercises ion_seq logic for >2 atoms.
+@pytest.mark.parametrize("elem_z", [3, 7])
+def test_linear_triatomic_charge_neutrality(elem_z):
+    """For a homonuclear linear triatomic at separation 5 bohr each, every atom
+    receives exactly zeta electrons (charge-neutral assignment)."""
+    charges = np.array([float(elem_z)] * 3)
+    coords = np.array([[0.0, 0.0, 0.0], [5.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+    nion = 3
+    # Use total = sum(zeta), pick a balanced spin partition.
+    total = 3 * elem_z
+    tot_up = total // 2 + (total % 2)  # ceil
+    tot_dn = total - tot_up
+    num_walkers = 4
+
+    np.random.seed(0)
+    _, _, up_owner, dn_owner = _generate_init_electron_configurations(tot_up, tot_dn, num_walkers, charges, coords)
+    for iw in range(num_walkers):
+        per_atom_total = np.bincount(up_owner[iw], minlength=nion) + np.bincount(dn_owner[iw], minlength=nion)
+        np.testing.assert_array_equal(
+            per_atom_total,
+            np.array([elem_z, elem_z, elem_z]),
+            err_msg=f"Z={elem_z}, walker {iw}: per-atom electron count != zeta (got {per_atom_total})",
+        )


### PR DESCRIPTION
## Summary

Speed up the preprocessing path that dominated startup at large walker counts (for example, `num_walkers = 16384`):
- Vectorize `_generate_init_electron_configurations` by replaying the deterministic atom-assignment state machine once and batching all per-walker randomness via `np.random`. The original implementation is kept as `_generate_init_electron_configurations_debug` for reference.
- Replace the per-walker `fold_in` list comprehension with a single `jax.random.split(key, num_walkers)` in `MCMC`, `GFMC_t`, `GFMC_n`, and their `_debug` variants.
- Drop the per-walker debug log loop, which ran `np.bincount` regardless of log level because it's very slow.
- Add `tests/test_init_electron_configurations.py` covering equivalence against the reference implementation and position uniqueness.

## Notes

Switching from `fold_in` to `split` breaks bit-for-bit reproducibility against pre-PR runs with the same `mcmc_seed`; the statistical properties are equivalent.