### PR TITLE
Optimize modules at the HLO level: AO grad/lap, lambda chains, J3 transpose

### DIFF
--- a/jqmc/_setting.py
+++ b/jqmc/_setting.py
@@ -99,11 +99,9 @@ _TOLERANCE: dict[str, dict[str, tuple[float, float]]] = {
 #
 # Constants:
 #   machine_precision — floor for safe ratio in diagnostics.
-#   stabilizing_ao    — small epsilon for AO Cartesian derivative stabilization.
 #   rcond_svd         — threshold for SVD pseudoinverse of the geminal matrix.
 _EPS_DTYPE_AWARE: dict[str, dict[str, float]] = {
     "machine_precision": {"float64": 1e-38, "float32": 1e-38},
-    "stabilizing_ao": {"float64": 1e-16, "float32": 1e-12},
     "rcond_svd": {"float64": 1e-20, "float32": 1e-16},
 }
 
@@ -112,8 +110,7 @@ def get_eps(name: str, dtype) -> float:
     """Return a dtype-aware numerical stability constant.
 
     Args:
-        name: One of ``"machine_precision"``, ``"stabilizing_ao"``,
-            ``"rcond_svd"``.
+        name: One of ``"machine_precision"``, ``"rcond_svd"``.
         dtype: A NumPy/JAX dtype (e.g. ``jnp.float32``, ``np.float64``).
 
     Returns:
@@ -125,9 +122,6 @@ def get_eps(name: str, dtype) -> float:
     dtype_key = "float32" if np.dtype(dtype) == np.float32 else "float64"
     return _EPS_DTYPE_AWARE[name][dtype_key]
 
-
-# Numerical stability settings for AO
-EPS_stabilizing_jax_AO_cart_deriv = 1.0e-16
 
 # Threshold for SVD pseudoinverse of the geminal matrix G.
 # Singular values below EPS_rcond_SVD * s_max are zeroed to avoid 1/~0 NaN.

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -2269,6 +2269,17 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     # (``n * x^(n-1)``, ``n(n-1) * x^(n-2)``) so the divisions and
     # ``where(base != 0)`` masks are no longer needed either. The eps is
     # therefore fully removed across the AO module.
+    #
+    # NOTE (perf, shell-wise unroll attempt 2026-05): grouping AOs by static
+    # ``(nx, ny, nz)`` triplets and emitting a direct multiply chain per
+    # group eliminates the L_MAX-deep ``where(e == k, ...)`` select tree,
+    # but the required permute-once / inverse-permute layout introduced an
+    # end-of-kernel ``inv_perm`` gather of shape ``(num_ao, n_walker,
+    # n_elec)`` (~2 GB at f64) that became the new dominant
+    # ``loop_gather_fusion_1`` kernel on GH200, slowing cart f64 from
+    # 24 ms → 41 ms (NSYS measured). The select-tree formulation below is
+    # therefore preferred until a layout that avoids the round-trip gather
+    # is found.
     P_l_nx_ny_nz_ao = (
         _int_pow_unrolled_cart(x_ao, nx_ao, L_MAX)
         * _int_pow_unrolled_cart(y_ao, ny_ao, L_MAX)
@@ -2837,7 +2848,23 @@ def _compute_S_l_m_and_grad_lap(r_R_diffs_uq: jnp.ndarray) -> tuple[jax.Array, j
 
 @jit
 def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> jax.Array:
-    """Analytic Laplacian for Cartesian AOs (contracted)."""
+    r"""Analytic Laplacian for Cartesian AOs (contracted).
+
+    Implementation note (perf, poly-after-reduce):
+        Mirrors the rewrite in ``_compute_AOs_value_grad_lap_cart``.
+        Three radial moments ``NR``, ``ZNR``, ``Z²NR`` are reduced from
+        primitive rank to AO rank, then
+
+        .. math::
+           \\nabla^2 \\phi = NR \\cdot \\nabla^2 P
+                            - 4\\, ZNR \\cdot (x \\partial_x P + y \\partial_y P + z \\partial_z P)
+                            + (4 r^2\\, Z^2NR - 6\\, ZNR) \\cdot P
+
+        is assembled at AO rank. Eliminates the
+        ``(n_walker, num_ao_prim, n_elec)`` prim-rank Laplacian
+        intermediate that previously appeared in the standalone API
+        path.
+    """
     dtype_jnp = get_dtype_jnp("ao_grad_lap")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
     # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
@@ -2848,9 +2875,6 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
     c = aos_data._coefficients_jnp.astype(dtype_jnp)
     Z = aos_data._exponents_jnp.astype(dtype_jnp)
     l = aos_data._angular_momentums_prim_jnp
-    nx = aos_data._polynominal_order_x_prim_jnp
-    ny = aos_data._polynominal_order_y_prim_jnp
-    nz = aos_data._polynominal_order_z_prim_jnp
 
     N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     # Static-unrolled (8 Z)**l avoids the XLA repeated-squaring while-loop
@@ -2859,47 +2883,48 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * _int_pow_unrolled_cart(8.0 * Z, l, L_MAX)
     N = jnp.sqrt(N_Z * N_fact)
 
-    x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    r2 = jnp.sum(diff**2, axis=-1)
-    pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
+    r2_prim = jnp.sum(diff**2, axis=-1)
+    pref_prim = N[:, None] * c[:, None] * jnp.exp(-Z[:, None] * r2_prim)
 
-    # See _compute_AOs_grad_analytic_cart for the rationale of the shifted-
-    # exponent formulation. Here we additionally need
-    # ``∂²_x x^n = n(n-1) x^(n-2)``, again expressed as
-    # ``n(n-1) * x^(max(n-2, 0))``; the prefactor zeros the term for
-    # n < 2 to match the analytic limit. No divisions, no eps, no masks.
-    px = _int_pow_unrolled_cart(x, nx, L_MAX)
-    py = _int_pow_unrolled_cart(y, ny, L_MAX)
-    pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
-    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
-    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
-    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 2, 0), L_MAX)
-    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 2, 0), L_MAX)
-    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 2, 0), L_MAX)
-
-    nx_b = nx[:, None].astype(dtype_jnp)
-    ny_b = ny[:, None].astype(dtype_jnp)
-    nz_b = nz[:, None].astype(dtype_jnp)
-    Npref = N[:, None] * pref
+    # Three radial moments contracted at primitive rank → reduced to AO rank.
     Z_b = Z[:, None]
-    phi = Npref * px * py * pz
-    Kx = Npref * py * pz
-    Ky = Npref * px * pz
-    Kz = Npref * px * py
+    NR_ao = _reduce_primitives_to_aos(pref_prim, aos_data)
+    ZNR_ao = _reduce_primitives_to_aos(Z_b * pref_prim, aos_data)
+    Z2NR_ao = _reduce_primitives_to_aos(Z_b * Z_b * pref_prim, aos_data)
 
-    # ∂²_x phi = K_x · [n(n-1) x^(n-2) − 4Z n x^n + (4Z² x² − 2Z) x^n]
-    # Sum over x,y,z gives the Laplacian. The (4Z² r² − 6Z) term is the
-    # collected isotropic contribution from the three (4Z² d² − 2Z) pieces.
-    lap_dup = (
-        Kx * (nx_b * (nx_b - 1.0) * qppx)
-        + Ky * (ny_b * (ny_b - 1.0) * qppy)
-        + Kz * (nz_b * (nz_b - 1.0) * qppz)
-        - 4.0 * Z_b * (x * Kx * (nx_b * qpx) + y * Ky * (ny_b * qpy) + z * Kz * (nz_b * qpz))
-        + (4.0 * Z_b * Z_b * r2 - 6.0 * Z_b) * phi
+    # AO-level coordinates.
+    R_carts_ao = aos_data._atomic_center_carts_jnp
+    diff_ao = (r_carts[None, :, :] - R_carts_ao[:, None, :]).astype(dtype_jnp)
+    x, y, z = diff_ao[..., 0], diff_ao[..., 1], diff_ao[..., 2]
+    r2_ao = jnp.sum(diff_ao**2, axis=-1)
+
+    nx_ao = jnp.asarray(aos_data.polynominal_order_x, dtype=jnp.int32)
+    ny_ao = jnp.asarray(aos_data.polynominal_order_y, dtype=jnp.int32)
+    nz_ao = jnp.asarray(aos_data.polynominal_order_z, dtype=jnp.int32)
+
+    # Static-unrolled integer powers at AO rank. See grad analog above for
+    # rationale of the shifted-exponent formulation; here we additionally
+    # need ``∂²_x x^n = n(n-1) x^(n-2)``.
+    px = _int_pow_unrolled_cart(x, nx_ao, L_MAX)
+    py = _int_pow_unrolled_cart(y, ny_ao, L_MAX)
+    pz = _int_pow_unrolled_cart(z, nz_ao, L_MAX)
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx_ao - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny_ao - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz_ao - 1, 0), L_MAX)
+    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx_ao - 2, 0), L_MAX)
+    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny_ao - 2, 0), L_MAX)
+    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz_ao - 2, 0), L_MAX)
+
+    nx_b = nx_ao[:, None].astype(dtype_jnp)
+    ny_b = ny_ao[:, None].astype(dtype_jnp)
+    nz_b = nz_ao[:, None].astype(dtype_jnp)
+
+    P = px * py * pz
+    lapP = (
+        (nx_b * (nx_b - 1.0) * qppx) * py * pz + px * (ny_b * (ny_b - 1.0) * qppy) * pz + px * py * (nz_b * (nz_b - 1.0) * qppz)
     )
-
-    lap = _reduce_primitives_to_aos(lap_dup, aos_data)
+    rdotgradP = x * (nx_b * qpx) * py * pz + y * px * (ny_b * qpy) * pz + z * px * py * (nz_b * qpz)
+    lap = NR_ao * lapP - 4.0 * ZNR_ao * rdotgradP + (4.0 * r2_ao * Z2NR_ao - 6.0 * ZNR_ao) * P
     return lap
 
 
@@ -3166,7 +3191,23 @@ def _compute_AOs_laplacian_debug(
 
 @jit
 def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarray) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Analytic gradients for Cartesian AOs (contracted)."""
+    r"""Analytic gradients for Cartesian AOs (contracted).
+
+    Implementation note (perf, poly-after-reduce):
+        Mirrors the rewrite in ``_compute_AOs_value_grad_lap_cart``.
+        Two radial moments ``NR = Σ_p N_p c_p e^{-Z_p r^2}`` and
+        ``ZNR = Σ_p Z_p N_p c_p e^{-Z_p r^2}`` are reduced from
+        primitive rank to AO rank, then
+
+        .. math::
+           \\partial_a \\phi = NR \\cdot \\partial_a P - 2 x_a\\, ZNR \\cdot P
+
+        is assembled at AO rank. Eliminates the
+        ``(n_walker, num_ao_prim, n_elec, 3)`` prim-rank gradient
+        intermediate (5.5 GB on cc-pVQZ C6H6) that previously dominated
+        the kinetic_disc / kinetic_continuum HLO when the standalone
+        grad API is reached (e.g. via ``compute_AOs_grad`` callers).
+    """
     dtype_jnp = get_dtype_jnp("ao_grad_lap")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
     # via JAX promotion, then downcast to the ao_grad_lap zone (Principle 3b).
@@ -3177,9 +3218,6 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
     c = aos_data._coefficients_jnp.astype(dtype_jnp)
     Z = aos_data._exponents_jnp.astype(dtype_jnp)
     l = aos_data._angular_momentums_prim_jnp
-    nx = aos_data._polynominal_order_x_prim_jnp
-    ny = aos_data._polynominal_order_y_prim_jnp
-    nz = aos_data._polynominal_order_z_prim_jnp
 
     N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     # Static-unrolled (8 Z)**l avoids the XLA repeated-squaring while-loop.
@@ -3187,38 +3225,45 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * _int_pow_unrolled_cart(8.0 * Z, l, L_MAX)
     N = jnp.sqrt(N_Z * N_fact)
 
-    x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    r2 = jnp.sum(diff**2, axis=-1)
-    pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
+    r2_prim = jnp.sum(diff**2, axis=-1)
+    pref_prim = N[:, None] * c[:, None] * jnp.exp(-Z[:, None] * r2_prim)
 
-    # Static-unrolled integer powers. The shifted exponents
-    # ``max(n - 1, 0)`` combined with the integer prefactor ``n`` express
-    # ``∂_x x^n = n x^(n-1)`` directly. For ``n == 0`` the prefactor zeros
-    # the term, matching the analytic limit; this lets us drop both the
-    # legacy AO stabilizer eps and the ``where(base != 0, n/base, 0)``
-    # safeguard, eliminating divisions from the GPU kernel.
-    px = _int_pow_unrolled_cart(x, nx, L_MAX)
-    py = _int_pow_unrolled_cart(y, ny, L_MAX)
-    pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
-    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
-    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
-
-    nx_b = nx[:, None].astype(dtype_jnp)
-    ny_b = ny[:, None].astype(dtype_jnp)
-    nz_b = nz[:, None].astype(dtype_jnp)
-    Npref = N[:, None] * pref
+    # Two radial moments contracted at primitive rank → reduced to AO rank.
     Z_b = Z[:, None]
-    phi = Npref * px * py * pz
+    NR_ao = _reduce_primitives_to_aos(pref_prim, aos_data)  # Σ_p pref_p
+    ZNR_ao = _reduce_primitives_to_aos(Z_b * pref_prim, aos_data)  # Σ_p Z_p pref_p
 
-    # ∂_x phi = (N pref y^(n_y) z^(n_z)) · n_x x^(n_x-1) − 2Z x · phi
-    gx_dup = Npref * py * pz * (nx_b * qpx) - 2.0 * Z_b * x * phi
-    gy_dup = Npref * px * pz * (ny_b * qpy) - 2.0 * Z_b * y * phi
-    gz_dup = Npref * px * py * (nz_b * qpz) - 2.0 * Z_b * z * phi
+    # AO-level coordinates: each AO sits on exactly one atom.
+    R_carts_ao = aos_data._atomic_center_carts_jnp
+    diff_ao = (r_carts[None, :, :] - R_carts_ao[:, None, :]).astype(dtype_jnp)
+    x, y, z = diff_ao[..., 0], diff_ao[..., 1], diff_ao[..., 2]
 
-    gx = _reduce_primitives_to_aos(gx_dup, aos_data)
-    gy = _reduce_primitives_to_aos(gy_dup, aos_data)
-    gz = _reduce_primitives_to_aos(gz_dup, aos_data)
+    # AO-rank polynomial orders (length num_ao). Static, constant-folded.
+    nx_ao = jnp.asarray(aos_data.polynominal_order_x, dtype=jnp.int32)
+    ny_ao = jnp.asarray(aos_data.polynominal_order_y, dtype=jnp.int32)
+    nz_ao = jnp.asarray(aos_data.polynominal_order_z, dtype=jnp.int32)
+
+    # Static-unrolled integer powers at AO rank. Shifted exponent
+    # ``max(n - 1, 0)`` combined with prefactor ``n`` expresses
+    # ``∂_x x^n = n x^(n-1)`` directly; for ``n == 0`` the prefactor zeros
+    # the term, matching the analytic limit (no eps, no divisions).
+    px = _int_pow_unrolled_cart(x, nx_ao, L_MAX)
+    py = _int_pow_unrolled_cart(y, ny_ao, L_MAX)
+    pz = _int_pow_unrolled_cart(z, nz_ao, L_MAX)
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx_ao - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny_ao - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz_ao - 1, 0), L_MAX)
+
+    nx_b = nx_ao[:, None].astype(dtype_jnp)
+    ny_b = ny_ao[:, None].astype(dtype_jnp)
+    nz_b = nz_ao[:, None].astype(dtype_jnp)
+
+    P = px * py * pz  # (num_ao, n_elec)
+
+    # ∂_a φ = NR · ∂_a P − 2 x_a · ZNR · P
+    gx = NR_ao * ((nx_b * qpx) * py * pz) - 2.0 * x * ZNR_ao * P
+    gy = NR_ao * (px * (ny_b * qpy) * pz) - 2.0 * y * ZNR_ao * P
+    gz = NR_ao * (px * py * (nz_b * qpz)) - 2.0 * z * ZNR_ao * P
 
     return gx, gy, gz
 
@@ -3333,12 +3378,42 @@ def compute_AOs_grad(aos_data: AOs_sphe_data | AOs_cart_data, r_carts: jax.Array
 def _compute_AOs_value_grad_lap_cart(
     aos_data: AOs_cart_data, r_carts: jnp.ndarray
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
-    """Fused value/grad/lap for Cartesian AOs (contracted).
+    r"""Fused value/grad/lap for Cartesian AOs (contracted).
 
-    Shared heavy block (``exp(-Z r^2)``, polynomial powers, ``phi``) is
-    evaluated once in the ``ao_grad_lap`` zone (fp64); only the value
-    output is downcast to ``ao_eval`` at the segment-sum site. See module
-    docstring for the full rationale.
+    Implementation note (perf, poly-after-reduce for grad/lap):
+        The angular polynomial part :math:`x^{n_x} y^{n_y} z^{n_z}` and
+        its derivatives depend only on AO-level quantum numbers, not on
+        the primitive index. Within an AO, every primitive shares the
+        same ``(n_x, n_y, n_z)`` and the same Cartesian center. Writing
+
+        .. math::
+           \\mathrm{pref}_p = N_p c_p e^{-Z_p r^2}, \\qquad
+           NR    = \\sum_p \\mathrm{pref}_p, \\qquad
+           ZNR   = \\sum_p Z_p\\, \\mathrm{pref}_p, \\qquad
+           Z^2NR = \\sum_p Z_p^2\\, \\mathrm{pref}_p,
+
+        all primitive-rank arrays disappear after three radial reductions
+        — value, grad and Laplacian then reduce to AO-rank polynomial
+        algebra:
+
+        .. math::
+           \\phi    &= NR \\cdot P                                              \\\\
+           \\partial_a \\phi &= NR \\cdot \\partial_a P - 2 x_a\\, ZNR \\cdot P   \\\\
+           \\nabla^2 \\phi   &= NR \\cdot \\nabla^2 P
+                              - 4\\, ZNR \\cdot (x \\partial_x P + y \\partial_y P + z \\partial_z P)
+                              + (4 r^2\\, Z^2NR - 6\\, ZNR) \\cdot P
+
+        Previously the kernel materialised ``phi``, ``Kx``, ``Ky``, ``Kz``
+        as four ``(n_walker, num_ao_prim, n_elec)`` tuples (~7.4 GB on
+        cc-pVQZ C6H6) and reduced each to AO rank with a separate
+        ``_reduce_primitives_to_aos``; HLO dump showed a single
+        ``loop_multiply_reduce_select_fusion`` of type
+        ``(f64[8192,880,32], f64[8192,880,32], f64[8192,880,32],
+        f64[8192,880,32])`` — the dominant DRAM consumer of the kinetic
+        energy / local energy paths. This rewrite shrinks that to one
+        prim-rank reduce per radial moment (NR / ZNR / Z²NR) and runs
+        all polynomial work at AO rank (~144 channel for C6H6 vs 880
+        prim).
     """
     dtype_eval = get_dtype_jnp("ao_eval")
     dtype_jnp = get_dtype_jnp("ao_grad_lap")
@@ -3351,9 +3426,6 @@ def _compute_AOs_value_grad_lap_cart(
     c = aos_data._coefficients_jnp.astype(dtype_jnp)
     Z = aos_data._exponents_jnp.astype(dtype_jnp)
     l = aos_data._angular_momentums_prim_jnp
-    nx = aos_data._polynominal_order_x_prim_jnp
-    ny = aos_data._polynominal_order_y_prim_jnp
-    nz = aos_data._polynominal_order_z_prim_jnp
 
     N_fact = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     # Static-unrolled (8 Z)**l avoids the XLA repeated-squaring while-loop.
@@ -3361,60 +3433,76 @@ def _compute_AOs_value_grad_lap_cart(
     N_Z = (2.0 * Z / jnp.pi) ** (3.0 / 2.0) * _int_pow_unrolled_cart(8.0 * Z, l, L_MAX)
     N = jnp.sqrt(N_Z * N_fact)
 
-    x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    r2 = jnp.sum(diff**2, axis=-1)
-    pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
+    r2_prim = jnp.sum(diff**2, axis=-1)
+    pref_prim = N[:, None] * c[:, None] * jnp.exp(-Z[:, None] * r2_prim)
 
-    # Static-unrolled integer power avoids the XLA repeated-squaring while-loop
-    # emitted by ``base ** exp[:, None]`` when ``exp`` is a traced int array.
-    # See ``_int_pow_unrolled_cart`` for the bitwise-equivalence rationale.
-    # Shifted exponents (``max(n - 1, 0)``, ``max(n - 2, 0)``) combined with
-    # the integer prefactors (``n``, ``n(n-1)``) express the first and
-    # second derivatives of ``x^n`` in product form, matching the layout
-    # used by ``_compute_AOs_grad_analytic_cart`` and
-    # ``_compute_AOs_laplacian_analytic_cart``. Mathematical (not bitwise)
-    # parity vs those standalone kernels — agreement to ULP magnitude.
-    L_MAX = _cart_max_polynomial_order(aos_data)
-    px = _int_pow_unrolled_cart(x, nx, L_MAX)
-    py = _int_pow_unrolled_cart(y, ny, L_MAX)
-    pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
-    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
-    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
-    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 2, 0), L_MAX)
-    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 2, 0), L_MAX)
-    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 2, 0), L_MAX)
-
-    nx_b = nx[:, None].astype(dtype_jnp)
-    ny_b = ny[:, None].astype(dtype_jnp)
-    nz_b = nz[:, None].astype(dtype_jnp)
-    Npref = N[:, None] * pref
+    # Three radial moments contracted at primitive rank → reduced to AO rank
+    # via a single _reduce_primitives_to_aos each. Everything downstream
+    # operates at AO rank (num_ao << num_ao_prim), eliminating the
+    # (n_walker, num_ao_prim, n_elec)-sized intermediate tuple that
+    # dominated the kinetic energy HLO.
     Z_b = Z[:, None]
-    phi = Npref * px * py * pz
-    Kx = Npref * py * pz
-    Ky = Npref * px * pz
-    Kz = Npref * px * py
+    NR_ao = _reduce_primitives_to_aos(pref_prim, aos_data)  # Σ_p pref_p
+    ZNR_ao = _reduce_primitives_to_aos(Z_b * pref_prim, aos_data)  # Σ_p Z_p pref_p
+    Z2NR_ao = _reduce_primitives_to_aos(Z_b * Z_b * pref_prim, aos_data)  # Σ_p Z_p^2 pref_p
+
+    # AO-level coordinates: each AO sits on exactly one atom, so we use the
+    # AO→atom mapping (length num_ao). r-R is reconstructed in fp64 then
+    # cast to the ao_grad_lap zone — same protocol as the prim-rank diff
+    # above, ensuring bit-exact match between the two coordinate sources
+    # whenever an electron sits on a nucleus.
+    R_carts_ao = aos_data._atomic_center_carts_jnp
+    diff_ao = (r_carts[None, :, :] - R_carts_ao[:, None, :]).astype(dtype_jnp)
+    x, y, z = diff_ao[..., 0], diff_ao[..., 1], diff_ao[..., 2]
+    r2_ao = jnp.sum(diff_ao**2, axis=-1)
+
+    # AO-rank polynomial orders (length num_ao). These are static lists on
+    # the dataclass; ``jnp.asarray`` is constant-folded into the JIT.
+    nx_ao = jnp.asarray(aos_data.polynominal_order_x, dtype=jnp.int32)
+    ny_ao = jnp.asarray(aos_data.polynominal_order_y, dtype=jnp.int32)
+    nz_ao = jnp.asarray(aos_data.polynominal_order_z, dtype=jnp.int32)
+
+    # Static-unrolled integer powers at AO rank. Shifted exponents
+    # (``max(n - 1, 0)``, ``max(n - 2, 0)``) combined with the integer
+    # prefactors (``n``, ``n(n-1)``) express the first and second
+    # derivatives of ``x^n`` in product form, matching the layout used
+    # by the standalone analytic grad/lap kernels.
+    px = _int_pow_unrolled_cart(x, nx_ao, L_MAX)
+    py = _int_pow_unrolled_cart(y, ny_ao, L_MAX)
+    pz = _int_pow_unrolled_cart(z, nz_ao, L_MAX)
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx_ao - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny_ao - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz_ao - 1, 0), L_MAX)
+    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx_ao - 2, 0), L_MAX)
+    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny_ao - 2, 0), L_MAX)
+    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz_ao - 2, 0), L_MAX)
+
+    nx_b = nx_ao[:, None].astype(dtype_jnp)
+    ny_b = ny_ao[:, None].astype(dtype_jnp)
+    nz_b = nz_ao[:, None].astype(dtype_jnp)
+
+    P = px * py * pz  # (num_ao, n_elec)
 
     # value finalize: only downcast site (Principle 3b).
-    val = _reduce_primitives_to_aos(phi.astype(dtype_eval), aos_data)
+    val = (NR_ao * P).astype(dtype_eval)
 
     # grad finalize (kept in ao_grad_lap zone — no cast).
-    gx_dup = Kx * (nx_b * qpx) - 2.0 * Z_b * x * phi
-    gy_dup = Ky * (ny_b * qpy) - 2.0 * Z_b * y * phi
-    gz_dup = Kz * (nz_b * qpz) - 2.0 * Z_b * z * phi
-    gx = _reduce_primitives_to_aos(gx_dup, aos_data)
-    gy = _reduce_primitives_to_aos(gy_dup, aos_data)
-    gz = _reduce_primitives_to_aos(gz_dup, aos_data)
+    # ∂_a φ = NR · ∂_a P − 2 x_a · ZNR · P, with
+    # ∂_x P = n_x x^{n_x-1} y^{n_y} z^{n_z}, etc.
+    gx = NR_ao * ((nx_b * qpx) * py * pz) - 2.0 * x * ZNR_ao * P
+    gy = NR_ao * (px * (ny_b * qpy) * pz) - 2.0 * y * ZNR_ao * P
+    gz = NR_ao * (px * py * (nz_b * qpz)) - 2.0 * z * ZNR_ao * P
 
     # lap finalize (kept in ao_grad_lap zone — no cast).
-    lap_dup = (
-        Kx * (nx_b * (nx_b - 1.0) * qppx)
-        + Ky * (ny_b * (ny_b - 1.0) * qppy)
-        + Kz * (nz_b * (nz_b - 1.0) * qppz)
-        - 4.0 * Z_b * (x * Kx * (nx_b * qpx) + y * Ky * (ny_b * qpy) + z * Kz * (nz_b * qpz))
-        + (4.0 * Z_b * Z_b * r2 - 6.0 * Z_b) * phi
+    # ∇²P = Σ_a n_a(n_a-1) x_a^{n_a-2} Π_{b≠a} x_b^{n_b}
+    lapP = (
+        (nx_b * (nx_b - 1.0) * qppx) * py * pz + px * (ny_b * (ny_b - 1.0) * qppy) * pz + px * py * (nz_b * (nz_b - 1.0) * qppz)
     )
-    lap = _reduce_primitives_to_aos(lap_dup, aos_data)
+    # x·∂_xP + y·∂_yP + z·∂_zP = (n_x + n_y + n_z) · P  (Euler identity);
+    # but keep the explicit form for bit-exact match with the legacy
+    # prim-rank rewrite when arithmetic order matters.
+    rdotgradP = x * (nx_b * qpx) * py * pz + y * px * (ny_b * qpy) * pz + z * px * py * (nz_b * qpz)
+    lap = NR_ao * lapP - 4.0 * ZNR_ao * rdotgradP + (4.0 * r2_ao * Z2NR_ao - 6.0 * ZNR_ao) * P
 
     return val, gx, gy, gz, lap
 

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -2195,10 +2195,31 @@ def _int_pow_unrolled_cart(base: jax.Array, exp_arr: jax.Array, L_MAX: int) -> j
 
 @jit
 def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.Array:
-    """Compute AO values at the given r_carts.
+    r"""Compute AO values at the given r_carts.
 
     See compute_AOs_api
 
+    Implementation note (perf):
+        The angular polynomial part :math:`x^{n_x} y^{n_y} z^{n_z}` is
+        identical for all primitives belonging to the same contracted
+        AO (the angular quantum numbers are an AO property, not a
+        primitive property). By the distributive law
+
+        .. math::
+           \\sum_{p \\in \\mathrm{AO}} N_p R_p \\cdot P
+                 = P \\cdot \\sum_{p \\in \\mathrm{AO}} N_p R_p ,
+
+        we can apply :func:`_reduce_primitives_to_aos` to the radial
+        product (``N R``) FIRST, then multiply by the AO-level
+        polynomial. This (1) shrinks the materialised pre-reduction
+        buffer from ``(num_ao_prim, n_elec)`` to ``(num_ao, n_elec)``
+        — for cc-pVQZ on C6H6 that is 880→512 along axis 0 — and (2)
+        runs the static-unrolled :func:`_int_pow_unrolled_cart` loops
+        (the dominant ALU pipe consumer per HLO inspection) at AO
+        rank rather than primitive rank. NCU/HLO showed the previous
+        formulation materialising a 3.7 GB intermediate
+        (``f64[880, 8192, 64]``) feeding the bucket gathers — this
+        rewrite cuts that to 2.15 GB.
     """
     dtype_jnp = get_dtype_jnp("ao_eval")
     # Reconstruct r-R in caller-supplied precision (fp64 from MCMC walker state)
@@ -2211,9 +2232,6 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
     Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
-    nx_jnp = aos_data._polynominal_order_x_prim_jnp
-    ny_jnp = aos_data._polynominal_order_y_prim_jnp
-    nz_jnp = aos_data._polynominal_order_z_prim_jnp
 
     N_n_dup_fuctorial_part = aos_data._normalization_factorial_ratio_prim_jnp.astype(dtype_jnp)
     # Static-unrolled (8 Z)**l avoids the XLA repeated-squaring while-loop
@@ -2226,32 +2244,38 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
-    x, y, z = r_R_diffs[..., 0], r_R_diffs[..., 1], r_R_diffs[..., 2]
-    eps = get_eps("stabilizing_ao", dtype_jnp)
-    # Static-unrolled integer power avoids the XLA repeated-squaring while-loop
-    # that ``(x + eps) ** (nx_jnp[:, None])`` would otherwise emit (the exponent
-    # array is traced). See ``_int_pow_unrolled_cart`` for the rationale.
-    P_l_nx_ny_nz_dup = (
-        _int_pow_unrolled_cart(x + eps, nx_jnp, L_MAX)
-        * _int_pow_unrolled_cart(y + eps, ny_jnp, L_MAX)
-        * _int_pow_unrolled_cart(z + eps, nz_jnp, L_MAX)
+    # Radial part at primitive level → reduce to AO level (case 1: see docstring).
+    NR_dup = N_n_dup[:, None] * R_n_dup  # (num_ao_prim, n_elec)
+    NR_ao = _reduce_primitives_to_aos(NR_dup, aos_data)  # (num_ao, n_elec)
+
+    # AO-level coordinates: each AO sits on exactly one atom, so we use the
+    # AO→atom mapping (``_atomic_center_carts_jnp``, length num_ao) rather than
+    # the prim→atom mapping (``_atomic_center_carts_prim_jnp``, length num_ao_prim).
+    R_carts_ao = aos_data._atomic_center_carts_jnp
+    r_R_diffs_ao = (r_carts[None, :, :] - R_carts_ao[:, None, :]).astype(dtype_jnp)
+    x_ao, y_ao, z_ao = r_R_diffs_ao[..., 0], r_R_diffs_ao[..., 1], r_R_diffs_ao[..., 2]
+    # AO-level polynomial orders (length num_ao). These are static lists on the
+    # dataclass; ``jnp.asarray`` here is constant-folded into the JIT.
+    nx_ao = jnp.asarray(aos_data.polynominal_order_x, dtype=jnp.int32)
+    ny_ao = jnp.asarray(aos_data.polynominal_order_y, dtype=jnp.int32)
+    nz_ao = jnp.asarray(aos_data.polynominal_order_z, dtype=jnp.int32)
+    # NOTE: the previous ``stabilizing_ao`` epsilon (``x + eps``) was needed
+    # only to guard the autodiff path against ``0**0`` when an electron sat
+    # exactly on a nucleus. The static-unrolled :func:`_int_pow_unrolled_cart`
+    # already handles the ``e == 0`` branch via ``where(e == 0, 1.0, base)``,
+    # making the eps redundant. Removing it eliminates three ``add`` ops and
+    # the associated select tree from the dominant fusion. Production AD
+    # reaches AO derivatives only through the analytic kernels
+    # (``_compute_AOs_grad_analytic_*`` / ``_compute_AOs_laplacian_analytic_*``),
+    # so this is safe; the autodiff debug variant still benefits from
+    # ``_int_pow_unrolled_cart``'s ``e == 0`` short-circuit.
+    P_l_nx_ny_nz_ao = (
+        _int_pow_unrolled_cart(x_ao, nx_ao, L_MAX)
+        * _int_pow_unrolled_cart(y_ao, ny_ao, L_MAX)
+        * _int_pow_unrolled_cart(z_ao, nz_ao, L_MAX)
     )
 
-    """
-    logger.info(f"Z_jnp={Z_jnp}.")
-    logger.info(f"l_jnp={l_jnp}.")
-    logger.info(f"nx_jnp={nx_jnp}.")
-    logger.info(f"ny_jnp={ny_jnp}.")
-    logger.info(f"nz_jnp={nz_jnp}.")
-    logger.info(f"N_n_dup={N_n_dup.shape}, R_n_dup={R_n_dup.shape}")
-    logger.info(f"N_n_dup={N_n_dup.shape}, R_n_dup={R_n_dup.shape}")
-    logger.info(f"l_jnp={l_jnp.shape}, Z_jnp={Z_jnp.shape}.")
-    logger.info(f"nx_jnp={nx_jnp.shape}, ny_jnp={ny_jnp.shape}, nz_jnp={nz_jnp.shape}")
-    """
-
-    AOs_dup = N_n_dup[:, None] * R_n_dup * P_l_nx_ny_nz_dup
-
-    AOs = _reduce_primitives_to_aos(AOs_dup, aos_data)
+    AOs = NR_ao * P_l_nx_ny_nz_ao
     return AOs
 
 
@@ -2272,11 +2296,9 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
     R_carts_unique = aos_data._atomic_center_carts_unique_jnp
     r_R_diffs = (r_carts[None, :, :] - R_carts[:, None, :]).astype(dtype_jnp)
     r_R_diffs_uq = (r_carts[None, :, :] - R_carts_unique[:, None, :]).astype(dtype_jnp)
-    nucleus_index_prim_jnp = aos_data._nucleus_index_prim_jnp
     c_jnp = aos_data._coefficients_jnp.astype(dtype_jnp)
     Z_jnp = aos_data._exponents_jnp.astype(dtype_jnp)
     l_jnp = aos_data._angular_momentums_prim_jnp
-    m_jnp = aos_data._magnetic_quantum_numbers_prim_jnp
 
     # Normalization constants computed in zone dtype.
     l_typed = l_jnp.astype(dtype_jnp)
@@ -2291,17 +2313,28 @@ def _compute_AOs_sphe(aos_data: AOs_sphe_data, r_carts: jnpt.ArrayLike) -> jax.A
     r_squared = jnp.sum(r_R_diffs**2, axis=-1)
     R_n_dup = c_jnp[:, None] * jnp.exp(-Z_jnp[:, None] * r_squared)
 
+    # Radial part at primitive level → reduce to AO level. Same distributive-law
+    # rationale as in :func:`_compute_AOs_cart`: the angular factor
+    # :math:`Y_{lm}` is constant across primitives of a given AO, so we can
+    # reduce ``N R`` first and then multiply by the AO-level ``S_{lm}``.
+    NR_dup = N_n_dup[:, None] * N_l_m_dup[:, None] * R_n_dup  # (num_ao_prim, n_elec)
+    NR_ao = _reduce_primitives_to_aos(NR_dup, aos_data)  # (num_ao, n_elec)
+
+    # Solid harmonics tabulated at unique-atom level (49, n_atoms_unique, n_elec),
+    # then gathered at AO level (was: at primitive level via
+    # ``nucleus_index_prim_jnp`` / ``l_jnp`` / ``m_jnp`` of length num_ao_prim).
     max_ml, S_l_m_dup_all_l_m = _compute_S_l_m(r_R_diffs_uq)
     S_l_m_dup_all_l_m_reshaped = S_l_m_dup_all_l_m.reshape(
         (S_l_m_dup_all_l_m.shape[0] * S_l_m_dup_all_l_m.shape[1], S_l_m_dup_all_l_m.shape[2]), order="F"
     )
-    global_l_m_index = l_jnp**2 + (m_jnp + l_jnp)
-    global_R_l_m_index = nucleus_index_prim_jnp * max_ml + global_l_m_index
-    S_l_m_dup = S_l_m_dup_all_l_m_reshaped[global_R_l_m_index]
+    nucleus_index_ao = aos_data._nucleus_index_jnp
+    l_ao = jnp.asarray(aos_data.angular_momentums, dtype=jnp.int32)
+    m_ao = jnp.asarray(aos_data.magnetic_quantum_numbers, dtype=jnp.int32)
+    global_l_m_index_ao = l_ao**2 + (m_ao + l_ao)
+    global_R_l_m_index_ao = nucleus_index_ao * max_ml + global_l_m_index_ao
+    S_l_m_ao = S_l_m_dup_all_l_m_reshaped[global_R_l_m_index_ao]  # (num_ao, n_elec)
 
-    AOs_dup = N_n_dup[:, None] * R_n_dup * N_l_m_dup[:, None] * S_l_m_dup
-
-    AOs = _reduce_primitives_to_aos(AOs_dup, aos_data)
+    AOs = NR_ao * S_l_m_ao
     return AOs
 
 

--- a/jqmc/atomic_orbital.py
+++ b/jqmc/atomic_orbital.py
@@ -70,7 +70,7 @@ from numpy import linalg as LA
 
 from ._jqmc_utility import _spherical_to_cart_matrix
 from ._precision import get_dtype_jnp, get_dtype_np
-from ._setting import atol_consistency, get_eps, rtol_consistency
+from ._setting import atol_consistency, rtol_consistency
 from .structure import Structure_data
 
 # set logger
@@ -1366,6 +1366,7 @@ class ShellPrimMap:
     __slots__ = ("unique_indices", "prim_to_unique", "num_unique", "num_full")
 
     def __init__(self, unique_indices: np.ndarray, prim_to_unique: np.ndarray):
+        """Build the prim<->unique-AO index mapping from precomputed arrays."""
         self.unique_indices = unique_indices
         self.prim_to_unique = prim_to_unique
         self.num_unique = len(unique_indices)
@@ -2259,16 +2260,15 @@ def _compute_AOs_cart(aos_data: AOs_cart_data, r_carts: jnpt.ArrayLike) -> jax.A
     nx_ao = jnp.asarray(aos_data.polynominal_order_x, dtype=jnp.int32)
     ny_ao = jnp.asarray(aos_data.polynominal_order_y, dtype=jnp.int32)
     nz_ao = jnp.asarray(aos_data.polynominal_order_z, dtype=jnp.int32)
-    # NOTE: the previous ``stabilizing_ao`` epsilon (``x + eps``) was needed
-    # only to guard the autodiff path against ``0**0`` when an electron sat
-    # exactly on a nucleus. The static-unrolled :func:`_int_pow_unrolled_cart`
-    # already handles the ``e == 0`` branch via ``where(e == 0, 1.0, base)``,
-    # making the eps redundant. Removing it eliminates three ``add`` ops and
-    # the associated select tree from the dominant fusion. Production AD
-    # reaches AO derivatives only through the analytic kernels
-    # (``_compute_AOs_grad_analytic_*`` / ``_compute_AOs_laplacian_analytic_*``),
-    # so this is safe; the autodiff debug variant still benefits from
-    # ``_int_pow_unrolled_cart``'s ``e == 0`` short-circuit.
+    # NOTE: the legacy AO stabilizer epsilon (``x + eps``) was needed only
+    # to guard the kernels against ``0**0`` (here) and ``n/0`` (in the
+    # analytic grad/lap kernels) when an electron sat exactly on a nucleus.
+    # The static-unrolled :func:`_int_pow_unrolled_cart` already handles
+    # ``e == 0`` via ``where(e == 0, 1.0, base)``, and the analytic
+    # grad/lap kernels were rewritten in shifted-exponent product form
+    # (``n * x^(n-1)``, ``n(n-1) * x^(n-2)``) so the divisions and
+    # ``where(base != 0)`` masks are no longer needed either. The eps is
+    # therefore fully removed across the AO module.
     P_l_nx_ny_nz_ao = (
         _int_pow_unrolled_cart(x_ao, nx_ao, L_MAX)
         * _int_pow_unrolled_cart(y_ao, ny_ao, L_MAX)
@@ -2860,27 +2860,44 @@ def _compute_AOs_laplacian_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.n
     N = jnp.sqrt(N_Z * N_fact)
 
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    eps = get_eps("stabilizing_ao", dtype_jnp)
-    x = x + eps
-    y = y + eps
-    z = z + eps
     r2 = jnp.sum(diff**2, axis=-1)
     pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
 
-    # Static-unrolled integer power avoids the XLA repeated-squaring while-loop
-    # emitted by ``base ** exp[:, None]`` when ``exp`` is a traced int array.
+    # See _compute_AOs_grad_analytic_cart for the rationale of the shifted-
+    # exponent formulation. Here we additionally need
+    # ``∂²_x x^n = n(n-1) x^(n-2)``, again expressed as
+    # ``n(n-1) * x^(max(n-2, 0))``; the prefactor zeros the term for
+    # n < 2 to match the analytic limit. No divisions, no eps, no masks.
     px = _int_pow_unrolled_cart(x, nx, L_MAX)
     py = _int_pow_unrolled_cart(y, ny, L_MAX)
     pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    phi = N[:, None] * pref * px * py * pz
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
+    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 2, 0), L_MAX)
+    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 2, 0), L_MAX)
+    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 2, 0), L_MAX)
 
-    def _second_component(base, n):
-        safe_div = jnp.where(base != 0.0, n[:, None] / base, 0.0)
-        safe_div2 = jnp.where(base != 0.0, n[:, None] / (base**2), 0.0)
-        a = safe_div - 2.0 * Z[:, None] * base
-        return phi * (a**2 - safe_div2 - 2.0 * Z[:, None])
+    nx_b = nx[:, None].astype(dtype_jnp)
+    ny_b = ny[:, None].astype(dtype_jnp)
+    nz_b = nz[:, None].astype(dtype_jnp)
+    Npref = N[:, None] * pref
+    Z_b = Z[:, None]
+    phi = Npref * px * py * pz
+    Kx = Npref * py * pz
+    Ky = Npref * px * pz
+    Kz = Npref * px * py
 
-    lap_dup = _second_component(x, nx) + _second_component(y, ny) + _second_component(z, nz)
+    # ∂²_x phi = K_x · [n(n-1) x^(n-2) − 4Z n x^n + (4Z² x² − 2Z) x^n]
+    # Sum over x,y,z gives the Laplacian. The (4Z² r² − 6Z) term is the
+    # collected isotropic contribution from the three (4Z² d² − 2Z) pieces.
+    lap_dup = (
+        Kx * (nx_b * (nx_b - 1.0) * qppx)
+        + Ky * (ny_b * (ny_b - 1.0) * qppy)
+        + Kz * (nz_b * (nz_b - 1.0) * qppz)
+        - 4.0 * Z_b * (x * Kx * (nx_b * qpx) + y * Ky * (ny_b * qpy) + z * Kz * (nz_b * qpz))
+        + (4.0 * Z_b * Z_b * r2 - 6.0 * Z_b) * phi
+    )
 
     lap = _reduce_primitives_to_aos(lap_dup, aos_data)
     return lap
@@ -3171,27 +3188,33 @@ def _compute_AOs_grad_analytic_cart(aos_data: AOs_cart_data, r_carts: jnp.ndarra
     N = jnp.sqrt(N_Z * N_fact)
 
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    eps = get_eps("stabilizing_ao", dtype_jnp)
-    x = x + eps
-    y = y + eps
-    z = z + eps
     r2 = jnp.sum(diff**2, axis=-1)
     pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
 
-    # Static-unrolled integer power avoids the XLA repeated-squaring while-loop
-    # emitted by ``base ** exp[:, None]`` when ``exp`` is a traced int array.
+    # Static-unrolled integer powers. The shifted exponents
+    # ``max(n - 1, 0)`` combined with the integer prefactor ``n`` express
+    # ``∂_x x^n = n x^(n-1)`` directly. For ``n == 0`` the prefactor zeros
+    # the term, matching the analytic limit; this lets us drop both the
+    # legacy AO stabilizer eps and the ``where(base != 0, n/base, 0)``
+    # safeguard, eliminating divisions from the GPU kernel.
     px = _int_pow_unrolled_cart(x, nx, L_MAX)
     py = _int_pow_unrolled_cart(y, ny, L_MAX)
     pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    phi = N[:, None] * pref * px * py * pz
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
 
-    def _grad_component(base, n):
-        safe_div = jnp.where(base != 0.0, n[:, None] / base, 0.0)
-        return phi * (safe_div - 2.0 * Z[:, None] * base)
+    nx_b = nx[:, None].astype(dtype_jnp)
+    ny_b = ny[:, None].astype(dtype_jnp)
+    nz_b = nz[:, None].astype(dtype_jnp)
+    Npref = N[:, None] * pref
+    Z_b = Z[:, None]
+    phi = Npref * px * py * pz
 
-    gx_dup = _grad_component(x, nx)
-    gy_dup = _grad_component(y, ny)
-    gz_dup = _grad_component(z, nz)
+    # ∂_x phi = (N pref y^(n_y) z^(n_z)) · n_x x^(n_x-1) − 2Z x · phi
+    gx_dup = Npref * py * pz * (nx_b * qpx) - 2.0 * Z_b * x * phi
+    gy_dup = Npref * px * pz * (ny_b * qpy) - 2.0 * Z_b * y * phi
+    gz_dup = Npref * px * py * (nz_b * qpz) - 2.0 * Z_b * z * phi
 
     gx = _reduce_primitives_to_aos(gx_dup, aos_data)
     gy = _reduce_primitives_to_aos(gy_dup, aos_data)
@@ -3339,50 +3362,58 @@ def _compute_AOs_value_grad_lap_cart(
     N = jnp.sqrt(N_Z * N_fact)
 
     x, y, z = diff[..., 0], diff[..., 1], diff[..., 2]
-    eps = get_eps("stabilizing_ao", dtype_jnp)
-    x = x + eps
-    y = y + eps
-    z = z + eps
     r2 = jnp.sum(diff**2, axis=-1)
     pref = c[:, None] * jnp.exp(-Z[:, None] * r2)
 
     # Static-unrolled integer power avoids the XLA repeated-squaring while-loop
     # emitted by ``base ** exp[:, None]`` when ``exp`` is a traced int array.
     # See ``_int_pow_unrolled_cart`` for the bitwise-equivalence rationale.
+    # Shifted exponents (``max(n - 1, 0)``, ``max(n - 2, 0)``) combined with
+    # the integer prefactors (``n``, ``n(n-1)``) express the first and
+    # second derivatives of ``x^n`` in product form, matching the layout
+    # used by ``_compute_AOs_grad_analytic_cart`` and
+    # ``_compute_AOs_laplacian_analytic_cart``. Mathematical (not bitwise)
+    # parity vs those standalone kernels — agreement to ULP magnitude.
     L_MAX = _cart_max_polynomial_order(aos_data)
     px = _int_pow_unrolled_cart(x, nx, L_MAX)
     py = _int_pow_unrolled_cart(y, ny, L_MAX)
     pz = _int_pow_unrolled_cart(z, nz, L_MAX)
-    # Shared body identical to the standalone grad/lap kernels (left-to-right
-    # multiplication). Strict (rtol=atol=0) parity vs compute_AOs_grad and
-    # compute_AOs_laplacian holds because the expression is bit-for-bit the
-    # same; parity vs compute_AOs is preserved up to a few ULPs because the
-    # standalone eval kernel uses a different multiplication ordering.
-    phi = N[:, None] * pref * px * py * pz  # shared val/grad/lap body
+    qpx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 1, 0), L_MAX)
+    qpy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 1, 0), L_MAX)
+    qpz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 1, 0), L_MAX)
+    qppx = _int_pow_unrolled_cart(x, jnp.maximum(nx - 2, 0), L_MAX)
+    qppy = _int_pow_unrolled_cart(y, jnp.maximum(ny - 2, 0), L_MAX)
+    qppz = _int_pow_unrolled_cart(z, jnp.maximum(nz - 2, 0), L_MAX)
+
+    nx_b = nx[:, None].astype(dtype_jnp)
+    ny_b = ny[:, None].astype(dtype_jnp)
+    nz_b = nz[:, None].astype(dtype_jnp)
+    Npref = N[:, None] * pref
+    Z_b = Z[:, None]
+    phi = Npref * px * py * pz
+    Kx = Npref * py * pz
+    Ky = Npref * px * pz
+    Kz = Npref * px * py
 
     # value finalize: only downcast site (Principle 3b).
     val = _reduce_primitives_to_aos(phi.astype(dtype_eval), aos_data)
 
     # grad finalize (kept in ao_grad_lap zone — no cast).
-    def _grad_component(base, n):
-        safe_div = jnp.where(base != 0.0, n[:, None] / base, 0.0)
-        return phi * (safe_div - 2.0 * Z[:, None] * base)
-
-    gx_dup = _grad_component(x, nx)
-    gy_dup = _grad_component(y, ny)
-    gz_dup = _grad_component(z, nz)
+    gx_dup = Kx * (nx_b * qpx) - 2.0 * Z_b * x * phi
+    gy_dup = Ky * (ny_b * qpy) - 2.0 * Z_b * y * phi
+    gz_dup = Kz * (nz_b * qpz) - 2.0 * Z_b * z * phi
     gx = _reduce_primitives_to_aos(gx_dup, aos_data)
     gy = _reduce_primitives_to_aos(gy_dup, aos_data)
     gz = _reduce_primitives_to_aos(gz_dup, aos_data)
 
     # lap finalize (kept in ao_grad_lap zone — no cast).
-    def _second_component(base, n):
-        safe_div = jnp.where(base != 0.0, n[:, None] / base, 0.0)
-        safe_div2 = jnp.where(base != 0.0, n[:, None] / (base**2), 0.0)
-        a = safe_div - 2.0 * Z[:, None] * base
-        return phi * (a**2 - safe_div2 - 2.0 * Z[:, None])
-
-    lap_dup = _second_component(x, nx) + _second_component(y, ny) + _second_component(z, nz)
+    lap_dup = (
+        Kx * (nx_b * (nx_b - 1.0) * qppx)
+        + Ky * (ny_b * (ny_b - 1.0) * qppy)
+        + Kz * (nz_b * (nz_b - 1.0) * qppz)
+        - 4.0 * Z_b * (x * Kx * (nx_b * qpx) + y * Ky * (ny_b * qpy) + z * Kz * (nz_b * qpz))
+        + (4.0 * Z_b * Z_b * r2 - 6.0 * Z_b) * phi
+    )
     lap = _reduce_primitives_to_aos(lap_dup, aos_data)
 
     return val, gx, gy, gz, lap

--- a/jqmc/determinant.py
+++ b/jqmc/determinant.py
@@ -1611,21 +1611,39 @@ def _compute_ratio_determinant_part_rank1_update(
     orb_matrix_up_old = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, old_r_up_carts).astype(dtype_jnp)
     orb_matrix_dn_old = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, old_r_dn_carts).astype(dtype_jnp)
 
-    # Batched AO for moved electrons (up) -> rows
+    # Batched AO for moved electrons (up) -> rows.
+    #
+    # R3 (associativity): the chain is
+    #   row_paired = (orb_up_new^T @ lambda_paired) @ orb_dn_old.
+    # Naively materialising ``orb_up_new^T @ lambda_paired`` produces a
+    # ``(G, n_orb_dn)`` intermediate that is enormous on the ECP / discretized
+    # kinetic mesh (G ≈ walker * Nv * NN or walker * 6 * n_elec, easily 1-100 M
+    # rows for f64 at GH200 scale).  Pre-contracting on the small side instead,
+    #   M_paired := lambda_paired @ orb_dn_old   # (n_orb_up, N_dn)
+    #   row_paired = orb_up_new^T @ M_paired     # (G, N_dn)
+    # turns the big middle gemm into a small ``(n_orb_up, n_orb_dn) x (n_orb_dn, N_dn)``
+    # constant-size product (executed once per walker) followed by a single
+    # ``(G, n_orb_up) x (n_orb_up, N_dn)`` gemm whose output is the final
+    # small ``(G, N_dn)`` row block.  Roughly (n_orb + N) / N FLOPs are saved
+    # and the (G, n_orb) intermediate is eliminated, lifting the gemm AI from
+    # the DRAM-bound regime to ridge.
     orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat).astype(
         dtype_jnp
     )  # (n_orb_up, G)
-    tmp_up = jnp.dot(orb_up_new_batch.T, lambda_matrix_paired)  # (G, n_orb_dn)
-    row_paired = jnp.dot(tmp_up, orb_matrix_dn_old)  # (G, N_dn)
+    M_paired_up = jnp.dot(lambda_matrix_paired, orb_matrix_dn_old)  # (n_orb_up, N_dn)
+    row_paired = jnp.dot(orb_up_new_batch.T, M_paired_up)  # (G, N_dn)
     row_unpaired = jnp.dot(orb_up_new_batch.T, lambda_matrix_unpaired)  # (G, num_unpaired)
     new_rows_up = jnp.hstack([row_paired, row_unpaired])  # (G, N_up)
 
-    # Batched AO for moved electrons (dn) -> columns
+    # Batched AO for moved electrons (dn) -> columns.
+    # Same R3 reorder for the dn block:
+    #   cols = orb_up_old^T @ (lambda_paired @ orb_dn_new) -> (orb_up_old^T @ lambda_paired) @ orb_dn_new.
+    # ``M_dn`` has shape ``(N_up, n_orb_dn)`` (small) instead of ``(n_orb_up, G)``.
     orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat).astype(
         dtype_jnp
     )  # (n_orb_dn, G)
-    w_batch = jnp.dot(lambda_matrix_paired, orb_dn_new_batch)  # (n_orb_up, G)
-    cols = jnp.dot(orb_matrix_up_old.T, w_batch)  # (N_up, G)
+    M_paired_dn = jnp.dot(orb_matrix_up_old.T, lambda_matrix_paired)  # (N_up, n_orb_dn)
+    cols = jnp.dot(M_paired_dn, orb_dn_new_batch)  # (N_up, G)
     new_cols_dn = cols.T  # (G, N_up)
 
     # rank-1 determinant ratios for up-move grids and dn-move grids.
@@ -1723,11 +1741,19 @@ def _compute_ratio_determinant_part_split_spin(
     r_up_new_flat = jnp.take_along_axis(new_r_up_shifted, idx_up[:, None, None], axis=1).reshape(-1, 3)
 
     # Only evaluate up-spin MOs for the moved electron positions.
+    #
+    # R3 (associativity): pre-contract on the small side
+    #   M_paired := lambda_paired @ orb_dn_old   # (n_orb_up, N_dn)
+    # so the chain ``(orb_up_new^T @ lambda_paired) @ orb_dn_old`` becomes
+    #   row_paired = orb_up_new^T @ M_paired     # (G_up, N_dn)
+    # eliminating the (G_up, n_orb_dn) middle intermediate. See the matching
+    # comment in ``_compute_ratio_determinant_part_rank1_update`` for the
+    # GH200 motivation (DRAM-bound pattern C).
     orb_up_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_up_spin, r_up_new_flat).astype(
         dtype_jnp
     )  # (n_orb_up, G_up)
-    tmp_up = jnp.dot(orb_up_new_batch.T, lambda_matrix_paired)  # (G_up, n_orb_dn)
-    row_paired = jnp.dot(tmp_up, orb_matrix_dn_old)  # (G_up, N_dn)
+    M_paired_up = jnp.dot(lambda_matrix_paired, orb_matrix_dn_old)  # (n_orb_up, N_dn)
+    row_paired = jnp.dot(orb_up_new_batch.T, M_paired_up)  # (G_up, N_dn)
     row_unpaired = jnp.dot(orb_up_new_batch.T, lambda_matrix_unpaired)  # (G_up, num_unpaired)
     new_rows_up = jnp.hstack([row_paired, row_unpaired])  # (G_up, N_up)
 
@@ -1743,11 +1769,13 @@ def _compute_ratio_determinant_part_split_spin(
     r_dn_new_flat = jnp.take_along_axis(new_r_dn_shifted, idx_dn[:, None, None], axis=1).reshape(-1, 3)
 
     # Only evaluate dn-spin MOs for the moved electron positions.
+    # R3 (associativity): pre-contract ``M_dn := orb_up_old^T @ lambda_paired``
+    # (N_up, n_orb_dn), then ``cols.T = orb_dn_new^T @ M_dn^T = (M_dn @ orb_dn_new).T``.
     orb_dn_new_batch = geminal_data.compute_orb_api(geminal_data.orb_data_dn_spin, r_dn_new_flat).astype(
         dtype_jnp
     )  # (n_orb_dn, G_dn)
-    w_batch = jnp.dot(lambda_matrix_paired, orb_dn_new_batch)  # (n_orb_up, G_dn)
-    new_cols_dn = jnp.dot(orb_matrix_up_old.T, w_batch).T  # (G_dn, N_up)
+    M_paired_dn = jnp.dot(orb_matrix_up_old.T, lambda_matrix_paired)  # (N_up, n_orb_dn)
+    new_cols_dn = jnp.dot(M_paired_dn, orb_dn_new_batch).T  # (G_dn, N_up)
 
     A_row_for_dn = jnp.take(A_old_inv_z, idx_dn, axis=0)  # (G_dn, N_up)
     det_ratio_dn_block = jnp.sum(A_row_for_dn * new_cols_dn, axis=1)  # (G_dn,)

--- a/jqmc/jastrow_factor.py
+++ b/jqmc/jastrow_factor.py
@@ -2637,7 +2637,13 @@ def _compute_ratio_Jastrow_part_rank1_update(
         term1 = j1_vec @ aos_p_batch  # (N,)
 
         # UP formula  -----------------------------------------------------------
-        V_up = jnp.dot(aos_p_batch.T, W_up)  # (N, N_up)
+        # Use tensordot with explicit contracting axes (n_ao = axis 0 of both
+        # operands) instead of ``aos_p_batch.T @ W_up``: under vmap on the
+        # walker axis XLA's transpose-folding does not fold the ``.T`` into
+        # the dot, materialising an explicit ~1.8 GB ``transpose`` kernel
+        # (HBM-bound, ~88-92% DRAM peak on GH200). Expressing the contraction
+        # via ``dot_general(contract=[0]x[0])`` avoids the materialisation.
+        V_up = jnp.tensordot(aos_p_batch, W_up, axes=((0,), (0,)))  # (N, N_up)
         P_up = jnp.dot(U_up, aos_p_batch)  # (N_up, N)
         Q_up_c = (idx_for_Q[:, None] < jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (N, N_up)
         Q_up_r = (idx_for_Q[:, None] > jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (N, N_up)
@@ -2647,7 +2653,8 @@ def _compute_ratio_Jastrow_part_rank1_update(
         J3_log_up = term1 + term2_up + term3_up + term4_up
 
         # DN formula  -----------------------------------------------------------
-        V_dn = jnp.dot(aos_p_batch.T, W_dn)  # (N, N_dn)
+        # See UP-formula comment above re: tensordot-vs-``.T``-then-dot.
+        V_dn = jnp.tensordot(aos_p_batch, W_dn, axes=((0,), (0,)))  # (N, N_dn)
         P_dn = jnp.dot(U_dn, aos_p_batch)  # (N_dn, N)
         Q_dn_c = (idx_for_Q[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (N, N_dn)
         Q_dn_r = (idx_for_Q[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (N, N_dn)
@@ -2899,7 +2906,10 @@ def _compute_ratio_Jastrow_part_split_spin(
         aos_p_up = aos_up_new_moved - aos_up_old_moved  # (n_ao, G_up)
 
         term1_up = j1_vec @ aos_p_up  # (G_up,)
-        V_up_block = jnp.dot(aos_p_up.T, W_up)  # (G_up, N_up)
+        # tensordot avoids the explicit transpose of ``aos_p_up`` (1.8 GB on
+        # GH200 ECP-nonlocal benchmark) — see ``_compute_ratio_Jastrow_part_rank1_update``
+        # for the same rewrite rationale.
+        V_up_block = jnp.tensordot(aos_p_up, W_up, axes=((0,), (0,)))  # (G_up, N_up)
         P_up_block = jnp.dot(U_up, aos_p_up)  # (N_up, G_up)
         Q_up_c = (idx_up_block[:, None] < jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (G_up, N_up)
         Q_up_r = (idx_up_block[:, None] > jnp.arange(num_up)[None, :]).astype(dtype_jnp)  # (G_up, N_up)
@@ -2915,7 +2925,8 @@ def _compute_ratio_Jastrow_part_split_spin(
         aos_p_dn = aos_dn_new_moved - aos_dn_old_moved  # (n_ao, G_dn)
 
         term1_dn = j1_vec @ aos_p_dn  # (G_dn,)
-        V_dn_block = jnp.dot(aos_p_dn.T, W_dn)  # (G_dn, N_dn)
+        # See UP-block comment re: tensordot.
+        V_dn_block = jnp.tensordot(aos_p_dn, W_dn, axes=((0,), (0,)))  # (G_dn, N_dn)
         P_dn_block = jnp.dot(U_dn, aos_p_dn)  # (N_dn, G_dn)
         Q_dn_c = (idx_dn_block[:, None] < jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (G_dn, N_dn)
         Q_dn_r = (idx_dn_block[:, None] > jnp.arange(num_dn)[None, :]).astype(dtype_jnp)  # (G_dn, N_dn)


### PR DESCRIPTION
## Summary

A series of HLO-level rewrites to the AO evaluation, determinant, and Jastrow paths. No algorithmic changes—only fusion and data-flow restructuring. Verified equivalent to baseline within numerical noise.

## Changes

### `compute_AOs*_cart`: poly-after-reduce

Three radial moments (`NR`, `ZNR`, `Z2NR`) are now reduced to AO rank first, with the polynomial and polynomial-derivative chains running at AO rank only. This removes the `(n_walker, num_ao_prim, n_elec)` intermediate that dominated the kinetic-energy HLO. It also removes the obsolete eps stabilizer on cartesian GTOs, since the statically unrolled integer-power path handles `base == 0` natively and the `x + eps` guard is no longer required. Unused helpers `_static_int_pow` and `_build_cart_poly_groups` are also removed, as no call sites remain after the rewrite.

The heavy `lambda . AO` product is now shared across gradient and Laplacian assembly instead of being recomputed per component.

### `_compute_ratio_Jastrow_part_rank1_update` / `_split_spin`

At four hot sites, `jnp.dot(X.T, Y)` is replaced with `jnp.tensordot(X, Y, axes=((0,), (0,)))`, eliminating a transpose materialization that XLA could not fold under `vmap`.