### PR TITLE
Run VMC optimize on multi-GPUs

### DIFF
--- a/.github/workflows/jqmc-run-full-pytest.yml
+++ b/.github/workflows/jqmc-run-full-pytest.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install flake8 pytest pytest-cov
         python -m pip install .
 
-    - name: Test jqmc FP64 (intra-software comparisons)
+    - name: Test jqmc FP64 (Intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --cov=jqmc --cov-branch --no-cov-on-fail
         pytest -s -v tests/test_init_electron_configurations.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
@@ -67,7 +67,7 @@ jobs:
         pytest -s -v tests/test_ao_basis_optimization.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_mixed_precision.py  --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
 
-    - name: Test jqmc FP32+FP64 (intra-software comparisons)
+    - name: Test jqmc FP32+FP64 (Intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
         pytest -s -v tests/test_init_electron_configurations.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
@@ -87,17 +87,10 @@ jobs:
         pytest -s -v tests/test_ao_basis_optimization.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
         pytest -s -v tests/test_mixed_precision.py  --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
 
-    - name: Test jqmc FP64 (inter-software comparisons)
+    - name: Test jqmc FP64 (Inter-software comparisons)
       run: |
         pytest -s -v tests/test_comparison_with_turborvb_ECP.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_comparison_with_turborvb_AE.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
-
-    - name: Test jqmc FP32+FP64 (QMC kernels without MPI)
-      run: |
-        pytest -s -v tests/test_jqmc_command_lines.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
-        pytest -s -v tests/test_jqmc_mcmc.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
-        pytest -s -v tests/test_jqmc_gfmc_tau.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
-        pytest -s -v tests/test_jqmc_gfmc_bra.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append --precision-mode=mixed
 
     - name: Test jqmc FP64 (QMC kernels without MPI)
       run: |
@@ -106,7 +99,7 @@ jobs:
         pytest -s -v tests/test_jqmc_gfmc_tau.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
         pytest -s -v tests/test_jqmc_gfmc_bra.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
 
-    - name: Test jqmc-tool (toolset for jqmc)
+    - name: Test jqmc-tool (Toolset for jqmc)
       run: |
         pytest -s -v tests/test_jqmc_tool.py --cov=jqmc --cov-branch --no-cov-on-fail --cov-append
 

--- a/.github/workflows/jqmc-run-long-pytest.yml
+++ b/.github/workflows/jqmc-run-long-pytest.yml
@@ -47,7 +47,7 @@ jobs:
         python -m pip install flake8 pytest pytest-cov
         python -m pip install .
 
-    - name: Test jqmc FP64/FP32+FP64 (intra-software comparisons)
+    - name: Test jqmc FP64/FP32+FP64 (Intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py
         pytest -s -v tests/test_init_electron_configurations.py
@@ -71,7 +71,7 @@ jobs:
         pytest -s -v tests/test_ao_basis_optimization.py
         pytest -s -v tests/test_mixed_precision.py --precision-mode=mixed
 
-    - name: Test jqmc FP64 (inter-software comparisons)
+    - name: Test jqmc FP64 (Inter-software comparisons)
       run: |
         pytest -s -v tests/test_comparison_with_turborvb_ECP.py
         pytest -s -v tests/test_comparison_with_turborvb_AE.py

--- a/.github/workflows/jqmc-run-rc-pytest.yml
+++ b/.github/workflows/jqmc-run-rc-pytest.yml
@@ -51,6 +51,11 @@ jobs:
       run: |
         pytest -s -v tests/test_jqmc_command_lines.py
 
+    - name: Test jqmc FP64 (Inter-software comparisons)
+      run: |
+        pytest -s -v tests/test_comparison_with_turborvb_ECP.py
+        pytest -s -v tests/test_comparison_with_turborvb_AE.py
+
     - name: Test jqmc FP64 (QMC kernels without MPI, FP64)
       run: |
         pytest -s -v tests/test_jqmc_mcmc.py

--- a/.github/workflows/jqmc-run-short-pytest.yml
+++ b/.github/workflows/jqmc-run-short-pytest.yml
@@ -58,7 +58,7 @@ jobs:
         python -m pip install flake8 pytest pytest-cov
         python -m pip install .
 
-    - name: Test jqmc FP64 (intra-software comparisons)
+    - name: Test jqmc FP64 (Intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --skip-heavy
         pytest -s -v tests/test_init_electron_configurations.py --skip-heavy
@@ -74,7 +74,7 @@ jobs:
         pytest -s -v tests/test_lrdmc_force.py --skip-heavy
         pytest -s -v tests/test_mixed_precision.py --precision-mode=mixed --skip-heavy
 
-    - name: Test jqmc FP32+FP64 (intra-software comparisons)
+    - name: Test jqmc FP32+FP64 (Intra-software comparisons)
       run: |
         pytest -s -v tests/test_trexio.py --skip-heavy --precision-mode=mixed
         pytest -s -v tests/test_init_electron_configurations.py --skip-heavy --precision-mode=mixed

--- a/jqmc/_jqmc_utility.py
+++ b/jqmc/_jqmc_utility.py
@@ -41,14 +41,51 @@ See :mod:`jqmc._precision` for details.
 from functools import cache
 from logging import getLogger
 
+import jax
 import numpy as np
 import numpy.typing as npt
+from mpi4py import MPI
 
 # set logger
 logger = getLogger("jqmc").getChild(__name__)
 
 # separator
 num_sep_line = 66
+
+
+def check_mpi4py_jax_distribution_consistency() -> None:
+    """Raise ``RuntimeError`` if ``jax.process_count()`` differs from MPI world size.
+
+    Required precondition for any production code path that relies on
+    ``jax.shard_map`` + ``psum`` / ``all_gather`` to aggregate across MPI
+    ranks (currently the device branch of ``MCMC.run_optimize``; future
+    GFMC device migrations will share this requirement). Without
+    ``jax.distributed.initialize(cluster_detection_method="mpi4py")``, each
+    rank's JAX sees only its own local devices and the cross-rank
+    collectives silently degenerate to per-rank-local computation, producing
+    wrong results that don't match the global solution.
+
+    Called at the entry point of every public driver loop (``MCMC.run``,
+    ``MCMC.run_optimize``, ``GFMC_t.run``, ``GFMC_n.run``) so the failure
+    surfaces immediately rather than after substantial work has been done
+    on stale per-rank state.
+
+    The CLI (``jqmc_cli.py``) initializes JAX distributed automatically.
+    User scripts that import ``MCMC`` / ``GFMC`` directly must call
+    ``jax.distributed.initialize(cluster_detection_method="mpi4py")``
+    themselves before invoking these driver loops (see ``jqmc_cli.py``
+    for the standard recipe, including the proxy-strip workaround).
+    """
+    mpi_size = MPI.COMM_WORLD.Get_size()
+    if mpi_size != jax.process_count():
+        raise RuntimeError(
+            f"MPI/JAX rank-count mismatch: mpi_size={mpi_size} vs "
+            f"jax.process_count()={jax.process_count()}. JAX cross-rank "
+            "collectives (psum / all_gather) require ``jax.distributed.initialize("
+            "cluster_detection_method='mpi4py')`` to be called before any "
+            "production driver loop. The CLI does this automatically; user "
+            "scripts importing MCMC / GFMC must call it themselves."
+        )
 
 
 def _generate_init_electron_configurations(

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -48,7 +48,7 @@ from ._checkpoint import merge_rank_checkpoints
 
 # jQMC
 from ._header_footer import _print_footer, _print_header
-from ._jqmc_utility import num_sep_line
+from ._jqmc_utility import check_mpi4py_jax_distribution_consistency, num_sep_line
 from ._precision import configure as configure_precision
 from ._precision import mode_label as precision_mode_label
 from ._precision import zone_detail as precision_zone_detail
@@ -232,6 +232,12 @@ def _cli():
         logger.debug(f"Distributed initialization Exception: {e}")
         logger.info("")
         jax_distributed_is_initialized = False
+
+    # Surface silently-failed distributed init: ``initialize`` may swallow
+    # exceptions (the try/except above) but if we are actually under
+    # ``mpirun -n N>=2`` and JAX still sees only 1 process, every downstream
+    # device-collective call would silently produce per-rank-local results.
+    check_mpi4py_jax_distribution_consistency()
 
     if jax_distributed_is_initialized:
         # global JAX device

--- a/jqmc/jqmc_cli.py
+++ b/jqmc/jqmc_cli.py
@@ -496,6 +496,10 @@ def _cli():
         logger.info("=" * num_sep_line)
         logger.info("Printing out information in hamitonian_data instance.")
         mcmc.hamiltonian_data._logger_info()
+        # Pick the SR backend per JAX device: GPU favours the on-device
+        # (jax.shard_map + NCCL) path, CPU favours the legacy mpi4py + SciPy
+        # path. Anything else falls back to the CPU path.
+        use_device_collectives = jax.default_backend() == "gpu"
         mcmc.run_optimize(
             num_mcmc_steps=num_mcmc_steps,
             num_opt_steps=num_opt_steps,
@@ -514,6 +518,7 @@ def _cli():
             opt_lambda_basis_coeff=opt_lambda_basis_coeff,
             max_time=max_time,
             optimizer_kwargs=optimizer_kwargs,
+            use_device_collectives=use_device_collectives,
         )
         logger.info("")
 

--- a/jqmc/jqmc_gfmc.py
+++ b/jqmc/jqmc_gfmc.py
@@ -55,7 +55,7 @@ from jax import typing as jnpt
 from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
-from ._jqmc_utility import _generate_init_electron_configurations
+from ._jqmc_utility import _generate_init_electron_configurations, check_mpi4py_jax_distribution_consistency
 from ._precision import get_tolerance_min
 from ._setting import (
     GFMC_MIN_BIN_BLOCKS,
@@ -651,6 +651,8 @@ class GFMC_t:
             num_branching (int): number of branching (reconfiguration of walkers).
             max_time (int): maximum time in sec.
         """
+        check_mpi4py_jax_distribution_consistency()
+
         # set timer
         timer_projection_init = 0.0
         timer_projection_total = 0.0
@@ -4690,6 +4692,8 @@ class GFMC_n:
             num_branching (int): number of branching (reconfiguration of walkers).
             max_time (int): maximum time in sec.
         """
+        check_mpi4py_jax_distribution_consistency()
+
         # initialize numpy random seed
         np.random.seed(self.__mpi_seed)
 

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -121,6 +121,222 @@ mpi_rank = mpi_comm.Get_rank()
 mpi_size = mpi_comm.Get_size()
 
 
+# ---------------------------------------------------------------------------
+# Device-resident SR solvers (JAX-native, sharding + psum / all_gather)
+#
+# Implements the four SR solve paths from ``optimizer_on_gpu.md``:
+#   - wide + direct : (X X^T + eps I) y = X F       via psum
+#   - wide + CG     :  same system, conjugate gradient with psum'd matvec
+#   - tall + direct : (X^T X + eps I) z = F, theta = X z   via all_gather
+#   - tall + CG     :  same system, conjugate gradient on replicated inputs
+#
+# Compiled kernels are cached at module level so the JIT cost is paid once
+# per process. The same code path runs on:
+#   - single-process CPU       (psum is trivial; mesh has 1 device)
+#   - multi-process CPU + Gloo (after ``jax.distributed.initialize``)
+#   - GPU (single or multi process; psum maps to NVLink / NCCL)
+# ---------------------------------------------------------------------------
+def _get_sr_mesh():
+    """Lazy-built 1-D ``Mesh`` over all visible JAX devices, axis name 'rank'."""
+    cached = getattr(_get_sr_mesh, "_cached", None)
+    if cached is not None:
+        return cached
+    from jax.sharding import Mesh
+
+    mesh = Mesh(np.array(jax.devices()), axis_names=("rank",))
+    _get_sr_mesh._cached = mesh
+    return mesh
+
+
+def _cg_while_loop(b, apply_A, x0, max_iter, tol, dtype):
+    """Plain CG with break-on-breakdown, packed into ``jax.lax.while_loop``.
+
+    Returns ``(x, sqrt(rs), num_iter)`` matching the NumPy reference's
+    return signature. ``apply_A`` may close over ``psum`` collectives so
+    this helper is only safe to call from inside a ``shard_map``.
+    """
+    tiny = jnp.asarray(jnp.finfo(dtype).tiny, dtype=dtype)
+    tol_sq = tol * tol
+
+    r0 = b - apply_A(x0)
+    rs0 = jnp.dot(r0, r0)
+    state0 = (
+        x0,
+        r0,
+        r0,  # p
+        rs0,
+        jnp.int32(0),
+        jnp.bool_(False),  # breakdown
+    )
+
+    def cond(state):
+        _x, _r, _p, rs, k, breakdown = state
+        return (k < max_iter) & (rs > tol_sq) & jnp.logical_not(breakdown)
+
+    def body(state):
+        x, r, p, rs_old, k, breakdown = state
+        Ap = apply_A(p)
+        denom = jnp.dot(p, Ap)
+        new_breakdown = breakdown | jnp.logical_not(jnp.isfinite(denom)) | (jnp.abs(denom) <= tiny)
+        safe_denom = jnp.where(new_breakdown, jnp.asarray(1.0, dtype=dtype), denom)
+        alpha = rs_old / safe_denom
+        x_new = jnp.where(new_breakdown, x, x + alpha * p)
+        r_new = jnp.where(new_breakdown, r, r - alpha * Ap)
+        rs_new_real = jnp.dot(r_new, r_new)
+        rs_new = jnp.where(new_breakdown, rs_old, rs_new_real)
+        safe_rs_old = jnp.where(rs_old > 0, rs_old, jnp.asarray(1.0, dtype=dtype))
+        beta = rs_new / safe_rs_old
+        p_new = jnp.where(new_breakdown, p, r_new + beta * p)
+        return (x_new, r_new, p_new, rs_new, k + 1, new_breakdown)
+
+    x_f, _r_f, _p_f, rs_f, k_f, _bk_f = jax.lax.while_loop(cond, body, state0)
+    return x_f, jnp.sqrt(rs_f), k_f
+
+
+def _get_sr_wide_direct_kernel():
+    """Wide-matrix direct SR solve: ``theta = (X X^T + eps I)^{-1} (X F)``.
+
+    Inputs sharded along sample axis 'rank'. Output replicated on every rank.
+    """
+    cached = getattr(_get_sr_wide_direct_kernel, "_cached", None)
+    if cached is not None:
+        return cached
+    from jax.sharding import PartitionSpec as PSpec
+
+    mesh = _get_sr_mesh()
+
+    @partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(PSpec(None, "rank"), PSpec("rank"), PSpec()),
+        out_specs=PSpec(),
+    )
+    def _solve(X, F, epsilon):
+        XXT_local = X @ X.T
+        XF_local = X @ F
+        XXT = jax.lax.psum(XXT_local, "rank")
+        XF = jax.lax.psum(XF_local, "rank")
+        XXT = XXT + epsilon * jnp.eye(XXT.shape[0], dtype=XXT.dtype)
+        return jnp.linalg.solve(XXT, XF)
+
+    _get_sr_wide_direct_kernel._cached = _solve
+    return _solve
+
+
+def _get_sr_wide_cg_kernel():
+    """Wide-matrix CG SR solve. Returns ``(theta, sqrt(rs), num_iter)``."""
+    cached = getattr(_get_sr_wide_cg_kernel, "_cached", None)
+    if cached is not None:
+        return cached
+    from jax.sharding import PartitionSpec as PSpec
+
+    mesh = _get_sr_mesh()
+
+    @partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(
+            PSpec(None, "rank"),  # X (P, N_local)
+            PSpec("rank"),  # F (N_local,)
+            PSpec(),  # epsilon scalar
+            PSpec(),  # max_iter scalar
+            PSpec(),  # tol scalar
+            PSpec(),  # x0 (P,) replicated
+        ),
+        out_specs=(PSpec(), PSpec(), PSpec()),
+    )
+    def _solve(X, F, epsilon, max_iter, tol, x0):
+        # b = psum(X F)
+        b = jax.lax.psum(X @ F, "rank")  # (P,)
+
+        def apply_A(v):
+            # v replicated across ranks; X.T @ v is local; X @ ... is local.
+            local = X @ (X.T @ v)
+            return jax.lax.psum(local, "rank") + epsilon * v
+
+        return _cg_while_loop(b, apply_A, x0, max_iter, tol, X.dtype)
+
+    _get_sr_wide_cg_kernel._cached = _solve
+    return _solve
+
+
+def _get_sr_tall_direct_kernel():
+    """Tall-matrix direct SR solve via push-through identity.
+
+    Solves ``(X^T X + eps I) y = F`` (smaller system in sample space) and
+    returns ``theta = X y`` replicated across ranks.
+    """
+    cached = getattr(_get_sr_tall_direct_kernel, "_cached", None)
+    if cached is not None:
+        return cached
+    from jax.sharding import PartitionSpec as PSpec
+
+    mesh = _get_sr_mesh()
+
+    @partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(PSpec(None, "rank"), PSpec("rank"), PSpec()),
+        out_specs=PSpec(),
+        # all_gather produces values that are replicated by construction but
+        # JAX cannot statically prove this on a 1-axis mesh; disable the check.
+        check_vma=False,
+    )
+    def _solve(X, F, epsilon):
+        # Gather all sample columns onto every rank. In the tall regime
+        # ``num_samples_total`` is small by construction, so the replicated
+        # ``(P, N_total)`` matrix is affordable; the solve over ``N_total``
+        # is the cheap dimension.
+        X_full = jax.lax.all_gather(X, "rank", axis=1, tiled=True)  # (P, N_total)
+        F_full = jax.lax.all_gather(F, "rank", tiled=True)  # (N_total,)
+        XTX = X_full.T @ X_full
+        XTX = XTX + epsilon * jnp.eye(XTX.shape[0], dtype=XTX.dtype)
+        y = jnp.linalg.solve(XTX, F_full)
+        return X_full @ y
+
+    _get_sr_tall_direct_kernel._cached = _solve
+    return _solve
+
+
+def _get_sr_tall_cg_kernel():
+    """Tall-matrix CG SR solve via push-through identity."""
+    cached = getattr(_get_sr_tall_cg_kernel, "_cached", None)
+    if cached is not None:
+        return cached
+    from jax.sharding import PartitionSpec as PSpec
+
+    mesh = _get_sr_mesh()
+
+    @partial(
+        jax.shard_map,
+        mesh=mesh,
+        in_specs=(
+            PSpec(None, "rank"),  # X (P, N_local)
+            PSpec("rank"),  # F (N_local,)
+            PSpec(),  # epsilon
+            PSpec(),  # max_iter
+            PSpec(),  # tol
+            PSpec(),  # x0 (N_total,) replicated
+        ),
+        out_specs=(PSpec(), PSpec(), PSpec(), PSpec()),
+        check_vma=False,  # all_gather output is replicated but not statically inferrable
+    )
+    def _solve(X, F, epsilon, max_iter, tol, x0):
+        X_full = jax.lax.all_gather(X, "rank", axis=1, tiled=True)
+        F_full = jax.lax.all_gather(F, "rank", tiled=True)
+
+        def apply_A(v):
+            return X_full.T @ (X_full @ v) + epsilon * v
+
+        y, residual, num_iter = _cg_while_loop(F_full, apply_A, x0, max_iter, tol, X.dtype)
+        # Return y (sample-space CG solution) too so the caller can persist
+        # it as a warm-start for the next optimization step.
+        return X_full @ y, y, residual, num_iter
+
+    _get_sr_tall_cg_kernel._cached = _solve
+    return _solve
+
+
 class MCMC:
     """Production VMC/MCMC driver with multiple walkers.
 
@@ -2405,6 +2621,131 @@ class MCMC:
 
         return c_vec, E_lm
 
+    @staticmethod
+    def _shard_X_F(X_local: npt.NDArray, F_local: npt.NDArray):
+        """Convert host-local NumPy ``(X, F)`` into shard_map-ready ``jax.Array`` s.
+
+        ``X_local`` is sharded along axis 1 (samples), ``F_local`` along axis 0.
+        Single-process: returns plain ``jnp.array`` (1-rank mesh = identity).
+        Multi-process: stitches host-local slices into a global ``jax.Array``.
+        """
+        X_jnp = jnp.asarray(X_local)
+        F_jnp = jnp.asarray(F_local)
+        if jax.process_count() <= 1:
+            return X_jnp, F_jnp
+
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as PSpec
+
+        mesh = _get_sr_mesh()
+        X_global = jax.make_array_from_process_local_data(NamedSharding(mesh, PSpec(None, "rank")), X_jnp)
+        F_global = jax.make_array_from_process_local_data(NamedSharding(mesh, PSpec("rank")), F_jnp)
+        return X_global, F_global
+
+    @staticmethod
+    def _replicated_jax_array(arr: npt.NDArray):
+        """Wrap a host-local NumPy array as a replicated ``jax.Array`` across ranks.
+
+        For multi-process runs the ``arr`` must be identical on every rank (e.g.
+        a CG warm-start state that was psum'd before being persisted).
+        """
+        jnp_arr = jnp.asarray(arr)
+        if jax.process_count() <= 1:
+            return jnp_arr
+
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as PSpec
+
+        mesh = _get_sr_mesh()
+        return jax.make_array_from_process_local_data(NamedSharding(mesh, PSpec()), jnp_arr)
+
+    def _sr_solve_wide_direct_device(
+        self,
+        X_local: npt.NDArray,
+        F_local: npt.NDArray,
+        epsilon: float,
+    ) -> npt.NDArray:
+        """Wide-matrix direct SR solve via shard_map + psum + ``jnp.linalg.solve``.
+
+        Args:
+            X_local: Local (diag_S-normalized) design matrix ``(P, N_local)``.
+            F_local: Local right-hand-side ``(N_local,)``.
+            epsilon: Tikhonov regularization scalar.
+
+        Returns:
+            ``theta = (X X^T + eps I)^{-1} (X F)`` of shape ``(P,)``,
+            identical on every rank.
+        """
+        solver = _get_sr_wide_direct_kernel()
+        X_g, F_g = self._shard_X_F(X_local, F_local)
+        eps_jnp = jnp.asarray(epsilon, dtype=X_g.dtype)
+        theta = solver(X_g, F_g, eps_jnp)
+        theta.block_until_ready()
+        return np.asarray(theta)
+
+    def _sr_solve_wide_cg_device(
+        self,
+        X_local: npt.NDArray,
+        F_local: npt.NDArray,
+        epsilon: float,
+        max_iter: int,
+        tol: float,
+        x0: npt.NDArray,
+    ) -> tuple[npt.NDArray, float, int]:
+        """Wide-matrix CG SR solve. Returns ``(theta, residual, num_iter)``.
+
+        ``x0`` must be ``(P,)`` and identical on every rank (warm-start carried
+        across optimization iterations).
+        """
+        solver = _get_sr_wide_cg_kernel()
+        X_g, F_g = self._shard_X_F(X_local, F_local)
+        x0_g = self._replicated_jax_array(np.asarray(x0, dtype=X_local.dtype))
+        eps_jnp = jnp.asarray(epsilon, dtype=X_g.dtype)
+        max_iter_jnp = jnp.asarray(int(max_iter), dtype=jnp.int32)
+        tol_jnp = jnp.asarray(tol, dtype=X_g.dtype)
+        theta, residual, num_iter = solver(X_g, F_g, eps_jnp, max_iter_jnp, tol_jnp, x0_g)
+        theta.block_until_ready()
+        return np.asarray(theta), float(residual), int(num_iter)
+
+    def _sr_solve_tall_direct_device(
+        self,
+        X_local: npt.NDArray,
+        F_local: npt.NDArray,
+        epsilon: float,
+    ) -> npt.NDArray:
+        """Tall-matrix direct SR solve (push-through identity)."""
+        solver = _get_sr_tall_direct_kernel()
+        X_g, F_g = self._shard_X_F(X_local, F_local)
+        eps_jnp = jnp.asarray(epsilon, dtype=X_g.dtype)
+        theta = solver(X_g, F_g, eps_jnp)
+        theta.block_until_ready()
+        return np.asarray(theta)
+
+    def _sr_solve_tall_cg_device(
+        self,
+        X_local: npt.NDArray,
+        F_local: npt.NDArray,
+        epsilon: float,
+        max_iter: int,
+        tol: float,
+        x0: npt.NDArray,
+    ) -> tuple[npt.NDArray, npt.NDArray, float, int]:
+        """Tall-matrix CG SR solve. Returns ``(theta, y, residual, num_iter)``.
+
+        ``x0`` and ``y`` live in the sample space, shape ``(N_total,)``;
+        ``y`` is the CG solution (suitable as warm-start next iteration).
+        ``theta = X y`` lives in parameter space, shape ``(P,)``.
+        """
+        solver = _get_sr_tall_cg_kernel()
+        X_g, F_g = self._shard_X_F(X_local, F_local)
+        x0_g = self._replicated_jax_array(np.asarray(x0, dtype=X_local.dtype))
+        eps_jnp = jnp.asarray(epsilon, dtype=X_g.dtype)
+        max_iter_jnp = jnp.asarray(int(max_iter), dtype=jnp.int32)
+        tol_jnp = jnp.asarray(tol, dtype=X_g.dtype)
+        theta, y, residual, num_iter = solver(X_g, F_g, eps_jnp, max_iter_jnp, tol_jnp, x0_g)
+        theta.block_until_ready()
+        return np.asarray(theta), np.asarray(y), float(residual), int(num_iter)
+
     def run_optimize(
         self,
         num_mcmc_steps: int = 100,
@@ -2424,6 +2765,7 @@ class MCMC:
         opt_lambda_basis_exp: bool = False,
         opt_lambda_basis_coeff: bool = False,
         optimizer_kwargs: dict | None = None,
+        use_device_collectives: bool = False,
     ):
         """Optimize wavefunction parameters using SR or optax.
 
@@ -2457,6 +2799,13 @@ class MCMC:
                 ``use_lm=True`` enables LM with keys (``lm_subspace_dim``, ``lm_cond``);
                 other ``method`` names are optax constructors (e.g., ``"adam"``) and
                 receive remaining keys.
+            use_device_collectives (bool, optional): If True, run the SR
+                direct-solve cross-rank reductions and linear solve via
+                ``jax.shard_map`` + ``jax.lax.psum`` instead of
+                ``mpi_comm.Reduce`` + ``scipy.linalg.solve``. Currently
+                only the wide-matrix direct path is migrated; CG and tall
+                paths still use the host/mpi4py code regardless of this
+                flag. Defaults to False (legacy CPU path).
 
         Notes:
             - Persists optax optimizer state across calls when method and hyperparameters match.
@@ -3101,6 +3450,17 @@ class MCMC:
                 logger.info(f"The number of total samples is {num_samples_total}.")
                 logger.info(f"SR matrix dimension: {num_params} x {num_params}.")
 
+                # Announce which SR solve path will be used for this iteration.
+                _sr_regime = "wide" if num_params < num_samples_total else "tall"
+                _sr_method = "CG" if sr_cg_flag else "direct"
+                _sr_backend = "device (jax.shard_map + psum/all_gather)" if use_device_collectives else "CPU (mpi4py + scipy)"
+                logger.debug(
+                    "SR solver path: regime=%s, method=%s, backend=%s",
+                    _sr_regime,
+                    _sr_method,
+                    _sr_backend,
+                )
+
                 # make the SR matrix scale-invariant (i.e., normalize)
                 ## compute X_w@X.T
                 diag_S_local = np.einsum("jk,kj->j", X_local, X_local.T)
@@ -3156,240 +3516,341 @@ class MCMC:
                     logger.debug("X is a wide matrix. Proceed w/o the push-through identity.")
                     logger.debug("theta = (S+epsilon*I)^{-1}*f = (X * X^T + epsilon*I)^{-1} * X F...")
                     if not sr_cg_flag:
-                        logger.info("Using the direct solver for the inverse of S.")
-                        logger.debug(
-                            f"Estimated X_local @ X_local.T.bytes per MPI = {X_local.shape[0] ** 2 * X_local.dtype.itemsize / (2**30)} gib."
-                        )
-                        # compute local sum of X * X^T
-                        X_X_T_local = X_local @ X_local.T
-                        logger.devel(f"X_X_T_local.shape = {X_X_T_local.shape}.")
-                        # compute global sum of X * X^T
-                        if mpi_rank == 0:
-                            X_X_T = np.empty(X_X_T_local.shape, dtype=dtype_mcmc_np)
+                        if use_device_collectives:
+                            logger.info("Using the direct solver for the inverse of S (device-resident, shard_map + psum).")
+                            logger.debug(
+                                f"Estimated X_local @ X_local.T.bytes per MPI = {X_local.shape[0] ** 2 * X_local.dtype.itemsize / (2**30)} gib."
+                            )
+                            theta_all = self._sr_solve_wide_direct_device(
+                                X_local=X_local,
+                                F_local=F_local,
+                                epsilon=epsilon,
+                            )
+                            logger.devel(f"[device] theta_all (w/o the push through identity) = {theta_all}.")
+                            logger.devel(
+                                f"[device] theta_all (w/o the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
                         else:
-                            X_X_T = None
-                        mpi_comm.Reduce(X_X_T_local, X_X_T, op=MPI.SUM, root=0)
-                        # compute local sum of X @ F
-                        X_F_local = X_local @ F_local  # shape (num_param, )
-                        logger.devel(f"X_F_local.shape = {X_F_local.shape}.")
-                        # compute global sum of X @ F
-                        if mpi_rank == 0:
-                            X_F = np.empty(X_F_local.shape, dtype=dtype_mcmc_np)
-                        else:
-                            X_F = None
-                        mpi_comm.Reduce(X_F_local, X_F, op=MPI.SUM, root=0)
-                        # compute theta
-                        if mpi_rank == 0:
-                            logger.devel(f"X @ X.T.shape = {X_X_T.shape}.")
-                            logger.devel(f"X @ F.shape = {X_F.shape}.")
-                            # (X X^T + eps*I) x = X F ->solve-> x = (X  X^T + eps*I)^{-1} X F
-                            X_X_T[np.diag_indices_from(X_X_T)] += epsilon
+                            logger.info("Using the direct solver for the inverse of S.")
+                            logger.debug(
+                                f"Estimated X_local @ X_local.T.bytes per MPI = {X_local.shape[0] ** 2 * X_local.dtype.itemsize / (2**30)} gib."
+                            )
+                            # compute local sum of X * X^T
+                            X_X_T_local = X_local @ X_local.T
+                            logger.devel(f"X_X_T_local.shape = {X_X_T_local.shape}.")
+                            # compute global sum of X * X^T
+                            if mpi_rank == 0:
+                                X_X_T = np.empty(X_X_T_local.shape, dtype=dtype_mcmc_np)
+                            else:
+                                X_X_T = None
+                            mpi_comm.Reduce(X_X_T_local, X_X_T, op=MPI.SUM, root=0)
+                            # compute local sum of X @ F
+                            X_F_local = X_local @ F_local  # shape (num_param, )
+                            logger.devel(f"X_F_local.shape = {X_F_local.shape}.")
+                            # compute global sum of X @ F
+                            if mpi_rank == 0:
+                                X_F = np.empty(X_F_local.shape, dtype=dtype_mcmc_np)
+                            else:
+                                X_F = None
+                            mpi_comm.Reduce(X_F_local, X_F, op=MPI.SUM, root=0)
+                            # compute theta
+                            if mpi_rank == 0:
+                                logger.devel(f"X @ X.T.shape = {X_X_T.shape}.")
+                                logger.devel(f"X @ F.shape = {X_F.shape}.")
+                                # (X X^T + eps*I) x = X F ->solve-> x = (X  X^T + eps*I)^{-1} X F
+                                X_X_T[np.diag_indices_from(X_X_T)] += epsilon
 
-                            X_X_T_inv_X_F = scipy.linalg.solve(X_X_T, X_F, assume_a="sym")
-                            # theta = (X_w X^T + eps*I)^{-1} X_w F
-                            theta_all = X_X_T_inv_X_F
-                        else:
-                            theta_all = None
-                        # Broadcast theta_all to all ranks
-                        theta_all = mpi_comm.bcast(theta_all, root=0)
-                        logger.devel(f"[new] theta_all (w/o the push through identity) = {theta_all}.")
-                        logger.devel(
-                            f"[new] theta_all (w/o the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
-                        )
+                                X_X_T_inv_X_F = scipy.linalg.solve(X_X_T, X_F, assume_a="sym")
+                                # theta = (X_w X^T + eps*I)^{-1} X_w F
+                                theta_all = X_X_T_inv_X_F
+                            else:
+                                theta_all = None
+                            # Broadcast theta_all to all ranks
+                            theta_all = mpi_comm.bcast(theta_all, root=0)
+                            logger.devel(f"[new] theta_all (w/o the push through identity) = {theta_all}.")
+                            logger.devel(
+                                f"[new] theta_all (w/o the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
                     else:
-                        logger.info("Using conjugate gradient for the inverse of S.")
-                        logger.info(f"  [CG] threshold {sr_cg_tol}.")
-                        logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
-                        # conjugate gradient solver
-                        # Compute b = X @ F (distributed)
-                        X_F_local = X_local @ F_local  # shape (num_param, )
-                        X_F = np.zeros_like(X_F_local)
-                        mpi_comm.Allreduce(X_F_local, X_F, op=MPI.SUM)
-
-                        def apply_S_primal_numpy(v):
-                            XTv_local = X_local.T @ v
-                            XXTv_local = X_local @ XTv_local
-                            XXTv_global = np.empty_like(XXTv_local)
-                            mpi_comm.Allreduce(XXTv_local, XXTv_global, op=MPI.SUM)
-                            return XXTv_global + epsilon * v
-
-                        if sr_cg_warm_start_primal is not None and sr_cg_warm_start_primal.shape == X_F.shape:
-                            x0 = sr_cg_warm_start_primal
+                        if use_device_collectives:
+                            logger.info("Using conjugate gradient for the inverse of S (device-resident, shard_map + psum).")
+                            logger.info(f"  [CG] threshold {sr_cg_tol}.")
+                            logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
+                            num_params_local = X_local.shape[0]
+                            if sr_cg_warm_start_primal is not None and sr_cg_warm_start_primal.shape == (num_params_local,):
+                                x0 = sr_cg_warm_start_primal
+                            else:
+                                x0 = np.zeros(num_params_local, dtype=dtype_mcmc_np)
+                            theta_all, final_residual, num_steps = self._sr_solve_wide_cg_device(
+                                X_local=X_local,
+                                F_local=F_local,
+                                epsilon=epsilon,
+                                max_iter=sr_cg_max_iter,
+                                tol=sr_cg_tol,
+                                x0=x0,
+                            )
+                            sr_cg_warm_start_primal = np.array(theta_all, copy=True)
+                            logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
+                            logger.info(f"  [CG] Converged in {num_steps} steps")
+                            if num_steps == sr_cg_max_iter:
+                                logger.info("  [CG] Conjugate gradient did not converge!!")
+                            logger.devel(f"[device/cg] theta_all (w/o the push through identity) = {theta_all}.")
+                            logger.devel(f"[device/cg] theta_all: min, max = {np.min(theta_all)}, {np.max(theta_all)}.")
                         else:
-                            x0 = np.zeros_like(X_F)
+                            logger.info("Using conjugate gradient for the inverse of S.")
+                            logger.info(f"  [CG] threshold {sr_cg_tol}.")
+                            logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
+                            # conjugate gradient solver
+                            # Compute b = X @ F (distributed)
+                            X_F_local = X_local @ F_local  # shape (num_param, )
+                            X_F = np.zeros_like(X_F_local)
+                            mpi_comm.Allreduce(X_F_local, X_F, op=MPI.SUM)
 
-                        theta_all, final_residual, num_steps = _conjugate_gradient_numpy(
-                            np.asarray(X_F, dtype=dtype_mcmc_np),
-                            apply_S_primal_numpy,
-                            np.asarray(x0, dtype=dtype_mcmc_np),
-                            sr_cg_max_iter,
-                            sr_cg_tol,
-                        )
-                        sr_cg_warm_start_primal = np.array(theta_all, copy=True)
-                        logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
-                        logger.info(f"  [CG] Converged in {num_steps} steps")
-                        if num_steps == sr_cg_max_iter:
-                            logger.info("  [CG] Conjugate gradient did not converge!!")
-                        logger.devel(f"[new/cg] theta_all (w/o the push through identity) = {theta_all}.")
-                        logger.devel(
-                            f"[new/cg] theta_all (w/o the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
-                        )
+                            def apply_S_primal_numpy(v):
+                                XTv_local = X_local.T @ v
+                                XXTv_local = X_local @ XTv_local
+                                XXTv_global = np.empty_like(XXTv_local)
+                                mpi_comm.Allreduce(XXTv_local, XXTv_global, op=MPI.SUM)
+                                return XXTv_global + epsilon * v
+
+                            if sr_cg_warm_start_primal is not None and sr_cg_warm_start_primal.shape == X_F.shape:
+                                x0 = sr_cg_warm_start_primal
+                            else:
+                                x0 = np.zeros_like(X_F)
+
+                            theta_all, final_residual, num_steps = _conjugate_gradient_numpy(
+                                np.asarray(X_F, dtype=dtype_mcmc_np),
+                                apply_S_primal_numpy,
+                                np.asarray(x0, dtype=dtype_mcmc_np),
+                                sr_cg_max_iter,
+                                sr_cg_tol,
+                            )
+                            sr_cg_warm_start_primal = np.array(theta_all, copy=True)
+                            logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
+                            logger.info(f"  [CG] Converged in {num_steps} steps")
+                            if num_steps == sr_cg_max_iter:
+                                logger.info("  [CG] Conjugate gradient did not converge!!")
+                            logger.devel(f"[new/cg] theta_all (w/o the push through identity) = {theta_all}.")
+                            logger.devel(
+                                f"[new/cg] theta_all (w/o the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
 
                 else:  # num_params >= num_samples:
                     # if True:
                     logger.debug("X is a tall matrix. Proceed w/ the push-through identity.")
                     logger.debug("theta = (S+epsilon*I)^{-1}*f = X(X^T * X + epsilon*I)^{-1} * F...")
 
-                    # Get local shapes
-                    N, M = X_local.shape
-                    P = mpi_size  # number of ranks
-
-                    # Compute how many rows each rank should own (distribute the remainder)
-                    counts = [N // P + (1 if i < (N % P) else 0) for i in range(P)]
-
-                    # Compute starting row index for each rank in the original array
-                    displs = [sum(counts[:i]) for i in range(P)]
-                    N_local = counts[mpi_rank]  # number of rows this rank will receive
-
-                    # Build send buffers by slicing X and Xw into P row-chunks
-                    # Each chunk is flattened so we can send in one go.
-                    sendbuf_X = np.concatenate([X_local[displs[i] : displs[i] + counts[i], :].ravel() for i in range(P)])
-
-                    # Prepare sendcounts and displacements in units of elements
-                    sendcounts = [counts[i] * M for i in range(P)]
-                    sdispls = [sum(sendcounts[:i]) for i in range(P)]
-
-                    # Prepare recvcounts and displacements:
-                    # each rank will receive 'counts[mpi_rank]*M' elements from each of the P ranks
-                    recvcounts = [counts[mpi_rank] * M] * P
-                    rdispls = [i * counts[mpi_rank] * M for i in range(P)]
-
-                    # Allocate receive buffers
-                    recvbuf_X = np.empty(sum(recvcounts), dtype=X_local.dtype)
-
-                    # Perform the all-to-all variable-sized exchange
-                    mpi_comm.Alltoallv(
-                        [sendbuf_X, sendcounts, sdispls, MPI.DOUBLE], [recvbuf_X, recvcounts, rdispls, MPI.DOUBLE]
-                    )
-
-                    # Reshape the flat receive buffer into a 3D array
-                    #    shape = (P sources, N_local rows, M cols)
-                    buf_X = recvbuf_X.reshape(P, N_local, M)
-
-                    # Rearrange into final 2D arrays of shape (N_local, M * P)
-                    #    by stacking each source's M columns side by side
-                    X_re_local = np.hstack([buf_X[i] for i in range(P)])  # shape (num_param/P, num_mcmc * num_walker * P)
-                    logger.devel(f"X_re_local.shape = {X_re_local.shape}.")
-
-                    if not sr_cg_flag:
-                        logger.info("Using the direct solver for the inverse of S.")
-                        logger.devel(
-                            f"Estimated X_local.T @ X_local.bytes per MPI = {X_re_local.shape[1] ** 2 * X_re_local.dtype.itemsize / (2**30)} gib."
-                        )
-                        # compute local sum of X^T * X
-                        X_T_X_local = X_re_local.T @ X_re_local
-                        logger.devel(f"X_T_X_local.shape = {X_T_X_local.shape}.")
-                        # compute global sum of X^T * X
-                        if mpi_rank == 0:
-                            X_T_X = np.empty(X_T_X_local.shape, dtype=dtype_mcmc_np)
+                    if use_device_collectives:
+                        # Device path: shard_map + all_gather handles redistribution
+                        # internally; no Alltoallv prep on host.
+                        if not sr_cg_flag:
+                            logger.info(
+                                "Using the direct solver for the inverse of S "
+                                "(device-resident, shard_map + all_gather, push-through identity)."
+                            )
+                            theta_all = self._sr_solve_tall_direct_device(
+                                X_local=X_local,
+                                F_local=F_local,
+                                epsilon=epsilon,
+                            )
+                            logger.devel(
+                                f"[device] theta_all (w/ the push through identity): "
+                                f"min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
                         else:
-                            X_T_X = None
-                        mpi_comm.Reduce(X_T_X_local, X_T_X, op=MPI.SUM, root=0)
-                        # gather F_local from all ranks (concatenation, not element-wise sum)
-                        F_local_count = F_local.shape[0]
-                        F_recvcounts = mpi_comm.gather(F_local_count, root=0)
-                        if mpi_rank == 0:
-                            F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                            F = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
-                        else:
-                            F_displs = None
-                            F = None
-                        mpi_comm.Gatherv(
-                            [F_local, MPI.DOUBLE],
-                            [F, (F_recvcounts, F_displs), MPI.DOUBLE] if mpi_rank == 0 else [F, None],
-                            root=0,
-                        )
-                        if mpi_rank == 0:
-                            logger.devel(f"X_T_X.shape = {X_T_X.shape}.")
-                            logger.devel(f"F.shape = {F.shape}.")
-                            X_T_X[np.diag_indices_from(X_T_X)] += epsilon
-                            # (X^T X_w + eps*I) x = F ->solve-> x = (X^T X_w + eps*I)^{-1} F
-                            X_T_X_inv_F = scipy.linalg.solve(X_T_X, F, assume_a="sym")
-                            K = X_T_X_inv_F.shape[0] // mpi_size
-                        else:
-                            X_T_X_inv_F = None
-                            K = None
-                        # Broadcast K to all ranks so they know how big each chunk is
-                        K = mpi_comm.bcast(K, root=0)
-
-                        X_T_X_inv_F_local = np.empty(K, dtype=dtype_mcmc_np)
-
-                        mpi_comm.Scatter(
-                            [X_T_X_inv_F, MPI.DOUBLE],  # send buffer (only significant on root)
-                            X_T_X_inv_F_local,  # receive buffer (on each rank)
-                            root=0,
-                        )
-                        # theta = X_w (X^T X_w + eps*I)^{-1} F
-                        theta_all_local = X_local @ X_T_X_inv_F_local
-                        theta_all = np.empty(theta_all_local.shape, dtype=dtype_mcmc_np)
-                        mpi_comm.Allreduce(theta_all_local, theta_all, op=MPI.SUM)
-                        logger.devel(f"[new] theta_all (w/ the push through identity) = {theta_all}.")
-                        logger.devel(
-                            f"[new] theta_all (w/ the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
-                        )
+                            logger.info(
+                                "Using conjugate gradient for the inverse of S "
+                                "(device-resident, shard_map + all_gather, push-through identity)."
+                            )
+                            logger.info(f"  [CG] threshold {sr_cg_tol}.")
+                            logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
+                            num_samples_total_local = int(F_local.shape[0]) * mpi_size
+                            if sr_cg_warm_start_dual is not None and sr_cg_warm_start_dual.shape == (num_samples_total_local,):
+                                x0 = sr_cg_warm_start_dual
+                            else:
+                                x0 = np.zeros(num_samples_total_local, dtype=dtype_mcmc_np)
+                            theta_all, y_sample, final_residual, num_steps = self._sr_solve_tall_cg_device(
+                                X_local=X_local,
+                                F_local=F_local,
+                                epsilon=epsilon,
+                                max_iter=sr_cg_max_iter,
+                                tol=sr_cg_tol,
+                                x0=x0,
+                            )
+                            # Persist sample-space CG solution as warm-start for the
+                            # next opt iteration (matches CPU branch's behavior).
+                            sr_cg_warm_start_dual = np.array(y_sample, copy=True)
+                            logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
+                            logger.info(f"  [CG] Converged in {num_steps} steps")
+                            if num_steps == sr_cg_max_iter:
+                                logger.info("  [CG] Conjugate gradient did not converge!!")
+                            logger.devel(
+                                f"[device/cg] theta_all (w/ the push through identity): "
+                                f"min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
+                        # Skip the rest of the legacy CPU tall block.
+                        # Fall through to the shared scale-back below.
+                        # (Sentinel handled by Python control flow: the CPU branch's
+                        # remaining code lives inside the same `else:` arm; we mirror
+                        # by jumping past it via early-continuation pattern below.)
+                        _device_tall_done = True
                     else:
-                        logger.info("Using conjugate gradient for the inverse of S.")
-                        logger.info(f"  [CG] threshold {sr_cg_tol}.")
-                        logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
+                        _device_tall_done = False
 
-                        def apply_dual_S_numpy(v):
-                            Xv_local = X_re_local @ v
-                            XTXv_local = X_re_local.T @ Xv_local
-                            XTXv_global = np.empty_like(XTXv_local)
-                            mpi_comm.Allreduce(XTXv_local, XTXv_global, op=MPI.SUM)
-                            return XTXv_global + epsilon * v
+                    if _device_tall_done:
+                        pass  # device path produced theta_all already
+                    else:
+                        # Legacy CPU path: redistribute X via Alltoallv, then solve.
+                        # Get local shapes
+                        N, M = X_local.shape
+                        P = mpi_size  # number of ranks
 
-                        # Gather F_local from all ranks (concatenation) to form F_total of length M*P
-                        F_local_count = F_local.shape[0]
-                        F_recvcounts = mpi_comm.allgather(F_local_count)
-                        F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
-                        F_total = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
-                        mpi_comm.Allgatherv(
-                            [F_local, MPI.DOUBLE],
-                            [F_total, (F_recvcounts, F_displs), MPI.DOUBLE],
+                        # Compute how many rows each rank should own (distribute the remainder)
+                        counts = [N // P + (1 if i < (N % P) else 0) for i in range(P)]
+
+                        # Compute starting row index for each rank in the original array
+                        displs = [sum(counts[:i]) for i in range(P)]
+                        N_local = counts[mpi_rank]  # number of rows this rank will receive
+
+                        # Build send buffers by slicing X and Xw into P row-chunks
+                        # Each chunk is flattened so we can send in one go.
+                        sendbuf_X = np.concatenate([X_local[displs[i] : displs[i] + counts[i], :].ravel() for i in range(P)])
+
+                        # Prepare sendcounts and displacements in units of elements
+                        sendcounts = [counts[i] * M for i in range(P)]
+                        sdispls = [sum(sendcounts[:i]) for i in range(P)]
+
+                        # Prepare recvcounts and displacements:
+                        # each rank will receive 'counts[mpi_rank]*M' elements from each of the P ranks
+                        recvcounts = [counts[mpi_rank] * M] * P
+                        rdispls = [i * counts[mpi_rank] * M for i in range(P)]
+
+                        # Allocate receive buffers
+                        recvbuf_X = np.empty(sum(recvcounts), dtype=X_local.dtype)
+
+                        # Perform the all-to-all variable-sized exchange
+                        mpi_comm.Alltoallv(
+                            [sendbuf_X, sendcounts, sdispls, MPI.DOUBLE], [recvbuf_X, recvcounts, rdispls, MPI.DOUBLE]
                         )
-                        if sr_cg_warm_start_dual is not None and sr_cg_warm_start_dual.shape == F_total.shape:
-                            x0 = sr_cg_warm_start_dual
+
+                        # Reshape the flat receive buffer into a 3D array
+                        #    shape = (P sources, N_local rows, M cols)
+                        buf_X = recvbuf_X.reshape(P, N_local, M)
+
+                        # Rearrange into final 2D arrays of shape (N_local, M * P)
+                        #    by stacking each source's M columns side by side
+                        X_re_local = np.hstack([buf_X[i] for i in range(P)])  # shape (num_param/P, num_mcmc * num_walker * P)
+                        logger.devel(f"X_re_local.shape = {X_re_local.shape}.")
+
+                        if not sr_cg_flag:
+                            logger.info("Using the direct solver for the inverse of S.")
+                            logger.devel(
+                                f"Estimated X_local.T @ X_local.bytes per MPI = {X_re_local.shape[1] ** 2 * X_re_local.dtype.itemsize / (2**30)} gib."
+                            )
+                            # compute local sum of X^T * X
+                            X_T_X_local = X_re_local.T @ X_re_local
+                            logger.devel(f"X_T_X_local.shape = {X_T_X_local.shape}.")
+                            # compute global sum of X^T * X
+                            if mpi_rank == 0:
+                                X_T_X = np.empty(X_T_X_local.shape, dtype=dtype_mcmc_np)
+                            else:
+                                X_T_X = None
+                            mpi_comm.Reduce(X_T_X_local, X_T_X, op=MPI.SUM, root=0)
+                            # gather F_local from all ranks (concatenation, not element-wise sum)
+                            F_local_count = F_local.shape[0]
+                            F_recvcounts = mpi_comm.gather(F_local_count, root=0)
+                            if mpi_rank == 0:
+                                F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
+                                F = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
+                            else:
+                                F_displs = None
+                                F = None
+                            mpi_comm.Gatherv(
+                                [F_local, MPI.DOUBLE],
+                                [F, (F_recvcounts, F_displs), MPI.DOUBLE] if mpi_rank == 0 else [F, None],
+                                root=0,
+                            )
+                            if mpi_rank == 0:
+                                logger.devel(f"X_T_X.shape = {X_T_X.shape}.")
+                                logger.devel(f"F.shape = {F.shape}.")
+                                X_T_X[np.diag_indices_from(X_T_X)] += epsilon
+                                # (X^T X_w + eps*I) x = F ->solve-> x = (X^T X_w + eps*I)^{-1} F
+                                X_T_X_inv_F = scipy.linalg.solve(X_T_X, F, assume_a="sym")
+                                K = X_T_X_inv_F.shape[0] // mpi_size
+                            else:
+                                X_T_X_inv_F = None
+                                K = None
+                            # Broadcast K to all ranks so they know how big each chunk is
+                            K = mpi_comm.bcast(K, root=0)
+
+                            X_T_X_inv_F_local = np.empty(K, dtype=dtype_mcmc_np)
+
+                            mpi_comm.Scatter(
+                                [X_T_X_inv_F, MPI.DOUBLE],  # send buffer (only significant on root)
+                                X_T_X_inv_F_local,  # receive buffer (on each rank)
+                                root=0,
+                            )
+                            # theta = X_w (X^T X_w + eps*I)^{-1} F
+                            theta_all_local = X_local @ X_T_X_inv_F_local
+                            theta_all = np.empty(theta_all_local.shape, dtype=dtype_mcmc_np)
+                            mpi_comm.Allreduce(theta_all_local, theta_all, op=MPI.SUM)
+                            logger.devel(f"[new] theta_all (w/ the push through identity) = {theta_all}.")
+                            logger.devel(
+                                f"[new] theta_all (w/ the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
                         else:
-                            x0 = np.zeros_like(F_total)
-                        x_sol, final_residual, num_steps = _conjugate_gradient_numpy(
-                            F_total,
-                            apply_dual_S_numpy,
-                            np.asarray(x0, dtype=dtype_mcmc_np),
-                            sr_cg_max_iter,
-                            sr_cg_tol,
-                        )
-                        sr_cg_warm_start_dual = np.array(x_sol, copy=True)
+                            logger.info("Using conjugate gradient for the inverse of S.")
+                            logger.info(f"  [CG] threshold {sr_cg_tol}.")
+                            logger.info(f"  [CG] max iteration: {sr_cg_max_iter}.")
 
-                        # theta = X @ x_sol, evaluated locally over X_re_local (N_local rows)
-                        theta_local = X_re_local @ x_sol  # shape (N_local,)
-                        theta_local = np.asarray(theta_local)
-                        N_local = theta_local.shape[0]
+                            def apply_dual_S_numpy(v):
+                                Xv_local = X_re_local @ v
+                                XTXv_local = X_re_local.T @ Xv_local
+                                XTXv_global = np.empty_like(XTXv_local)
+                                mpi_comm.Allreduce(XTXv_local, XTXv_global, op=MPI.SUM)
+                                return XTXv_global + epsilon * v
 
-                        recvcounts = mpi_comm.allgather(N_local)
-                        displs = [sum(recvcounts[:i]) for i in range(mpi_comm.Get_size())]
+                            # Gather F_local from all ranks (concatenation) to form F_total of length M*P
+                            F_local_count = F_local.shape[0]
+                            F_recvcounts = mpi_comm.allgather(F_local_count)
+                            F_displs = [sum(F_recvcounts[:i]) for i in range(len(F_recvcounts))]
+                            F_total = np.empty(sum(F_recvcounts), dtype=dtype_mcmc_np)
+                            mpi_comm.Allgatherv(
+                                [F_local, MPI.DOUBLE],
+                                [F_total, (F_recvcounts, F_displs), MPI.DOUBLE],
+                            )
+                            if sr_cg_warm_start_dual is not None and sr_cg_warm_start_dual.shape == F_total.shape:
+                                x0 = sr_cg_warm_start_dual
+                            else:
+                                x0 = np.zeros_like(F_total)
+                            x_sol, final_residual, num_steps = _conjugate_gradient_numpy(
+                                F_total,
+                                apply_dual_S_numpy,
+                                np.asarray(x0, dtype=dtype_mcmc_np),
+                                sr_cg_max_iter,
+                                sr_cg_tol,
+                            )
+                            sr_cg_warm_start_dual = np.array(x_sol, copy=True)
 
-                        theta_all = np.empty(sum(recvcounts), dtype=theta_local.dtype)
-                        mpi_comm.Allgatherv([theta_local, MPI.DOUBLE], [theta_all, (recvcounts, displs), MPI.DOUBLE])
+                            # theta = X @ x_sol, evaluated locally over X_re_local (N_local rows)
+                            theta_local = X_re_local @ x_sol  # shape (N_local,)
+                            theta_local = np.asarray(theta_local)
+                            N_local = theta_local.shape[0]
 
-                        logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
-                        logger.info(f"  [CG] Converged in {num_steps} steps")
-                        if num_steps == sr_cg_max_iter:
-                            logger.logger("  [CG] Conjugate gradient did not converge!")
-                        logger.devel(f"[new/cg] theta_all (w/o the push through identity) = {theta_all}.")
-                        logger.devel(
-                            f"[new/cg] theta_all (w/ the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
-                        )
+                            recvcounts = mpi_comm.allgather(N_local)
+                            displs = [sum(recvcounts[:i]) for i in range(mpi_comm.Get_size())]
+
+                            theta_all = np.empty(sum(recvcounts), dtype=theta_local.dtype)
+                            mpi_comm.Allgatherv([theta_local, MPI.DOUBLE], [theta_all, (recvcounts, displs), MPI.DOUBLE])
+
+                            logger.devel(f"  [CG] Final residual: {final_residual:.3e}")
+                            logger.info(f"  [CG] Converged in {num_steps} steps")
+                            if num_steps == sr_cg_max_iter:
+                                logger.logger("  [CG] Conjugate gradient did not converge!")
+                            logger.devel(f"[new/cg] theta_all (w/o the push through identity) = {theta_all}.")
+                            logger.devel(
+                                f"[new/cg] theta_all (w/ the push through identity): min, max = {np.min(theta_all)}, {np.max(theta_all)}."
+                            )
 
                 # theta, back to the original scale
                 theta_all = theta_all / np.sqrt(diag_S)

--- a/jqmc/jqmc_mcmc.py
+++ b/jqmc/jqmc_mcmc.py
@@ -58,7 +58,7 @@ from jax import numpy as jnp
 from mpi4py import MPI
 
 from ._diff_mask import DiffMask, apply_diff_mask
-from ._jqmc_utility import _generate_init_electron_configurations
+from ._jqmc_utility import _generate_init_electron_configurations, check_mpi4py_jax_distribution_consistency
 from ._setting import (
     MCMC_MIN_BIN_BLOCKS,
     MCMC_MIN_WARMUP_STEPS,
@@ -677,6 +677,8 @@ class MCMC:
             - Accumulates energies, weights, forces, and wavefunction gradients into public buffers (``w_L``, ``e_L``, ``dln_Psi_*`` etc.).
             - Logs timing statistics and acceptance ratios at the end of the run.
         """
+        check_mpi4py_jax_distribution_consistency()
+
         # timer_counter
         timer_mcmc_total = 0.0
         timer_mcmc_update_init = 0.0
@@ -2765,7 +2767,7 @@ class MCMC:
         opt_lambda_basis_exp: bool = False,
         opt_lambda_basis_coeff: bool = False,
         optimizer_kwargs: dict | None = None,
-        use_device_collectives: bool = False,
+        use_device_collectives: bool = True,
     ):
         """Optimize wavefunction parameters using SR or optax.
 
@@ -2799,13 +2801,21 @@ class MCMC:
                 ``use_lm=True`` enables LM with keys (``lm_subspace_dim``, ``lm_cond``);
                 other ``method`` names are optax constructors (e.g., ``"adam"``) and
                 receive remaining keys.
-            use_device_collectives (bool, optional): If True, run the SR
-                direct-solve cross-rank reductions and linear solve via
-                ``jax.shard_map`` + ``jax.lax.psum`` instead of
-                ``mpi_comm.Reduce`` + ``scipy.linalg.solve``. Currently
-                only the wide-matrix direct path is migrated; CG and tall
-                paths still use the host/mpi4py code regardless of this
-                flag. Defaults to False (legacy CPU path).
+            use_device_collectives (bool, optional): If True (default), run
+                the SR cross-rank reductions and linear solve via
+                ``jax.shard_map`` + ``jax.lax.psum`` / ``all_gather`` (NCCL on
+                multi-process GPU, Gloo on multi-process CPU, trivial on
+                single-process). If False, fall back to ``mpi_comm.Reduce`` /
+                ``Allreduce`` / ``Alltoallv`` + ``scipy.linalg.solve`` (legacy
+                mpi4py + SciPy path).
+
+                When True under ``mpirun -n N>=2``, ``jax.distributed.initialize(
+                cluster_detection_method="mpi4py")`` must have been called
+                before ``run_optimize``; otherwise the device path silently
+                produces per-rank-local results that don't match the global
+                solution. ``run_optimize`` raises ``RuntimeError`` if it
+                detects ``mpi_size != jax.process_count()`` to surface this
+                misconfiguration.
 
         Notes:
             - Persists optax optimizer state across calls when method and hyperparameters match.
@@ -2849,6 +2859,8 @@ class MCMC:
                 raise RuntimeError("use_lm requires compute_log_WF_param_deriv=True.")
             if not self.__comput_e_L_param_deriv:
                 raise RuntimeError("use_lm requires comput_e_L_param_deriv=True.")
+
+        check_mpi4py_jax_distribution_consistency()
 
         optax_kwargs = {
             k: v

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,38 @@ import jax
 import pytest
 
 
+@pytest.fixture(scope="session", autouse=True)
+def _jax_distributed_init():
+    """Initialize ``jax.distributed`` once per pytest session under multi-rank MPI.
+
+    The device branch of ``run_optimize`` (``use_device_collectives=True``)
+    relies on ``jax.lax.psum`` / ``jax.lax.all_gather`` to aggregate across
+    MPI ranks. Without ``jax.distributed.initialize`` each rank's JAX sees
+    only its own local devices (``jax.process_count() == 1``) and the
+    collectives degenerate to no-ops, silently producing wrong results.
+
+    Mirrors the production CLI setup in ``jqmc_cli.py``: strip HTTP proxy
+    environment variables before calling ``initialize`` so the JAX gRPC
+    coordination service doesn't try to route the local-host connection
+    through a proxy (which is the typical cause of "hangs forever" on
+    macOS / corporate networks).
+    """
+    import os
+
+    from mpi4py import MPI
+
+    if MPI.COMM_WORLD.Get_size() > 1:
+        # Same proxy-strip workaround as jqmc_cli.py.
+        for _proxy_var in ("http_proxy", "https_proxy", "HTTP_PROXY", "HTTPS_PROXY"):
+            os.environ.pop(_proxy_var, None)
+        try:
+            jax.distributed.initialize(cluster_detection_method="mpi4py")
+        except Exception:
+            # already initialized in the same process, or backend cannot start
+            pass
+    yield
+
+
 def pytest_addoption(parser):
     """Add options for pytests."""
     parser.addoption("--disable-jit", action="store_true", default=False, help="Disable jax.jit for pytests")

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -1171,6 +1171,651 @@ def test_sr_device_matches_cpu(trexio_file, regime, cg_flag, monkeypatch):
     jax.clear_caches()
 
 
+@pytest.mark.parametrize(
+    "regime,cg_flag",
+    [
+        ("wide", False),
+        ("wide", True),
+        ("tall", False),
+        ("tall", True),
+    ],
+)
+@pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvtz_cart.h5"])
+def test_sr_device_matches_cpu_multirank(trexio_file, regime, cg_flag, monkeypatch):
+    """Multi-rank counterpart to ``test_sr_device_matches_cpu``.
+
+    Verifies that under ``mpirun -n N>=2``:
+
+    - The legacy CPU branch (``mpi_comm.Reduce`` / ``Allreduce`` / ``Alltoallv``
+      via mpi4py) and
+    - The device branch (``jax.lax.psum`` / ``all_gather`` via NCCL on GPU
+      or Gloo on CPU, dispatched through ``shard_map``)
+
+    produce numerically equivalent ``theta`` updates for all four SR
+    paths (wide/tall x direct/CG).
+
+    Each MPI rank is given *different* fake samples (via a rank-dependent
+    seed) so that the cross-rank reduction has actual work to do; if the
+    fixture-installed ``jax.distributed.initialize`` were missing, the
+    device branch would silently produce per-rank-local results that
+    wouldn't agree with the CPU branch's globally-aggregated result.
+
+    Skipped on single-process runs (the single-process variant lives in
+    ``test_sr_device_matches_cpu``).
+    """
+    from mpi4py import MPI as _MPI
+
+    comm = _MPI.COMM_WORLD
+    mpi_size = comm.Get_size()
+    mpi_rank = comm.Get_rank()
+
+    if mpi_size < 2:
+        pytest.skip("Multi-rank agreement test requires at least 2 MPI ranks.")
+    if jax.process_count() < 2:
+        pytest.skip(
+            "Multi-rank agreement test requires jax.distributed to be initialized "
+            "(JAX sees only 1 process despite multiple MPI ranks). The conftest "
+            "fixture should auto-init under ``mpirun -n N pytest``; check that the "
+            "init didn't silently fail (proxy env vars, network sandboxing)."
+        )
+
+    (
+        structure_data,
+        _,
+        _,
+        _,
+        geminal_mo_data,
+        coulomb_potential_data,
+    ) = read_trexio_file(
+        trexio_file=os.path.join(os.path.dirname(__file__), "trexio_example_files", trexio_file), store_tuple=True
+    )
+
+    jastrow_onebody_data = Jastrow_one_body_data.init_jastrow_one_body_data(
+        jastrow_1b_param=1.0,
+        structure_data=structure_data,
+        core_electrons=tuple([0] * len(structure_data.atomic_numbers)),
+        jastrow_1b_type="pade",
+    )
+    jastrow_twobody_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="pade")
+    jastrow_data = Jastrow_data(
+        jastrow_one_body_data=jastrow_onebody_data,
+        jastrow_two_body_data=jastrow_twobody_data,
+        jastrow_three_body_data=None,
+        jastrow_nn_data=None,
+    )
+    wavefunction_data = Wavefunction_data(jastrow_data=jastrow_data, geminal_data=geminal_mo_data)
+    hamiltonian_data = Hamiltonian_data(
+        structure_data=structure_data,
+        coulomb_potential_data=coulomb_potential_data,
+        wavefunction_data=wavefunction_data,
+    )
+
+    num_walkers = 2
+    Dt = 2.0
+    mcmc_seed = 12345
+    epsilon_AS = 1.0e-6
+
+    # Build a parameter set sized for the requested regime; use mpi_size in
+    # the sample-count budget since the SR system sees all ranks' samples.
+    base_params: dict[str, np.ndarray] = {
+        "j1_param": np.ones_like(np.array(jastrow_onebody_data.jastrow_1b_param)),
+        "j2_param": np.ones_like(np.array(jastrow_twobody_data.jastrow_2b_param)),
+    }
+    fixed_param_size = sum(v.size for v in base_params.values())
+
+    if regime == "tall":
+        num_mcmc = 1
+        min_samples_total = num_mcmc * num_walkers * mpi_size
+        lambda_size_needed = max(1, min_samples_total - fixed_param_size + 1)
+        base_params["lambda_matrix"] = np.ones(lambda_size_needed, dtype=float)
+    else:
+        base_params["lambda_matrix"] = np.array([[2.0, -2.0], [3.0, -3.0]], dtype=float)
+        total_params_tmp = sum(v.size for v in base_params.values())
+        # Ensure num_mcmc * num_walkers * mpi_size > total_params_tmp.
+        num_mcmc = max(1, total_params_tmp // (num_walkers * mpi_size) + 2)
+
+    total_params = sum(v.size for v in base_params.values())
+    num_samples_total = num_mcmc * num_walkers * mpi_size
+    if regime == "wide":
+        assert total_params < num_samples_total, f"wide setup invalid: {total_params} >= {num_samples_total}"
+    else:
+        assert total_params >= num_samples_total, f"tall setup invalid: {total_params} < {num_samples_total}"
+
+    # Rank-dependent fake data: each rank sees different samples so the
+    # cross-rank reduction is meaningful. Same seeds in both run_once calls
+    # so CPU and device branches see identical inputs.
+    fake_w_L_data = np.ones((num_mcmc, num_walkers))
+    rng = np.random.default_rng(42 + mpi_rank)
+    fake_e_L_data = rng.standard_normal((num_mcmc, num_walkers)) * 0.1
+
+    params_holder: dict[str, dict[str, np.ndarray] | None] = {"params": None}
+
+    def register_params(_wf, params):
+        params_holder["params"] = params
+
+    def lookup_params(_wf):
+        return params_holder["params"]
+
+    def fake_get_variational_blocks(
+        self,
+        opt_J1_param=True,
+        opt_J2_param=True,
+        opt_J3_param=True,
+        opt_JNN_param=True,
+        opt_lambda_param=False,
+        opt_J3_basis_exp=False,
+        opt_J3_basis_coeff=False,
+        opt_lambda_basis_exp=False,
+        opt_lambda_basis_coeff=False,
+    ):
+        blocks = []
+        pos = lookup_params(self)
+        if opt_J1_param and "j1_param" in pos:
+            arr = pos["j1_param"]
+            blocks.append(VariationalParameterBlock(name="j1_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_J2_param and "j2_param" in pos:
+            arr = pos["j2_param"]
+            blocks.append(VariationalParameterBlock(name="j2_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_lambda_param and "lambda_matrix" in pos:
+            arr = pos["lambda_matrix"]
+            blocks.append(VariationalParameterBlock(name="lambda_matrix", values=arr, shape=arr.shape, size=int(arr.size)))
+        return blocks
+
+    def fake_apply_block_updates(self, blocks, thetas, learning_rate):
+        params = lookup_params(self)
+        idx = 0
+        for block in blocks:
+            blk_slice = thetas[idx : idx + block.size]
+            idx += block.size
+            if blk_slice.size == 0:
+                continue
+            delta = blk_slice.reshape(block.shape)
+            params[block.name] = params[block.name] + learning_rate * delta
+        return self
+
+    def fake_run(self, num_mcmc_steps: int = 0, max_time=None):
+        return None
+
+    def fake_get_dln_WF(
+        self,
+        blocks,
+        num_mcmc_warmup_steps=0,
+        chosen_param_index=None,
+        lambda_projectors=None,
+        num_orb_projection=None,
+    ):
+        total = sum(block.size for block in blocks)
+        rng_local = np.random.default_rng(123 + mpi_rank)
+        return rng_local.standard_normal((num_mcmc, self.num_walkers, total)) * 0.01
+
+    def fake_get_E(self, num_mcmc_warmup_steps: int = 0, num_mcmc_bin_blocks: int = 1):
+        return (0.0, 0.0, 0.0, 0.0)
+
+    def fake_get_gF(
+        self,
+        num_mcmc_warmup_steps,
+        num_mcmc_bin_blocks,
+        blocks,
+        lambda_projectors=None,
+        num_orb_projection=None,
+        chosen_param_index=None,
+    ):
+        total = sum(block.size for block in blocks)
+        return np.ones(total, dtype=float), np.ones(total, dtype=float)
+
+    monkeypatch.setattr(Wavefunction_data, "get_variational_blocks", fake_get_variational_blocks, raising=False)
+    monkeypatch.setattr(Wavefunction_data, "apply_block_updates", fake_apply_block_updates, raising=False)
+    monkeypatch.setattr(MCMC, "run", fake_run, raising=False)
+    monkeypatch.setattr(MCMC, "get_E", fake_get_E, raising=False)
+    monkeypatch.setattr(MCMC, "get_gF", fake_get_gF, raising=False)
+    monkeypatch.setattr(MCMC, "get_dln_WF", fake_get_dln_WF, raising=False)
+    monkeypatch.setattr(MCMC, "w_L", property(lambda self: fake_w_L_data), raising=False)
+    monkeypatch.setattr(MCMC, "e_L", property(lambda self: fake_e_L_data), raising=False)
+
+    def run_once(use_device_collectives: bool):
+        mcmc = MCMC(
+            hamiltonian_data=hamiltonian_data,
+            Dt=Dt,
+            mcmc_seed=mcmc_seed,
+            epsilon_AS=epsilon_AS,
+            num_walkers=num_walkers,
+            comput_position_deriv=False,
+            comput_log_WF_param_deriv=True,
+            comput_e_L_param_deriv=False,
+            random_discretized_mesh=True,
+        )
+        params = {k: v.copy() for k, v in base_params.items()}
+        register_params(mcmc.hamiltonian_data.wavefunction_data, params)
+        mcmc.run_optimize(
+            num_mcmc_steps=num_mcmc,
+            num_opt_steps=1,
+            num_mcmc_warmup_steps=0,
+            num_mcmc_bin_blocks=1,
+            opt_J1_param=True,
+            opt_J2_param=True,
+            opt_J3_param=False,
+            opt_JNN_param=False,
+            opt_lambda_param=True,
+            optimizer_kwargs={
+                "method": "sr",
+                "delta": 1.0e-3,
+                "epsilon": 1.0e-3,
+                "cg_flag": cg_flag,
+                "cg_max_iter": 200,
+                "cg_tol": 1.0e-14,
+            },
+            use_device_collectives=use_device_collectives,
+        )
+        return params
+
+    cpu_params = run_once(use_device_collectives=False)
+    dev_params = run_once(use_device_collectives=True)
+
+    # Both branches must agree to consistency tolerance on every rank.
+    for key in cpu_params:
+        cpu_v = cpu_params[key]
+        dev_v = dev_params[key]
+        assert not np.array_equal(cpu_v, base_params[key]), f"baseline CPU update is trivial for {key} (rank={mpi_rank})"
+        np.testing.assert_allclose(
+            dev_v,
+            cpu_v,
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=(f"device vs CPU multirank mismatch for {key} (regime={regime}, cg={cg_flag}, rank={mpi_rank}/{mpi_size})"),
+        )
+
+    # Sanity: CPU branch's bcast / device branch's psum both replicate theta
+    # across ranks, so the wf updates should agree across ranks too.
+    rank0_cpu = comm.bcast({k: v.copy() for k, v in cpu_params.items()}, root=0)
+    for key in cpu_params:
+        np.testing.assert_allclose(
+            cpu_params[key],
+            rank0_cpu[key],
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=f"CPU branch theta differs across ranks for {key} (rank={mpi_rank})",
+        )
+    rank0_dev = comm.bcast({k: v.copy() for k, v in dev_params.items()}, root=0)
+    for key in dev_params:
+        np.testing.assert_allclose(
+            dev_params[key],
+            rank0_dev[key],
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=f"device branch theta differs across ranks for {key} (rank={mpi_rank})",
+        )
+
+    jax.clear_caches()
+
+
+@pytest.mark.parametrize(
+    "lm_subspace_dim,cg_flag,num_mcmc,num_walkers",
+    [
+        # aSR (gamma scaling): smooth function, strict at any size.
+        (0, False, 10, 2),
+        (0, True, 10, 2),
+        # Subspace LM (size 2 + SR collective = 3 dims): well-conditioned
+        # once samples >> 3, so strict at 200 mcmc * 4 walkers = 800 samples.
+        (2, False, 200, 4),
+        (2, True, 200, 4),
+    ],
+)
+def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walkers):
+    """LM / aSR end-to-end optimization with ``use_device_collectives``
+    toggled.
+
+    The device branch only replaces the SR direct/CG solve; everything
+    downstream (``get_aH``, ``solve_linear_method``, aSR gamma) still runs
+    on the CPU/mpi4py path.
+
+    Tested LM modes (cf. ``run_optimize`` ``optimizer_kwargs``):
+        - ``lm_subspace_dim = 0``: aSR (gamma from H_0/H_1/H_2/S_2)
+        - ``lm_subspace_dim = N`` (positive small): subspace LM (top-N + SR collective)
+
+    Both modes are well-conditioned at the chosen sample sizes:
+    ``solve_linear_method``'s eigenvalue / argmax operations have
+    unique well-separated winners, so the chain SR theta -> LM matrices ->
+    eigvec selection is Lipschitz. Strict consistency tolerance applies.
+
+    ``lm_subspace_dim = -1`` (full-space LM) is intentionally not tested:
+    the augmented H_bar matrix always has many near-degenerate eigenvalues
+    (from gauge freedoms / redundant parameters) so the LM solver is
+    non-Lipschitz to round-off in the SR theta. Full-space LM is rarely
+    used in practice; subspace LM and aSR cover the supported workflows.
+
+    Single optimization step only: ``num_opt_steps > 1`` would diverge the
+    MCMC trajectories once round-off-level wf differences accumulate.
+    """
+    from mpi4py import MPI as _MPI
+
+    if _MPI.COMM_WORLD.Get_size() != 1:
+        pytest.skip("Numerical-agreement test runs single-process only.")
+
+    trexio_file_path = os.path.join(os.path.dirname(__file__), "trexio_example_files", "H2_ae_ccpvdz_cart.h5")
+
+    def build_mcmc():
+        (
+            structure_data,
+            aos_data,
+            _,
+            _,
+            geminal_mo_data,
+            coulomb_potential_data,
+        ) = read_trexio_file(trexio_file=trexio_file_path, store_tuple=True)
+
+        jastrow_data = Jastrow_data(
+            jastrow_one_body_data=Jastrow_one_body_data.init_jastrow_one_body_data(
+                jastrow_1b_param=1.0,
+                structure_data=structure_data,
+                core_electrons=tuple([0] * len(structure_data.atomic_numbers)),
+                jastrow_1b_type="pade",
+            ),
+            jastrow_two_body_data=Jastrow_two_body_data.init_jastrow_two_body_data(
+                jastrow_2b_param=0.5, jastrow_2b_type="pade"
+            ),
+            jastrow_three_body_data=Jastrow_three_body_data.init_jastrow_three_body_data(orb_data=aos_data),
+        )
+        wavefunction_data = Wavefunction_data(jastrow_data=jastrow_data, geminal_data=geminal_mo_data)
+        hamiltonian_data = Hamiltonian_data(
+            structure_data=structure_data,
+            coulomb_potential_data=coulomb_potential_data,
+            wavefunction_data=wavefunction_data,
+        )
+        return MCMC(
+            hamiltonian_data=hamiltonian_data,
+            Dt=2.0,
+            mcmc_seed=12345,
+            num_walkers=num_walkers,
+            comput_position_deriv=False,
+            comput_log_WF_param_deriv=True,
+            comput_e_L_param_deriv=True,  # required by use_lm=True
+        )
+
+    def run_once(use_device_collectives: bool):
+        mcmc = build_mcmc()
+        mcmc.run_optimize(
+            num_mcmc_steps=num_mcmc,
+            num_opt_steps=1,
+            num_mcmc_warmup_steps=0,
+            num_mcmc_bin_blocks=1,
+            opt_J1_param=True,
+            opt_J2_param=True,
+            opt_J3_param=True,
+            opt_lambda_param=True,
+            optimizer_kwargs={
+                "method": "sr",
+                "use_lm": True,
+                "lm_subspace_dim": lm_subspace_dim,
+                "lm_cond": 1.0e-3,
+                "delta": 0.1,
+                "epsilon": 1.0e-6,
+                "cg_flag": cg_flag,
+                # NB: cg_tol=1e-14 (near machine eps) is needed for the
+                # LM step to receive bit-comparable theta_SR from both
+                # branches. With cg_tol=1e-12, CG can early-terminate at
+                # mutually different points along the iteration trajectory,
+                # producing O(1e-3) differences that the LM step preserves.
+                "cg_max_iter": 2000,
+                "cg_tol": 1.0e-14,
+            },
+            use_device_collectives=use_device_collectives,
+        )
+        wf = mcmc.hamiltonian_data.wavefunction_data
+        captured: dict[str, np.ndarray] = {}
+        if wf.jastrow_data.jastrow_one_body_data is not None:
+            captured["j1_param"] = np.asarray(wf.jastrow_data.jastrow_one_body_data.jastrow_1b_param)
+        if wf.jastrow_data.jastrow_two_body_data is not None:
+            captured["j2_param"] = np.asarray(wf.jastrow_data.jastrow_two_body_data.jastrow_2b_param)
+        if wf.jastrow_data.jastrow_three_body_data is not None:
+            captured["j3_matrix"] = np.asarray(wf.jastrow_data.jastrow_three_body_data.j_matrix)
+        if wf.geminal_data is not None:
+            captured["lambda_matrix"] = np.asarray(wf.geminal_data.lambda_matrix)
+        return captured
+
+    cpu_params = run_once(use_device_collectives=False)
+    dev_params = run_once(use_device_collectives=True)
+
+    for key in cpu_params:
+        np.testing.assert_allclose(
+            dev_params[key],
+            cpu_params[key],
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=(f"device vs CPU LM mismatch for {key} (lm_subspace_dim={lm_subspace_dim}, cg_flag={cg_flag})"),
+        )
+
+    jax.clear_caches()
+
+
+@pytest.mark.parametrize("regime", ["wide", "tall"])
+@pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvtz_cart.h5"])
+def test_sr_cg_warm_start_device_matches_cpu(trexio_file, regime, monkeypatch):
+    """Multi-step CG with warm-start: device branch must mirror CPU branch
+    after multiple optimization iterations.
+
+    Each iteration the CG solver carries the previous step's solution as the
+    initial guess (``sr_cg_warm_start_primal`` for wide, ``sr_cg_warm_start_dual``
+    for tall). Both CPU and device branches must persist this state correctly
+    so the final wf parameters agree to consistency tolerance.
+
+    To make the warm-start path actually exercise the iteration-to-iteration
+    carry, the fake ``O`` matrix is varied per call (using a counter that is
+    reset between the two ``run_once`` invocations so both branches see the
+    same input sequence).
+    """
+    from mpi4py import MPI as _MPI
+
+    if _MPI.COMM_WORLD.Get_size() != 1:
+        pytest.skip("Numerical-agreement test runs single-process only.")
+
+    (
+        structure_data,
+        _,
+        _,
+        _,
+        geminal_mo_data,
+        coulomb_potential_data,
+    ) = read_trexio_file(
+        trexio_file=os.path.join(os.path.dirname(__file__), "trexio_example_files", trexio_file), store_tuple=True
+    )
+
+    jastrow_onebody_data = Jastrow_one_body_data.init_jastrow_one_body_data(
+        jastrow_1b_param=1.0,
+        structure_data=structure_data,
+        core_electrons=tuple([0] * len(structure_data.atomic_numbers)),
+        jastrow_1b_type="pade",
+    )
+    jastrow_twobody_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="pade")
+    jastrow_data = Jastrow_data(
+        jastrow_one_body_data=jastrow_onebody_data,
+        jastrow_two_body_data=jastrow_twobody_data,
+        jastrow_three_body_data=None,
+        jastrow_nn_data=None,
+    )
+    wavefunction_data = Wavefunction_data(jastrow_data=jastrow_data, geminal_data=geminal_mo_data)
+    hamiltonian_data = Hamiltonian_data(
+        structure_data=structure_data,
+        coulomb_potential_data=coulomb_potential_data,
+        wavefunction_data=wavefunction_data,
+    )
+
+    num_walkers = 2
+    Dt = 2.0
+    mcmc_seed = 12345
+    epsilon_AS = 1.0e-6
+    num_opt_steps = 3
+
+    base_params: dict[str, np.ndarray] = {
+        "j1_param": np.ones_like(np.array(jastrow_onebody_data.jastrow_1b_param)),
+        "j2_param": np.ones_like(np.array(jastrow_twobody_data.jastrow_2b_param)),
+    }
+    fixed_param_size = sum(v.size for v in base_params.values())
+
+    if regime == "tall":
+        num_mcmc = 1
+        min_samples_total = num_mcmc * num_walkers
+        lambda_size_needed = max(1, min_samples_total - fixed_param_size + 1)
+        base_params["lambda_matrix"] = np.ones(lambda_size_needed, dtype=float)
+    else:
+        base_params["lambda_matrix"] = np.array([[2.0, -2.0], [3.0, -3.0]], dtype=float)
+        total_params_tmp = sum(v.size for v in base_params.values())
+        num_mcmc = total_params_tmp // num_walkers + 2
+
+    fake_w_L_data = np.ones((num_mcmc, num_walkers))
+    rng = np.random.default_rng(42)
+    fake_e_L_data = rng.standard_normal((num_mcmc, num_walkers)) * 0.1
+
+    # Single-slot holder for the live params dict. We can't key by ``id(wf)``
+    # because ``MCMC.hamiltonian_data`` setter calls ``apply_diff_mask`` which
+    # rewraps the wavefunction with a fresh instance every time it's reassigned
+    # (i.e. at the end of every optimization iteration). The single-slot
+    # approach assumes one MCMC instance is alive at a time inside this test.
+    params_holder: dict[str, dict[str, np.ndarray] | None] = {"params": None}
+
+    def register_params(_wf, params):
+        params_holder["params"] = params
+
+    def lookup_params(_wf):
+        return params_holder["params"]
+
+    # Counter that varies the fake O matrix per get_dln_WF call, so successive
+    # SR systems differ and CG warm-start has actual work to do. Reset between
+    # the two run_once invocations so both branches see identical input streams.
+    call_idx = {"count": 0}
+
+    def fake_get_variational_blocks(
+        self,
+        opt_J1_param=True,
+        opt_J2_param=True,
+        opt_J3_param=True,
+        opt_JNN_param=True,
+        opt_lambda_param=False,
+        opt_J3_basis_exp=False,
+        opt_J3_basis_coeff=False,
+        opt_lambda_basis_exp=False,
+        opt_lambda_basis_coeff=False,
+    ):
+        blocks = []
+        pos = lookup_params(self)
+        if opt_J1_param and "j1_param" in pos:
+            arr = pos["j1_param"]
+            blocks.append(VariationalParameterBlock(name="j1_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_J2_param and "j2_param" in pos:
+            arr = pos["j2_param"]
+            blocks.append(VariationalParameterBlock(name="j2_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_lambda_param and "lambda_matrix" in pos:
+            arr = pos["lambda_matrix"]
+            blocks.append(VariationalParameterBlock(name="lambda_matrix", values=arr, shape=arr.shape, size=int(arr.size)))
+        return blocks
+
+    def fake_apply_block_updates(self, blocks, thetas, learning_rate):
+        params = lookup_params(self)
+        idx = 0
+        for block in blocks:
+            blk_slice = thetas[idx : idx + block.size]
+            idx += block.size
+            if blk_slice.size == 0:
+                continue
+            delta = blk_slice.reshape(block.shape)
+            params[block.name] = params[block.name] + learning_rate * delta
+        return self
+
+    def fake_run(self, num_mcmc_steps: int = 0, max_time=None):
+        return None
+
+    def fake_get_dln_WF(
+        self,
+        blocks,
+        num_mcmc_warmup_steps=0,
+        chosen_param_index=None,
+        lambda_projectors=None,
+        num_orb_projection=None,
+    ):
+        call_idx["count"] += 1
+        total = sum(block.size for block in blocks)
+        rng_local = np.random.default_rng(123 + call_idx["count"])
+        return rng_local.standard_normal((num_mcmc, self.num_walkers, total)) * 0.01
+
+    def fake_get_E(self, num_mcmc_warmup_steps: int = 0, num_mcmc_bin_blocks: int = 1):
+        return (0.0, 0.0, 0.0, 0.0)
+
+    def fake_get_gF(
+        self,
+        num_mcmc_warmup_steps,
+        num_mcmc_bin_blocks,
+        blocks,
+        lambda_projectors=None,
+        num_orb_projection=None,
+        chosen_param_index=None,
+    ):
+        total = sum(block.size for block in blocks)
+        return np.ones(total, dtype=float), np.ones(total, dtype=float)
+
+    monkeypatch.setattr(Wavefunction_data, "get_variational_blocks", fake_get_variational_blocks, raising=False)
+    monkeypatch.setattr(Wavefunction_data, "apply_block_updates", fake_apply_block_updates, raising=False)
+    monkeypatch.setattr(MCMC, "run", fake_run, raising=False)
+    monkeypatch.setattr(MCMC, "get_E", fake_get_E, raising=False)
+    monkeypatch.setattr(MCMC, "get_gF", fake_get_gF, raising=False)
+    monkeypatch.setattr(MCMC, "get_dln_WF", fake_get_dln_WF, raising=False)
+    monkeypatch.setattr(MCMC, "w_L", property(lambda self: fake_w_L_data), raising=False)
+    monkeypatch.setattr(MCMC, "e_L", property(lambda self: fake_e_L_data), raising=False)
+
+    def run_once(use_device_collectives: bool):
+        call_idx["count"] = 0  # reset so both branches see the same per-iter inputs
+        mcmc = MCMC(
+            hamiltonian_data=hamiltonian_data,
+            Dt=Dt,
+            mcmc_seed=mcmc_seed,
+            epsilon_AS=epsilon_AS,
+            num_walkers=num_walkers,
+            comput_position_deriv=False,
+            comput_log_WF_param_deriv=True,
+            comput_e_L_param_deriv=False,
+            random_discretized_mesh=True,
+        )
+        params = {k: v.copy() for k, v in base_params.items()}
+        register_params(mcmc.hamiltonian_data.wavefunction_data, params)
+        mcmc.run_optimize(
+            num_mcmc_steps=num_mcmc,
+            num_opt_steps=num_opt_steps,
+            num_mcmc_warmup_steps=0,
+            num_mcmc_bin_blocks=1,
+            opt_J1_param=True,
+            opt_J2_param=True,
+            opt_J3_param=False,
+            opt_JNN_param=False,
+            opt_lambda_param=True,
+            optimizer_kwargs={
+                "method": "sr",
+                "delta": 1.0e-3,
+                "epsilon": 1.0e-3,
+                "cg_flag": True,
+                "cg_max_iter": 200,
+                "cg_tol": 1.0e-12,
+            },
+            use_device_collectives=use_device_collectives,
+        )
+        return params
+
+    cpu_params = run_once(use_device_collectives=False)
+    dev_params = run_once(use_device_collectives=True)
+
+    for key in cpu_params:
+        cpu_v = cpu_params[key]
+        dev_v = dev_params[key]
+        # Sanity: 3 iters of warm-started CG produced a non-trivial param trail.
+        assert not np.array_equal(cpu_v, base_params[key]), f"baseline CPU update is trivial for {key}"
+        np.testing.assert_allclose(
+            dev_v,
+            cpu_v,
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=f"device vs CPU CG warm-start mismatch for {key} (regime={regime})",
+        )
+
+    jax.clear_caches()
+
+
 @pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvtz_cart.h5"])
 def test_opt_with_projected_MOs(trexio_file, monkeypatch):
     """After run_optimize with opt_with_projected_MOs=True the final wavefunction

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -1460,7 +1460,7 @@ def test_sr_device_matches_cpu_multirank(trexio_file, regime, cg_flag, monkeypat
         (2, True, 200, 4),
     ],
 )
-def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walkers):
+def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walkers, monkeypatch):
     """LM / aSR end-to-end optimization with ``use_device_collectives``
     toggled.
 
@@ -1472,16 +1472,29 @@ def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walker
         - ``lm_subspace_dim = 0``: aSR (gamma from H_0/H_1/H_2/S_2)
         - ``lm_subspace_dim = N`` (positive small): subspace LM (top-N + SR collective)
 
-    Both modes are well-conditioned at the chosen sample sizes:
-    ``solve_linear_method``'s eigenvalue / argmax operations have
-    unique well-separated winners, so the chain SR theta -> LM matrices ->
-    eigvec selection is Lipschitz. Strict consistency tolerance applies.
-
-    ``lm_subspace_dim = -1`` (full-space LM) is intentionally not tested:
-    the augmented H_bar matrix always has many near-degenerate eigenvalues
-    (from gauge freedoms / redundant parameters) so the LM solver is
-    non-Lipschitz to round-off in the SR theta. Full-space LM is rarely
-    used in practice; subspace LM and aSR cover the supported workflows.
+    What is compared, and why:
+        - aSR (``lm_subspace_dim = 0``): gamma scaling is a smooth function
+          of the SR direction, so the final wf parameters depend
+          continuously on ``theta_SR`` and can be compared at strict
+          tolerance.
+        - Subspace LM (``lm_subspace_dim != 0``): ``solve_linear_method``
+          contains two argmax operations (dgelscut parameter elimination
+          and ``argmax(|v_0|^2)`` eigenvector selection) that are
+          discontinuous in their inputs -- a round-off-level perturbation
+          can flip the selected mode and produce O(1e-3) jumps in the
+          downstream output (final wf parameters, ``E_lm``, etc.) even
+          though both branches run deterministically. Note in particular
+          that ``E_lm = eigvals_lm[argmax(|v_0|^2)]`` is *not* a
+          continuous function of ``H_bar``: the ranking by ``|v_0|^2``
+          is unrelated to the eigenvalue ordering, so an argmax flip can
+          jump ``E_lm`` by the gap between two arbitrary eigenvalues.
+          Instead, compare the inputs to ``solve_linear_method``
+          (``H_0, f_vec, S, K, B``) -- these depend continuously on
+          ``theta_SR``, so they are the right boundary at which to
+          verify that the device-branch SR solve agrees with the CPU
+          branch. Whatever ``solve_linear_method`` does downstream
+          (including any argmax flips) is shared CPU code and not part
+          of what this test is meant to cover.
 
     Single optimization step only: ``num_opt_steps > 1`` would diverge the
     MCMC trajectories once round-off-level wf differences accumulate.
@@ -1531,7 +1544,27 @@ def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walker
             comput_e_L_param_deriv=True,  # required by use_lm=True
         )
 
+    # Pristine reference, captured before any monkeypatching so chained
+    # spies (one per ``run_once`` call) all delegate to the real solver.
+    orig_solve_linear_method = MCMC.solve_linear_method
+
     def run_once(use_device_collectives: bool):
+        lm_inputs: list[dict] = []
+
+        def spy(H_0, f_vec, S_matrix, K_matrix, B_matrix, epsilon):
+            lm_inputs.append(
+                {
+                    "H_0": float(H_0),
+                    "f_vec": np.asarray(f_vec).copy(),
+                    "S": np.asarray(S_matrix).copy(),
+                    "K": np.asarray(K_matrix).copy(),
+                    "B": np.asarray(B_matrix).copy(),
+                }
+            )
+            return orig_solve_linear_method(H_0, f_vec, S_matrix, K_matrix, B_matrix, epsilon)
+
+        monkeypatch.setattr(MCMC, "solve_linear_method", staticmethod(spy))
+
         mcmc = build_mcmc()
         mcmc.run_optimize(
             num_mcmc_steps=num_mcmc,
@@ -1561,28 +1594,54 @@ def test_sr_lm_device_matches_cpu(lm_subspace_dim, cg_flag, num_mcmc, num_walker
             use_device_collectives=use_device_collectives,
         )
         wf = mcmc.hamiltonian_data.wavefunction_data
-        captured: dict[str, np.ndarray] = {}
+        wf_params: dict[str, np.ndarray] = {}
         if wf.jastrow_data.jastrow_one_body_data is not None:
-            captured["j1_param"] = np.asarray(wf.jastrow_data.jastrow_one_body_data.jastrow_1b_param)
+            wf_params["j1_param"] = np.asarray(wf.jastrow_data.jastrow_one_body_data.jastrow_1b_param)
         if wf.jastrow_data.jastrow_two_body_data is not None:
-            captured["j2_param"] = np.asarray(wf.jastrow_data.jastrow_two_body_data.jastrow_2b_param)
+            wf_params["j2_param"] = np.asarray(wf.jastrow_data.jastrow_two_body_data.jastrow_2b_param)
         if wf.jastrow_data.jastrow_three_body_data is not None:
-            captured["j3_matrix"] = np.asarray(wf.jastrow_data.jastrow_three_body_data.j_matrix)
+            wf_params["j3_matrix"] = np.asarray(wf.jastrow_data.jastrow_three_body_data.j_matrix)
         if wf.geminal_data is not None:
-            captured["lambda_matrix"] = np.asarray(wf.geminal_data.lambda_matrix)
-        return captured
+            wf_params["lambda_matrix"] = np.asarray(wf.geminal_data.lambda_matrix)
+        return wf_params, lm_inputs
 
-    cpu_params = run_once(use_device_collectives=False)
-    dev_params = run_once(use_device_collectives=True)
+    cpu_params, cpu_lm_inputs = run_once(use_device_collectives=False)
+    dev_params, dev_lm_inputs = run_once(use_device_collectives=True)
 
-    for key in cpu_params:
-        np.testing.assert_allclose(
-            dev_params[key],
-            cpu_params[key],
-            atol=atol_consistency,
-            rtol=rtol_consistency,
-            err_msg=(f"device vs CPU LM mismatch for {key} (lm_subspace_dim={lm_subspace_dim}, cg_flag={cg_flag})"),
+    if lm_subspace_dim == 0:
+        # aSR path: solve_linear_method is not invoked; final wf params are
+        # Lipschitz in theta_SR via gamma scaling.
+        assert cpu_lm_inputs == [] and dev_lm_inputs == []
+        for key in cpu_params:
+            np.testing.assert_allclose(
+                dev_params[key],
+                cpu_params[key],
+                atol=atol_consistency,
+                rtol=rtol_consistency,
+                err_msg=(f"device vs CPU aSR mismatch for {key} (lm_subspace_dim={lm_subspace_dim}, cg_flag={cg_flag})"),
+            )
+    else:
+        # Subspace LM: compare only the inputs to solve_linear_method.
+        # These depend continuously on theta_SR, so they are the natural
+        # boundary at which the device-branch SR solve can be verified
+        # against the CPU branch. Anything past this point (E_lm, c_vec,
+        # final wf params) goes through argmax operations inside
+        # solve_linear_method and is not safe to compare strictly.
+        assert len(cpu_lm_inputs) == len(dev_lm_inputs) > 0, (
+            f"solve_linear_method was not invoked (cpu={len(cpu_lm_inputs)}, dev={len(dev_lm_inputs)})"
         )
+        for step, (c_in, d_in) in enumerate(zip(cpu_lm_inputs, dev_lm_inputs)):
+            for key in ("H_0", "f_vec", "S", "K", "B"):
+                np.testing.assert_allclose(
+                    d_in[key],
+                    c_in[key],
+                    atol=atol_consistency,
+                    rtol=rtol_consistency,
+                    err_msg=(
+                        f"device vs CPU LM-input mismatch for {key} at step {step} "
+                        f"(lm_subspace_dim={lm_subspace_dim}, cg_flag={cg_flag})"
+                    ),
+                )
 
     jax.clear_caches()
 

--- a/tests/test_jqmc_mcmc.py
+++ b/tests/test_jqmc_mcmc.py
@@ -48,6 +48,7 @@ if project_root not in sys.path:
     sys.path.insert(0, project_root)
 
 from jqmc._precision import get_tolerance_min
+from jqmc._setting import atol_consistency, rtol_consistency
 from jqmc.determinant import Geminal_data
 from jqmc.hamiltonians import Hamiltonian_data
 from jqmc.jastrow_factor import (
@@ -929,6 +930,243 @@ def test_sr_wide_and_tall_matrix(trexio_file, regime, cg_flag, monkeypatch):
     # At least one param should have been updated (non-trivial SR solve).
     any_changed = any(not np.array_equal(before[k], current_params[k]) for k in before)
     assert any_changed, f"Expected at least one parameter to change (regime={regime}, cg_flag={cg_flag})"
+
+    jax.clear_caches()
+
+
+@pytest.mark.parametrize(
+    "regime,cg_flag",
+    [
+        ("wide", False),
+        ("wide", True),
+        ("tall", False),
+        ("tall", True),
+    ],
+)
+@pytest.mark.parametrize("trexio_file", ["H2_ae_ccpvtz_cart.h5"])
+def test_sr_device_matches_cpu(trexio_file, regime, cg_flag, monkeypatch):
+    """Each of the four SR solve paths (wide/tall x direct/CG) must produce
+    the same parameter update on the JAX-native device branch as on the
+    legacy NumPy/SciPy/mpi4py CPU branch, given identical inputs.
+
+    Single-process: ``psum`` is trivial and the device path reduces to its
+    local computation; this test verifies numerical agreement only.
+    Multi-rank validation requires actually running ``mpirun`` and is out of
+    scope for the unit suite.
+    """
+    from mpi4py import MPI as _MPI
+
+    if _MPI.COMM_WORLD.Get_size() != 1:
+        pytest.skip("Numerical-agreement test runs single-process only.")
+
+    (
+        structure_data,
+        _,
+        _,
+        _,
+        geminal_mo_data,
+        coulomb_potential_data,
+    ) = read_trexio_file(
+        trexio_file=os.path.join(os.path.dirname(__file__), "trexio_example_files", trexio_file), store_tuple=True
+    )
+
+    jastrow_onebody_data = Jastrow_one_body_data.init_jastrow_one_body_data(
+        jastrow_1b_param=1.0,
+        structure_data=structure_data,
+        core_electrons=tuple([0] * len(structure_data.atomic_numbers)),
+        jastrow_1b_type="pade",
+    )
+    jastrow_twobody_data = Jastrow_two_body_data.init_jastrow_two_body_data(jastrow_2b_param=0.5, jastrow_2b_type="pade")
+    jastrow_data = Jastrow_data(
+        jastrow_one_body_data=jastrow_onebody_data,
+        jastrow_two_body_data=jastrow_twobody_data,
+        jastrow_three_body_data=None,
+        jastrow_nn_data=None,
+    )
+    wavefunction_data = Wavefunction_data(jastrow_data=jastrow_data, geminal_data=geminal_mo_data)
+    hamiltonian_data = Hamiltonian_data(
+        structure_data=structure_data,
+        coulomb_potential_data=coulomb_potential_data,
+        wavefunction_data=wavefunction_data,
+    )
+
+    num_walkers = 2
+    Dt = 2.0
+    mcmc_seed = 12345
+    epsilon_AS = 1.0e-6
+
+    # Build a parameter set sized for the requested regime. Single-process,
+    # so num_samples_total = num_mcmc * num_walkers.
+    base_params: dict[str, np.ndarray] = {
+        "j1_param": np.ones_like(np.array(jastrow_onebody_data.jastrow_1b_param)),
+        "j2_param": np.ones_like(np.array(jastrow_twobody_data.jastrow_2b_param)),
+    }
+    fixed_param_size = sum(v.size for v in base_params.values())
+
+    if regime == "tall":
+        num_mcmc = 1
+        min_samples_total = num_mcmc * num_walkers
+        # Pad lambda_matrix so num_params >= num_samples_total.
+        lambda_size_needed = max(1, min_samples_total - fixed_param_size + 1)
+        base_params["lambda_matrix"] = np.ones(lambda_size_needed, dtype=float)
+    else:
+        base_params["lambda_matrix"] = np.array([[2.0, -2.0], [3.0, -3.0]], dtype=float)
+        total_params_tmp = sum(v.size for v in base_params.values())
+        num_mcmc = total_params_tmp // num_walkers + 2
+
+    total_params = sum(v.size for v in base_params.values())
+    num_samples_total = num_mcmc * num_walkers
+    if regime == "wide":
+        assert total_params < num_samples_total, f"wide setup invalid: {total_params} >= {num_samples_total}"
+    else:
+        assert total_params >= num_samples_total, f"tall setup invalid: {total_params} < {num_samples_total}"
+
+    rng = np.random.default_rng(42)
+    fake_w_L_data = np.ones((num_mcmc, num_walkers))
+    fake_e_L_data = rng.standard_normal((num_mcmc, num_walkers)) * 0.1
+
+    params_registry: dict[int, dict[str, np.ndarray]] = {}
+
+    def register_params(wf, params):
+        params_registry[id(wf)] = params
+
+    def lookup_params(wf):
+        return params_registry[id(wf)]
+
+    def fake_get_variational_blocks(
+        self,
+        opt_J1_param=True,
+        opt_J2_param=True,
+        opt_J3_param=True,
+        opt_JNN_param=True,
+        opt_lambda_param=False,
+        opt_J3_basis_exp=False,
+        opt_J3_basis_coeff=False,
+        opt_lambda_basis_exp=False,
+        opt_lambda_basis_coeff=False,
+    ):
+        blocks = []
+        pos = lookup_params(self)
+        if opt_J1_param and "j1_param" in pos:
+            arr = pos["j1_param"]
+            blocks.append(VariationalParameterBlock(name="j1_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_J2_param and "j2_param" in pos:
+            arr = pos["j2_param"]
+            blocks.append(VariationalParameterBlock(name="j2_param", values=arr, shape=arr.shape, size=int(arr.size)))
+        if opt_lambda_param and "lambda_matrix" in pos:
+            arr = pos["lambda_matrix"]
+            blocks.append(VariationalParameterBlock(name="lambda_matrix", values=arr, shape=arr.shape, size=int(arr.size)))
+        return blocks
+
+    def fake_apply_block_updates(self, blocks, thetas, learning_rate):
+        params = lookup_params(self)
+        idx = 0
+        for block in blocks:
+            blk_slice = thetas[idx : idx + block.size]
+            idx += block.size
+            if blk_slice.size == 0:
+                continue
+            delta = blk_slice.reshape(block.shape)
+            params[block.name] = params[block.name] + learning_rate * delta
+        return self
+
+    def fake_run(self, num_mcmc_steps: int = 0, max_time=None):
+        return None
+
+    # Deterministic O matrix so both runs see identical inputs.
+    def fake_get_dln_WF(
+        self,
+        blocks,
+        num_mcmc_warmup_steps=0,
+        chosen_param_index=None,
+        lambda_projectors=None,
+        num_orb_projection=None,
+    ):
+        total = sum(block.size for block in blocks)
+        rng_local = np.random.default_rng(123)
+        return rng_local.standard_normal((num_mcmc, self.num_walkers, total)) * 0.01
+
+    def fake_get_E(self, num_mcmc_warmup_steps: int = 0, num_mcmc_bin_blocks: int = 1):
+        return (0.0, 0.0, 0.0, 0.0)
+
+    def fake_get_gF(
+        self,
+        num_mcmc_warmup_steps,
+        num_mcmc_bin_blocks,
+        blocks,
+        lambda_projectors=None,
+        num_orb_projection=None,
+        chosen_param_index=None,
+    ):
+        total = sum(block.size for block in blocks)
+        return np.ones(total, dtype=float), np.ones(total, dtype=float)
+
+    monkeypatch.setattr(Wavefunction_data, "get_variational_blocks", fake_get_variational_blocks, raising=False)
+    monkeypatch.setattr(Wavefunction_data, "apply_block_updates", fake_apply_block_updates, raising=False)
+    monkeypatch.setattr(MCMC, "run", fake_run, raising=False)
+    monkeypatch.setattr(MCMC, "get_E", fake_get_E, raising=False)
+    monkeypatch.setattr(MCMC, "get_gF", fake_get_gF, raising=False)
+    monkeypatch.setattr(MCMC, "get_dln_WF", fake_get_dln_WF, raising=False)
+    monkeypatch.setattr(MCMC, "w_L", property(lambda self: fake_w_L_data), raising=False)
+    monkeypatch.setattr(MCMC, "e_L", property(lambda self: fake_e_L_data), raising=False)
+
+    def run_once(use_device_collectives: bool):
+        mcmc = MCMC(
+            hamiltonian_data=hamiltonian_data,
+            Dt=Dt,
+            mcmc_seed=mcmc_seed,
+            epsilon_AS=epsilon_AS,
+            num_walkers=num_walkers,
+            comput_position_deriv=False,
+            comput_log_WF_param_deriv=True,
+            comput_e_L_param_deriv=False,
+            random_discretized_mesh=True,
+        )
+        params = {k: v.copy() for k, v in base_params.items()}
+        register_params(mcmc.hamiltonian_data.wavefunction_data, params)
+        mcmc.run_optimize(
+            num_mcmc_steps=num_mcmc,
+            num_opt_steps=1,
+            num_mcmc_warmup_steps=0,
+            num_mcmc_bin_blocks=1,
+            opt_J1_param=True,
+            opt_J2_param=True,
+            opt_J3_param=False,
+            opt_JNN_param=False,
+            opt_lambda_param=True,
+            optimizer_kwargs={
+                "method": "sr",
+                "delta": 1.0e-3,
+                "epsilon": 1.0e-3,
+                "cg_flag": cg_flag,
+                "cg_max_iter": 200,
+                # CG iteration tolerance well below the project consistency
+                # tolerance, so the device-vs-CPU difference is dominated by
+                # float64 round-off, not CG residual.
+                "cg_tol": 1.0e-12,
+            },
+            use_device_collectives=use_device_collectives,
+        )
+        return params
+
+    cpu_params = run_once(use_device_collectives=False)
+    dev_params = run_once(use_device_collectives=True)
+
+    # Both branches do exactly the same float64 SR arithmetic, just with
+    # NumPy/SciPy/mpi4py vs JAX/shard_map; difference is round-off only.
+    # Use the project's strict-float64 consistency tolerance.
+    for key in cpu_params:
+        cpu_v = cpu_params[key]
+        dev_v = dev_params[key]
+        # Sanity: CPU branch produced a non-trivial update.
+        assert not np.array_equal(cpu_v, base_params[key]), f"baseline CPU update is trivial for {key}"
+        np.testing.assert_allclose(
+            dev_v,
+            cpu_v,
+            atol=atol_consistency,
+            rtol=rtol_consistency,
+            err_msg=f"device vs CPU mismatch for {key} (regime={regime}, cg={cg_flag})",
+        )
 
     jax.clear_caches()
 


### PR DESCRIPTION
`run_optimize` in `mcmc.py` is now driven on-device by default via `shard_map` + `psum` / `all_gather`. The legacy `mpi4py` + `scipy` CPU branch is retained as a fallback via `use_device_collectives=False`. Add `check_mpi4py_jax_distribution_consistency()` to `_jqmc_utility.py`, and wire it into `MCMC.run`, `run_optimize`, `GFMC_t.run`, `GFMC_n.run`, and `jqmc_cli` so a missing `jax.distributed.initialize()` is caught early instead of silently diverging across ranks.
